### PR TITLE
[dygraph-light] Fix preview legend order by associating legend labels with object ID

### DIFF
--- a/src/main/js/dygraph-light/main/LabelMaker.ts
+++ b/src/main/js/dygraph-light/main/LabelMaker.ts
@@ -83,11 +83,11 @@ export default class LabelMaker {
 			if (this.linking === 'concatenate'){
 				this.labels = this.hasY2
 					? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
-					: [this.xlabel].concat(this.metadata[0].labels.y)
+					: [this.xlabel].concat(this.metadata[0].labels.y);
 			} else {
 				this.labels = this.hasY2
 					? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y,dobj.labels.y2!]))
-					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y))
+					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
 			}
 		}
 	}
@@ -140,7 +140,7 @@ export default class LabelMaker {
 	}
 }
 
-const getLegendDataIndexes = (linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes => {
+function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes {
 	if (linking === 'concatenate'){
 		if (hasY2) {
 			return {
@@ -153,24 +153,23 @@ const getLegendDataIndexes = (linking: Linking, ids: string[], hasY2: boolean): 
 				y2: []
 			};
 		}
-
 	} else {
-		const length = hasY2 ? ids.length * 2 : ids.length;
-		const indexes = Array.from({length}, (_, i) => i);
+        const length = hasY2 ? ids.length * 2 : ids.length;
+        const indexes = Array.from({length}, (_, i) => i);
 
-		if (hasY2) {
-			return {
-				y: indexes.filter(idx => idx % 2 === 0),
-				y2: indexes.filter(idx => idx % 2 !== 0)
-			};
-		} else {
-			return {
-				y: indexes,
-				y2: []
-			};
-		}
-	}
-};
+        if (hasY2) {
+            return {
+                y: indexes.filter(idx => idx % 2 === 0),
+                y2: indexes.filter(idx => idx % 2 !== 0)
+            };
+        } else {
+            return {
+                y: indexes,
+                y2: []
+            };
+        }
+    }
+}
 
 class Metadata {
 	readonly labels: {y: string, y2?: string};
@@ -195,11 +194,11 @@ class Metadata {
 		this.labels = {
 			y: yLabel,
 			y2: y2Label
-		}
+		};
 	}
 }
 
-const getFinalLabel = (linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') => {
+function getFinalLabel(linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') {
 	if (requestedLabel) return requestedLabel + postfix;
 
 	if (linking === 'concatenate'){
@@ -208,9 +207,9 @@ const getFinalLabel = (linking: 'overlap' | 'concatenate', requestedLabel: strin
 	const filename = object.filename;
 
 	return filename.slice(0, filename.lastIndexOf('.')) + postfix;
-};
+}
 
-const getLegendLabelFromParams = (params: UrlSearchParams, name: string, objId: string) => {
+function getLegendLabelFromParams(params: UrlSearchParams, name: string, objId: string) {
 	const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
 	const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
 	
@@ -219,19 +218,19 @@ const getLegendLabelFromParams = (params: UrlSearchParams, name: string, objId: 
 	const idx = ids.findIndex(id => objId.includes(id));
 
 	return (idx !== -1 && labels[idx]) ? labels[idx] : '';
-};
+}
 
-const isColNameValid = (tableFormat: TableFormat, colName: string) => {
+function isColNameValid(tableFormat: TableFormat, colName: string) {
 	return tableFormat.getColumnIndex(colName) >= 0;
-};
+}
 
-const getLabel = (tableFormat: TableFormat, colName: string) => {
+function getLabel(tableFormat: TableFormat, colName: string) {
 	const unit = getColInfoParam(tableFormat, colName, 'unit');
 	const label = getColInfoParam(tableFormat, colName, 'label');
 
 	return unit === '?' ? label : `${label} [${unit}]`;
-};
+}
 
 function getColInfoParam<T extends keyof ColumnInfo>(tableFormat: TableFormat, colName: string, param: T) {
 	return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
-};
+}

--- a/src/main/js/dygraph-light/main/LabelMaker.ts
+++ b/src/main/js/dygraph-light/main/LabelMaker.ts
@@ -83,11 +83,11 @@ export default class LabelMaker {
 			if (this.linking === 'concatenate'){
 				this.labels = this.hasY2
 					? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
-					: [this.xlabel].concat(this.metadata[0].labels.y);
+					: [this.xlabel].concat(this.metadata[0].labels.y)
 			} else {
 				this.labels = this.hasY2
 					? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y,dobj.labels.y2!]))
-					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
+					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y))
 			}
 		}
 	}
@@ -140,7 +140,7 @@ export default class LabelMaker {
 	}
 }
 
-function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes {
+const getLegendDataIndexes = (linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes => {
 	if (linking === 'concatenate'){
 		if (hasY2) {
 			return {
@@ -153,23 +153,24 @@ function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): 
 				y2: []
 			};
 		}
-	} else {
-        const length = hasY2 ? ids.length * 2 : ids.length;
-        const indexes = Array.from({length}, (_, i) => i);
 
-        if (hasY2) {
-            return {
-                y: indexes.filter(idx => idx % 2 === 0),
-                y2: indexes.filter(idx => idx % 2 !== 0)
-            };
-        } else {
-            return {
-                y: indexes,
-                y2: []
-            };
-        }
-    }
-}
+	} else {
+		const length = hasY2 ? ids.length * 2 : ids.length;
+		const indexes = Array.from({length}, (_, i) => i);
+
+		if (hasY2) {
+			return {
+				y: indexes.filter(idx => idx % 2 === 0),
+				y2: indexes.filter(idx => idx % 2 !== 0)
+			};
+		} else {
+			return {
+				y: indexes,
+				y2: []
+			};
+		}
+	}
+};
 
 class Metadata {
 	readonly labels: {y: string, y2?: string};
@@ -194,11 +195,11 @@ class Metadata {
 		this.labels = {
 			y: yLabel,
 			y2: y2Label
-		};
+		}
 	}
 }
 
-function getFinalLabel(linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') {
+const getFinalLabel = (linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') => {
 	if (requestedLabel) return requestedLabel + postfix;
 
 	if (linking === 'concatenate'){
@@ -207,9 +208,9 @@ function getFinalLabel(linking: 'overlap' | 'concatenate', requestedLabel: strin
 	const filename = object.filename;
 
 	return filename.slice(0, filename.lastIndexOf('.')) + postfix;
-}
+};
 
-function getLegendLabelFromParams(params: UrlSearchParams, name: string, objId: string) {
+const getLegendLabelFromParams = (params: UrlSearchParams, name: string, objId: string) => {
 	const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
 	const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
 	
@@ -218,19 +219,19 @@ function getLegendLabelFromParams(params: UrlSearchParams, name: string, objId: 
 	const idx = ids.findIndex(id => objId.includes(id));
 
 	return (idx !== -1 && labels[idx]) ? labels[idx] : '';
-}
+};
 
-function isColNameValid(tableFormat: TableFormat, colName: string) {
+const isColNameValid = (tableFormat: TableFormat, colName: string) => {
 	return tableFormat.getColumnIndex(colName) >= 0;
-}
+};
 
-function getLabel(tableFormat: TableFormat, colName: string) {
+const getLabel = (tableFormat: TableFormat, colName: string) => {
 	const unit = getColInfoParam(tableFormat, colName, 'unit');
 	const label = getColInfoParam(tableFormat, colName, 'label');
 
 	return unit === '?' ? label : `${label} [${unit}]`;
-}
+};
 
 function getColInfoParam<T extends keyof ColumnInfo>(tableFormat: TableFormat, colName: string, param: T) {
 	return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
-}
+};

--- a/src/main/js/dygraph-light/main/LabelMaker.ts
+++ b/src/main/js/dygraph-light/main/LabelMaker.ts
@@ -1,161 +1,161 @@
 import UrlSearchParams from "../../common/main/models/UrlSearchParams";
-import {ColumnInfo, TableFormat} from "icos-cp-backend";
+import { ColumnInfo, TableFormat } from "icos-cp-backend";
 import { dygraphs } from "dygraphs";
 import PerSeriesOptions = dygraphs.PerSeriesOptions;
 import LegendData = dygraphs.LegendData;
 
 export type MetaWithTableFormat = {
-	id: string
-	objSpec: string
-	nRows: number
-	filename: string
-	specLabel: string
-	startedAtTime: string
-	columnNames: string[] | undefined
-	tableFormat: TableFormat
+    id: string
+    objSpec: string
+    nRows: number
+    filename: string
+    specLabel: string
+    startedAtTime: string
+    columnNames: string[] | undefined
+    tableFormat: TableFormat
 }
 
 type LegendDataSerieIndexes = {
-	y: number[],
-	y2: number[]
+    y: number[],
+    y2: number[]
 }
 type Linking = 'overlap' | 'concatenate'
-type LegendTitles = {y: string, y2: string}
+type LegendTitles = { y: string, y2: string }
 
 export default class LabelMaker {
-	readonly ids: string[];
-	readonly hasY2: boolean;
-	readonly linking: Linking;
-	public metadata?: Metadata[];
-	readonly legendLabels: string[] = [];
-	public chartTitle?: string;
-	public xlabel: string = '';
-	public xLegendLabel: string = '';
-	public valueFormatX: string = '';
-	public ylabel: string = '';
-	public y2label: string = '';
-	public labels: string[] = [];
-	public object?: MetaWithTableFormat;
-	public tableFormat?: TableFormat;
-	private legendDataSerieIndexes: LegendDataSerieIndexes;
-	public readonly legendTitles: LegendTitles;
+    readonly ids: string[];
+    readonly hasY2: boolean;
+    readonly linking: Linking;
+    public metadata?: Metadata[];
+    readonly legendLabels: string[] = [];
+    public chartTitle?: string;
+    public xlabel: string = '';
+    public xLegendLabel: string = '';
+    public valueFormatX: string = '';
+    public ylabel: string = '';
+    public y2label: string = '';
+    public labels: string[] = [];
+    public object?: MetaWithTableFormat;
+    public tableFormat?: TableFormat;
+    private legendDataSerieIndexes: LegendDataSerieIndexes;
+    public readonly legendTitles: LegendTitles;
 
-	constructor(private params: UrlSearchParams) {
-		this.ids = params.has('objId') ? params.get('objId').split(',') as string[] : [];
-		this.linking = params.get('linking') === 'concatenate' ? 'concatenate' : 'overlap';
-		this.hasY2 = params.has('y2');
+    constructor(private params: UrlSearchParams) {
+        this.ids = params.has('objId') ? params.get('objId').split(',') as string[] : [];
+        this.linking = params.get('linking') === 'concatenate' ? 'concatenate' : 'overlap';
+        this.hasY2 = params.has('y2');
 
-		if (params.has('legendLabels'))
-			this.legendLabels = params.get('legendLabels').split(',');
+        if (params.has('legendLabels'))
+            this.legendLabels = params.get('legendLabels').split(',');
 
-		this.legendDataSerieIndexes = getLegendDataIndexes(this.linking, this.ids, this.hasY2);
-		this.legendTitles = {
-			y: this.hasY2 ? params.get('y') : 'Legend',
-			y2: params.get('y2')
-		};
-	}
+        this.legendDataSerieIndexes = getLegendDataIndexes(this.linking, this.ids, this.hasY2);
+        this.legendTitles = {
+            y: this.hasY2 ? params.get('y') : 'Legend',
+            y2: params.get('y2')
+        };
+    }
 
-	set objects(objects: MetaWithTableFormat[]){
-		const sortedObjects = objects.sort((obj1, obj2) =>
-			new Date(obj1.startedAtTime).getTime() - new Date(obj2.startedAtTime).getTime()
-		);
-		const specList = Array.from(new Set(sortedObjects.map(o => o.specLabel))).join(' / ');
-		this.chartTitle = this.hasY2
-			? `${specList} - ${this.params.get('y')} and ${this.params.get('y2')}`
-			: `${specList} - ${this.params.get('y')}`;
+    set objects(objects: MetaWithTableFormat[]) {
+        const sortedObjects = objects.sort((obj1, obj2) =>
+            new Date(obj1.startedAtTime).getTime() - new Date(obj2.startedAtTime).getTime()
+        );
+        const specList = Array.from(new Set(sortedObjects.map(o => o.specLabel))).join(' / ');
+        this.chartTitle = this.hasY2
+            ? `${specList} - ${this.params.get('y')} and ${this.params.get('y2')}`
+            : `${specList} - ${this.params.get('y')}`;
 
-		this.metadata = sortedObjects.map((object, idx) => new Metadata(this.linking, object, idx, this.params));
+        this.metadata = sortedObjects.map((object, idx) => new Metadata(this.linking, object, idx, this.params));
 
-		this.object = sortedObjects.find(object =>
-			isColNameValid(object.tableFormat, this.params.get('x'))
-			&& isColNameValid(object.tableFormat, this.params.get('y'))
-			&& (!this.hasY2 || isColNameValid(object.tableFormat, this.params.get('y2')))
-		);
+        this.object = sortedObjects.find(object =>
+            isColNameValid(object.tableFormat, this.params.get('x'))
+            && isColNameValid(object.tableFormat, this.params.get('y'))
+            && (!this.hasY2 || isColNameValid(object.tableFormat, this.params.get('y2')))
+        );
 
-		if (this.object) {
-			this.xlabel = getLabel(this.object.tableFormat, this.params.get('x'));
-			this.xLegendLabel = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'label');
-			this.valueFormatX = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'valueFormat');
-			this.ylabel = getLabel(this.object.tableFormat, this.params.get('y'));
-			if (this.hasY2)
-				this.y2label = getLabel(this.object.tableFormat, this.params.get('y2'));
+        if (this.object) {
+            this.xlabel = getLabel(this.object.tableFormat, this.params.get('x'));
+            this.xLegendLabel = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'label');
+            this.valueFormatX = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'valueFormat');
+            this.ylabel = getLabel(this.object.tableFormat, this.params.get('y'));
+            if (this.hasY2)
+                this.y2label = getLabel(this.object.tableFormat, this.params.get('y2'));
 
-			if (this.linking === 'concatenate'){
-				this.labels = this.hasY2
-					? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
-					: [this.xlabel].concat(this.metadata[0].labels.y);
-			} else {
-				this.labels = this.hasY2
-					? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y,dobj.labels.y2!]))
-					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
-			}
-		}
-	}
+            if (this.linking === 'concatenate') {
+                this.labels = this.hasY2
+                    ? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
+                    : [this.xlabel].concat(this.metadata[0].labels.y);
+            } else {
+                this.labels = this.hasY2
+                    ? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y, dobj.labels.y2!]))
+                    : [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
+            }
+        }
+    }
 
-	get title(){
-		return !window.frameElement && this.chartTitle || ' ';
-	}
+    get title() {
+        return !window.frameElement && this.chartTitle || ' ';
+    }
 
-	get series(){
-		if (!this.hasY2 || !this.metadata || this.metadata.some(dobj => dobj.labels.y2 === undefined))
-			return {};
+    get series() {
+        if (!this.hasY2 || !this.metadata || this.metadata.some(dobj => dobj.labels.y2 === undefined))
+            return {};
 
-		// Use a single scale if y and y2 have the same value type
-		if (this.object){
-			const mwtf = this.object;//to keep the compiler happy
-			const yColInfo = (ycol: 'y' | 'y2', key: keyof ColumnInfo) => {
-				return getColInfoParam(mwtf.tableFormat, this.params.get(ycol), key);
-			}
+        // Use a single scale if y and y2 have the same value type
+        if (this.object) {
+            const mwtf = this.object;//to keep the compiler happy
+            const yColInfo = (ycol: 'y' | 'y2', key: keyof ColumnInfo) => {
+                return getColInfoParam(mwtf.tableFormat, this.params.get(ycol), key);
+            }
 
-			const sameValueType = (['label', 'unit'] as const).every(key =>
-				yColInfo('y', key) === yColInfo('y2', key)
-			)
-			if(sameValueType) return {};
-		}
+            const sameValueType = (['label', 'unit'] as const).every(key =>
+                yColInfo('y', key) === yColInfo('y2', key)
+            )
+            if (sameValueType) return {};
+        }
 
-		return this.metadata.reduce<{[k: string]: PerSeriesOptions}>((acc, dobj) => {
-			acc[dobj.labels.y] = {axis: 'y1'};
-			acc[dobj.labels.y2!] = {axis: 'y2'};
+        return this.metadata.reduce<{ [k: string]: PerSeriesOptions }>((acc, dobj) => {
+            acc[dobj.labels.y] = { axis: 'y1' };
+            acc[dobj.labels.y2!] = { axis: 'y2' };
 
-			return acc;
-		}, {});
-	}
+            return acc;
+        }, {});
+    }
 
-	legendData(data: LegendData){
-		return {
-			y: this.legendDataSerieIndexes.y.map(i => data.series[i]),
-			y2: this.legendDataSerieIndexes.y2.map(i => data.series[i])
-		};
-	}
+    legendData(data: LegendData) {
+        return {
+            y: this.legendDataSerieIndexes.y.map(i => data.series[i]),
+            y2: this.legendDataSerieIndexes.y2.map(i => data.series[i])
+        };
+    }
 
-	get uniqueLabels() {
-		return this.labels.reduce<string[]>((acc, lbl, idx) => {
-			if (acc.includes(lbl))
-				acc.push(`${idx} ${lbl}`);
-			else
-				acc.push(lbl);
+    get uniqueLabels() {
+        return this.labels.reduce<string[]>((acc, lbl, idx) => {
+            if (acc.includes(lbl))
+                acc.push(`${idx} ${lbl}`);
+            else
+                acc.push(lbl);
 
-			return acc;
-		}, []);
-	}
+            return acc;
+        }, []);
+    }
 }
 
 function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes {
-	if (linking === 'concatenate'){
-		if (hasY2) {
-			return {
-				y: [0],
-				y2: [1]
-			};
-		} else {
-			return {
-				y: [0],
-				y2: []
-			};
-		}
-	} else {
+    if (linking === 'concatenate') {
+        if (hasY2) {
+            return {
+                y: [0],
+                y2: [1]
+            };
+        } else {
+            return {
+                y: [0],
+                y2: []
+            };
+        }
+    } else {
         const length = hasY2 ? ids.length * 2 : ids.length;
-        const indexes = Array.from({length}, (_, i) => i);
+        const indexes = Array.from({ length }, (_, i) => i);
 
         if (hasY2) {
             return {
@@ -172,65 +172,65 @@ function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): 
 }
 
 class Metadata {
-	readonly labels: {y: string, y2?: string};
+    readonly labels: { y: string, y2?: string };
 
-	constructor(linking: Linking, readonly object: MetaWithTableFormat, idx: number, params: UrlSearchParams) {
-		const hasY2 = params.has('y2');
+    constructor(linking: Linking, readonly object: MetaWithTableFormat, idx: number, params: UrlSearchParams) {
+        const hasY2 = params.has('y2');
 
-		// Labels must be unique in dygraphs
-		const postfix = hasY2 && linking !== 'concatenate' ? ' '.repeat(idx + 2) : '';
-		const postfixY2 = linking === 'concatenate' ? '' : ' ';
+        // Labels must be unique in dygraphs
+        const postfix = hasY2 && linking !== 'concatenate' ? ' '.repeat(idx + 2) : '';
+        const postfixY2 = linking === 'concatenate' ? '' : ' ';
 
-		const paramsYLabel = getLegendLabelFromParams(params, 'legendLabels', object.id);
-		const yLabel = getFinalLabel(linking, paramsYLabel, object, params.get('y'), postfix);
+        const paramsYLabel = getLegendLabelFromParams(params, 'legendLabels', object.id);
+        const yLabel = getFinalLabel(linking, paramsYLabel, object, params.get('y'), postfix);
 
-		let y2Label: string | undefined = undefined;
+        let y2Label: string | undefined = undefined;
 
-		if (hasY2) {
-			const paramsY2Label = getLegendLabelFromParams(params, 'legendLabelsY2', object.id);
-			y2Label = getFinalLabel(linking, paramsY2Label, object, params.get('y2'), postfixY2);
-		}
+        if (hasY2) {
+            const paramsY2Label = getLegendLabelFromParams(params, 'legendLabelsY2', object.id);
+            y2Label = getFinalLabel(linking, paramsY2Label, object, params.get('y2'), postfixY2);
+        }
 
-		this.labels = {
-			y: yLabel,
-			y2: y2Label
-		};
-	}
+        this.labels = {
+            y: yLabel,
+            y2: y2Label
+        };
+    }
 }
 
 function getFinalLabel(linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') {
-	if (requestedLabel) return requestedLabel + postfix;
+    if (requestedLabel) return requestedLabel + postfix;
 
-	if (linking === 'concatenate'){
-		return getLabel(object.tableFormat, colName) + postfix;
-	} 
-	const filename = object.filename;
+    if (linking === 'concatenate') {
+        return getLabel(object.tableFormat, colName) + postfix;
+    }
+    const filename = object.filename;
 
-	return filename.slice(0, filename.lastIndexOf('.')) + postfix;
+    return filename.slice(0, filename.lastIndexOf('.')) + postfix;
 }
 
 function getLegendLabelFromParams(params: UrlSearchParams, name: string, objId: string) {
-	const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
-	const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
-	
-	if (labels.length === 0 || ids.length === 0) return '';
-	
-	const idx = ids.findIndex(id => objId.includes(id));
+    const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
+    const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
 
-	return (idx !== -1 && labels[idx]) ? labels[idx] : '';
+    if (labels.length === 0 || ids.length === 0) return '';
+
+    const idx = ids.findIndex(id => objId.includes(id));
+
+    return (idx !== -1 && labels[idx]) ? labels[idx] : '';
 }
 
 function isColNameValid(tableFormat: TableFormat, colName: string) {
-	return tableFormat.getColumnIndex(colName) >= 0;
+    return tableFormat.getColumnIndex(colName) >= 0;
 }
 
 function getLabel(tableFormat: TableFormat, colName: string) {
-	const unit = getColInfoParam(tableFormat, colName, 'unit');
-	const label = getColInfoParam(tableFormat, colName, 'label');
+    const unit = getColInfoParam(tableFormat, colName, 'unit');
+    const label = getColInfoParam(tableFormat, colName, 'label');
 
-	return unit === '?' ? label : `${label} [${unit}]`;
+    return unit === '?' ? label : `${label} [${unit}]`;
 }
 
 function getColInfoParam<T extends keyof ColumnInfo>(tableFormat: TableFormat, colName: string, param: T) {
-	return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
+    return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
 }

--- a/src/main/js/dygraph-light/main/LabelMaker.ts
+++ b/src/main/js/dygraph-light/main/LabelMaker.ts
@@ -1,161 +1,161 @@
 import UrlSearchParams from "../../common/main/models/UrlSearchParams";
-import { ColumnInfo, TableFormat } from "icos-cp-backend";
+import {ColumnInfo, TableFormat} from "icos-cp-backend";
 import { dygraphs } from "dygraphs";
 import PerSeriesOptions = dygraphs.PerSeriesOptions;
 import LegendData = dygraphs.LegendData;
 
 export type MetaWithTableFormat = {
-    id: string
-    objSpec: string
-    nRows: number
-    filename: string
-    specLabel: string
-    startedAtTime: string
-    columnNames: string[] | undefined
-    tableFormat: TableFormat
+	id: string
+	objSpec: string
+	nRows: number
+	filename: string
+	specLabel: string
+	startedAtTime: string
+	columnNames: string[] | undefined
+	tableFormat: TableFormat
 }
 
 type LegendDataSerieIndexes = {
-    y: number[],
-    y2: number[]
+	y: number[],
+	y2: number[]
 }
 type Linking = 'overlap' | 'concatenate'
-type LegendTitles = { y: string, y2: string }
+type LegendTitles = {y: string, y2: string}
 
 export default class LabelMaker {
-    readonly ids: string[];
-    readonly hasY2: boolean;
-    readonly linking: Linking;
-    public metadata?: Metadata[];
-    readonly legendLabels: string[] = [];
-    public chartTitle?: string;
-    public xlabel: string = '';
-    public xLegendLabel: string = '';
-    public valueFormatX: string = '';
-    public ylabel: string = '';
-    public y2label: string = '';
-    public labels: string[] = [];
-    public object?: MetaWithTableFormat;
-    public tableFormat?: TableFormat;
-    private legendDataSerieIndexes: LegendDataSerieIndexes;
-    public readonly legendTitles: LegendTitles;
+	readonly ids: string[];
+	readonly hasY2: boolean;
+	readonly linking: Linking;
+	public metadata?: Metadata[];
+	readonly legendLabels: string[] = [];
+	public chartTitle?: string;
+	public xlabel: string = '';
+	public xLegendLabel: string = '';
+	public valueFormatX: string = '';
+	public ylabel: string = '';
+	public y2label: string = '';
+	public labels: string[] = [];
+	public object?: MetaWithTableFormat;
+	public tableFormat?: TableFormat;
+	private legendDataSerieIndexes: LegendDataSerieIndexes;
+	public readonly legendTitles: LegendTitles;
 
-    constructor(private params: UrlSearchParams) {
-        this.ids = params.has('objId') ? params.get('objId').split(',') as string[] : [];
-        this.linking = params.get('linking') === 'concatenate' ? 'concatenate' : 'overlap';
-        this.hasY2 = params.has('y2');
+	constructor(private params: UrlSearchParams) {
+		this.ids = params.has('objId') ? params.get('objId').split(',') as string[] : [];
+		this.linking = params.get('linking') === 'concatenate' ? 'concatenate' : 'overlap';
+		this.hasY2 = params.has('y2');
 
-        if (params.has('legendLabels'))
-            this.legendLabels = params.get('legendLabels').split(',');
+		if (params.has('legendLabels'))
+			this.legendLabels = params.get('legendLabels').split(',');
 
-        this.legendDataSerieIndexes = getLegendDataIndexes(this.linking, this.ids, this.hasY2);
-        this.legendTitles = {
-            y: this.hasY2 ? params.get('y') : 'Legend',
-            y2: params.get('y2')
-        };
-    }
+		this.legendDataSerieIndexes = getLegendDataIndexes(this.linking, this.ids, this.hasY2);
+		this.legendTitles = {
+			y: this.hasY2 ? params.get('y') : 'Legend',
+			y2: params.get('y2')
+		};
+	}
 
-    set objects(objects: MetaWithTableFormat[]) {
-        const sortedObjects = objects.sort((obj1, obj2) =>
-            new Date(obj1.startedAtTime).getTime() - new Date(obj2.startedAtTime).getTime()
-        );
-        const specList = Array.from(new Set(sortedObjects.map(o => o.specLabel))).join(' / ');
-        this.chartTitle = this.hasY2
-            ? `${specList} - ${this.params.get('y')} and ${this.params.get('y2')}`
-            : `${specList} - ${this.params.get('y')}`;
+	set objects(objects: MetaWithTableFormat[]){
+		const sortedObjects = objects.sort((obj1, obj2) =>
+			new Date(obj1.startedAtTime).getTime() - new Date(obj2.startedAtTime).getTime()
+		);
+		const specList = Array.from(new Set(sortedObjects.map(o => o.specLabel))).join(' / ');
+		this.chartTitle = this.hasY2
+			? `${specList} - ${this.params.get('y')} and ${this.params.get('y2')}`
+			: `${specList} - ${this.params.get('y')}`;
 
-        this.metadata = sortedObjects.map((object, idx) => new Metadata(this.linking, object, idx, this.params));
+		this.metadata = sortedObjects.map((object, idx) => new Metadata(this.linking, object, idx, this.params));
 
-        this.object = sortedObjects.find(object =>
-            isColNameValid(object.tableFormat, this.params.get('x'))
-            && isColNameValid(object.tableFormat, this.params.get('y'))
-            && (!this.hasY2 || isColNameValid(object.tableFormat, this.params.get('y2')))
-        );
+		this.object = sortedObjects.find(object =>
+			isColNameValid(object.tableFormat, this.params.get('x'))
+			&& isColNameValid(object.tableFormat, this.params.get('y'))
+			&& (!this.hasY2 || isColNameValid(object.tableFormat, this.params.get('y2')))
+		);
 
-        if (this.object) {
-            this.xlabel = getLabel(this.object.tableFormat, this.params.get('x'));
-            this.xLegendLabel = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'label');
-            this.valueFormatX = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'valueFormat');
-            this.ylabel = getLabel(this.object.tableFormat, this.params.get('y'));
-            if (this.hasY2)
-                this.y2label = getLabel(this.object.tableFormat, this.params.get('y2'));
+		if (this.object) {
+			this.xlabel = getLabel(this.object.tableFormat, this.params.get('x'));
+			this.xLegendLabel = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'label');
+			this.valueFormatX = getColInfoParam(this.object.tableFormat, this.params.get('x'), 'valueFormat');
+			this.ylabel = getLabel(this.object.tableFormat, this.params.get('y'));
+			if (this.hasY2)
+				this.y2label = getLabel(this.object.tableFormat, this.params.get('y2'));
 
-            if (this.linking === 'concatenate') {
-                this.labels = this.hasY2
-                    ? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
-                    : [this.xlabel].concat(this.metadata[0].labels.y);
-            } else {
-                this.labels = this.hasY2
-                    ? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y, dobj.labels.y2!]))
-                    : [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
-            }
-        }
-    }
+			if (this.linking === 'concatenate'){
+				this.labels = this.hasY2
+					? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
+					: [this.xlabel].concat(this.metadata[0].labels.y);
+			} else {
+				this.labels = this.hasY2
+					? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y,dobj.labels.y2!]))
+					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
+			}
+		}
+	}
 
-    get title() {
-        return !window.frameElement && this.chartTitle || ' ';
-    }
+	get title(){
+		return !window.frameElement && this.chartTitle || ' ';
+	}
 
-    get series() {
-        if (!this.hasY2 || !this.metadata || this.metadata.some(dobj => dobj.labels.y2 === undefined))
-            return {};
+	get series(){
+		if (!this.hasY2 || !this.metadata || this.metadata.some(dobj => dobj.labels.y2 === undefined))
+			return {};
 
-        // Use a single scale if y and y2 have the same value type
-        if (this.object) {
-            const mwtf = this.object;//to keep the compiler happy
-            const yColInfo = (ycol: 'y' | 'y2', key: keyof ColumnInfo) => {
-                return getColInfoParam(mwtf.tableFormat, this.params.get(ycol), key);
-            }
+		// Use a single scale if y and y2 have the same value type
+		if (this.object){
+			const mwtf = this.object;//to keep the compiler happy
+			const yColInfo = (ycol: 'y' | 'y2', key: keyof ColumnInfo) => {
+				return getColInfoParam(mwtf.tableFormat, this.params.get(ycol), key);
+			}
 
-            const sameValueType = (['label', 'unit'] as const).every(key =>
-                yColInfo('y', key) === yColInfo('y2', key)
-            )
-            if (sameValueType) return {};
-        }
+			const sameValueType = (['label', 'unit'] as const).every(key =>
+				yColInfo('y', key) === yColInfo('y2', key)
+			)
+			if(sameValueType) return {};
+		}
 
-        return this.metadata.reduce<{ [k: string]: PerSeriesOptions }>((acc, dobj) => {
-            acc[dobj.labels.y] = { axis: 'y1' };
-            acc[dobj.labels.y2!] = { axis: 'y2' };
+		return this.metadata.reduce<{[k: string]: PerSeriesOptions}>((acc, dobj) => {
+			acc[dobj.labels.y] = {axis: 'y1'};
+			acc[dobj.labels.y2!] = {axis: 'y2'};
 
-            return acc;
-        }, {});
-    }
+			return acc;
+		}, {});
+	}
 
-    legendData(data: LegendData) {
-        return {
-            y: this.legendDataSerieIndexes.y.map(i => data.series[i]),
-            y2: this.legendDataSerieIndexes.y2.map(i => data.series[i])
-        };
-    }
+	legendData(data: LegendData){
+		return {
+			y: this.legendDataSerieIndexes.y.map(i => data.series[i]),
+			y2: this.legendDataSerieIndexes.y2.map(i => data.series[i])
+		};
+	}
 
-    get uniqueLabels() {
-        return this.labels.reduce<string[]>((acc, lbl, idx) => {
-            if (acc.includes(lbl))
-                acc.push(`${idx} ${lbl}`);
-            else
-                acc.push(lbl);
+	get uniqueLabels() {
+		return this.labels.reduce<string[]>((acc, lbl, idx) => {
+			if (acc.includes(lbl))
+				acc.push(`${idx} ${lbl}`);
+			else
+				acc.push(lbl);
 
-            return acc;
-        }, []);
-    }
+			return acc;
+		}, []);
+	}
 }
 
 function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes {
-    if (linking === 'concatenate') {
-        if (hasY2) {
-            return {
-                y: [0],
-                y2: [1]
-            };
-        } else {
-            return {
-                y: [0],
-                y2: []
-            };
-        }
-    } else {
+	if (linking === 'concatenate'){
+		if (hasY2) {
+			return {
+				y: [0],
+				y2: [1]
+			};
+		} else {
+			return {
+				y: [0],
+				y2: []
+			};
+		}
+	} else {
         const length = hasY2 ? ids.length * 2 : ids.length;
-        const indexes = Array.from({ length }, (_, i) => i);
+        const indexes = Array.from({length}, (_, i) => i);
 
         if (hasY2) {
             return {
@@ -172,65 +172,65 @@ function getLegendDataIndexes(linking: Linking, ids: string[], hasY2: boolean): 
 }
 
 class Metadata {
-    readonly labels: { y: string, y2?: string };
+	readonly labels: {y: string, y2?: string};
 
-    constructor(linking: Linking, readonly object: MetaWithTableFormat, idx: number, params: UrlSearchParams) {
-        const hasY2 = params.has('y2');
+	constructor(linking: Linking, readonly object: MetaWithTableFormat, idx: number, params: UrlSearchParams) {
+		const hasY2 = params.has('y2');
 
-        // Labels must be unique in dygraphs
-        const postfix = hasY2 && linking !== 'concatenate' ? ' '.repeat(idx + 2) : '';
-        const postfixY2 = linking === 'concatenate' ? '' : ' ';
+		// Labels must be unique in dygraphs
+		const postfix = hasY2 && linking !== 'concatenate' ? ' '.repeat(idx + 2) : '';
+		const postfixY2 = linking === 'concatenate' ? '' : ' ';
 
-        const paramsYLabel = getLegendLabelFromParams(params, 'legendLabels', object.id);
-        const yLabel = getFinalLabel(linking, paramsYLabel, object, params.get('y'), postfix);
+		const paramsYLabel = getLegendLabelFromParams(params, 'legendLabels', object.id);
+		const yLabel = getFinalLabel(linking, paramsYLabel, object, params.get('y'), postfix);
 
-        let y2Label: string | undefined = undefined;
+		let y2Label: string | undefined = undefined;
 
-        if (hasY2) {
-            const paramsY2Label = getLegendLabelFromParams(params, 'legendLabelsY2', object.id);
-            y2Label = getFinalLabel(linking, paramsY2Label, object, params.get('y2'), postfixY2);
-        }
+		if (hasY2) {
+			const paramsY2Label = getLegendLabelFromParams(params, 'legendLabelsY2', object.id);
+			y2Label = getFinalLabel(linking, paramsY2Label, object, params.get('y2'), postfixY2);
+		}
 
-        this.labels = {
-            y: yLabel,
-            y2: y2Label
-        };
-    }
+		this.labels = {
+			y: yLabel,
+			y2: y2Label
+		};
+	}
 }
 
 function getFinalLabel(linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') {
-    if (requestedLabel) return requestedLabel + postfix;
+	if (requestedLabel) return requestedLabel + postfix;
 
-    if (linking === 'concatenate') {
-        return getLabel(object.tableFormat, colName) + postfix;
-    }
-    const filename = object.filename;
+	if (linking === 'concatenate'){
+		return getLabel(object.tableFormat, colName) + postfix;
+	} 
+	const filename = object.filename;
 
-    return filename.slice(0, filename.lastIndexOf('.')) + postfix;
+	return filename.slice(0, filename.lastIndexOf('.')) + postfix;
 }
 
 function getLegendLabelFromParams(params: UrlSearchParams, name: string, objId: string) {
-    const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
-    const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
+	const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
+	const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
+	
+	if (labels.length === 0 || ids.length === 0) return '';
+	
+	const idx = ids.findIndex(id => objId.includes(id));
 
-    if (labels.length === 0 || ids.length === 0) return '';
-
-    const idx = ids.findIndex(id => objId.includes(id));
-
-    return (idx !== -1 && labels[idx]) ? labels[idx] : '';
+	return (idx !== -1 && labels[idx]) ? labels[idx] : '';
 }
 
 function isColNameValid(tableFormat: TableFormat, colName: string) {
-    return tableFormat.getColumnIndex(colName) >= 0;
+	return tableFormat.getColumnIndex(colName) >= 0;
 }
 
 function getLabel(tableFormat: TableFormat, colName: string) {
-    const unit = getColInfoParam(tableFormat, colName, 'unit');
-    const label = getColInfoParam(tableFormat, colName, 'label');
+	const unit = getColInfoParam(tableFormat, colName, 'unit');
+	const label = getColInfoParam(tableFormat, colName, 'label');
 
-    return unit === '?' ? label : `${label} [${unit}]`;
+	return unit === '?' ? label : `${label} [${unit}]`;
 }
 
 function getColInfoParam<T extends keyof ColumnInfo>(tableFormat: TableFormat, colName: string, param: T) {
-    return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
+	return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
 }

--- a/src/main/js/dygraph-light/main/LabelMaker.ts
+++ b/src/main/js/dygraph-light/main/LabelMaker.ts
@@ -1,31 +1,26 @@
 import UrlSearchParams from "../../common/main/models/UrlSearchParams";
-import { ColumnInfo, TableFormat } from "icos-cp-backend";
+import {ColumnInfo, TableFormat} from "icos-cp-backend";
 import { dygraphs } from "dygraphs";
 import PerSeriesOptions = dygraphs.PerSeriesOptions;
 import LegendData = dygraphs.LegendData;
 
 export type MetaWithTableFormat = {
-	id: string;
-	objSpec: string;
-	nRows: number;
-	filename: string;
-	specLabel: string;
-	startedAtTime: string;
-	columnNames: string[] | undefined;
-	tableFormat: TableFormat;
+	id: string
+	objSpec: string
+	nRows: number
+	filename: string
+	specLabel: string
+	startedAtTime: string
+	columnNames: string[] | undefined
+	tableFormat: TableFormat
 }
 
 type LegendDataSerieIndexes = {
-	y: number[];
-	y2: number[];
+	y: number[],
+	y2: number[]
 }
-
-type Linking = 'overlap' | 'concatenate';
-
-type LegendTitles = {
-	y: string;
-	y2: string;
-}
+type Linking = 'overlap' | 'concatenate'
+type LegendTitles = {y: string, y2: string}
 
 export default class LabelMaker {
 	readonly ids: string[];
@@ -34,11 +29,11 @@ export default class LabelMaker {
 	public metadata?: Metadata[];
 	readonly legendLabels: string[] = [];
 	public chartTitle?: string;
-	public xlabel = '';
-	public xLegendLabel = '';
-	public valueFormatX = '';
-	public ylabel = '';
-	public y2label = '';
+	public xlabel: string = '';
+	public xLegendLabel: string = '';
+	public valueFormatX: string = '';
+	public ylabel: string = '';
+	public y2label: string = '';
 	public labels: string[] = [];
 	public object?: MetaWithTableFormat;
 	public tableFormat?: TableFormat;
@@ -46,7 +41,7 @@ export default class LabelMaker {
 	public readonly legendTitles: LegendTitles;
 
 	constructor(private params: UrlSearchParams) {
-		this.ids = params.has('objId') ? params.get('objId').split(',') : [];
+		this.ids = params.has('objId') ? params.get('objId').split(',') as string[] : [];
 		this.linking = params.get('linking') === 'concatenate' ? 'concatenate' : 'overlap';
 		this.hasY2 = params.has('y2');
 
@@ -60,7 +55,7 @@ export default class LabelMaker {
 		};
 	}
 
-	set objects(objects: MetaWithTableFormat[]) {
+	set objects(objects: MetaWithTableFormat[]){
 		const sortedObjects = objects.sort((obj1, obj2) =>
 			new Date(obj1.startedAtTime).getTime() - new Date(obj2.startedAtTime).getTime()
 		);
@@ -85,35 +80,36 @@ export default class LabelMaker {
 			if (this.hasY2)
 				this.y2label = getLabel(this.object.tableFormat, this.params.get('y2'));
 
-			if (this.linking === 'concatenate') {
+			if (this.linking === 'concatenate'){
 				this.labels = this.hasY2
 					? [this.xlabel].concat(this.metadata[0].labels.y).concat(this.metadata[0].labels.y2!)
-					: [this.xlabel].concat(this.metadata[0].labels.y);
+					: [this.xlabel].concat(this.metadata[0].labels.y)
 			} else {
 				this.labels = this.hasY2
 					? [this.xlabel].concat(this.metadata.flatMap(dobj => [dobj.labels.y,dobj.labels.y2!]))
-					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y));
+					: [this.xlabel].concat(this.metadata.map(dobj => dobj.labels.y))
 			}
 		}
 	}
 
-	get title() {
+	get title(){
 		return !window.frameElement && this.chartTitle || ' ';
 	}
 
-	get series() {
+	get series(){
 		if (!this.hasY2 || !this.metadata || this.metadata.some(dobj => dobj.labels.y2 === undefined))
 			return {};
 
 		// Use a single scale if y and y2 have the same value type
-		if (this.object) {
+		if (this.object){
+			const mwtf = this.object;//to keep the compiler happy
 			const yColInfo = (ycol: 'y' | 'y2', key: keyof ColumnInfo) => {
-				return getColInfoParam(this.object!.tableFormat, this.params.get(ycol), key);
-			};
+				return getColInfoParam(mwtf.tableFormat, this.params.get(ycol), key);
+			}
 
 			const sameValueType = (['label', 'unit'] as const).every(key =>
 				yColInfo('y', key) === yColInfo('y2', key)
-			);
+			)
 			if(sameValueType) return {};
 		}
 
@@ -125,7 +121,7 @@ export default class LabelMaker {
 		}, {});
 	}
 
-	legendData(data: LegendData) {
+	legendData(data: LegendData){
 		return {
 			y: this.legendDataSerieIndexes.y.map(i => data.series[i]),
 			y2: this.legendDataSerieIndexes.y2.map(i => data.series[i])
@@ -145,7 +141,7 @@ export default class LabelMaker {
 }
 
 const getLegendDataIndexes = (linking: Linking, ids: string[], hasY2: boolean): LegendDataSerieIndexes => {
-	if (linking === 'concatenate') {
+	if (linking === 'concatenate'){
 		if (hasY2) {
 			return {
 				y: [0],
@@ -177,7 +173,7 @@ const getLegendDataIndexes = (linking: Linking, ids: string[], hasY2: boolean): 
 };
 
 class Metadata {
-	readonly labels: { y: string; y2?: string };
+	readonly labels: {y: string, y2?: string};
 
 	constructor(linking: Linking, readonly object: MetaWithTableFormat, idx: number, params: UrlSearchParams) {
 		const hasY2 = params.has('y2');
@@ -199,16 +195,16 @@ class Metadata {
 		this.labels = {
 			y: yLabel,
 			y2: y2Label
-		};
+		}
 	}
 }
 
 const getFinalLabel = (linking: 'overlap' | 'concatenate', requestedLabel: string, object: MetaWithTableFormat, colName: string, postfix: string = '') => {
 	if (requestedLabel) return requestedLabel + postfix;
 
-	if (linking === 'concatenate') {
+	if (linking === 'concatenate'){
 		return getLabel(object.tableFormat, colName) + postfix;
-	}
+	} 
 	const filename = object.filename;
 
 	return filename.slice(0, filename.lastIndexOf('.')) + postfix;
@@ -217,7 +213,7 @@ const getFinalLabel = (linking: 'overlap' | 'concatenate', requestedLabel: strin
 const getLegendLabelFromParams = (params: UrlSearchParams, name: string, objId: string) => {
 	const labels: string[] = params.has(name) ? params.get(name).split(',') : [];
 	const ids: string[] = params.has('objId') ? params.get('objId').split(',') : [];
-
+	
 	if (labels.length === 0 || ids.length === 0) return '';
 	
 	const idx = ids.findIndex(id => objId.includes(id));
@@ -238,4 +234,4 @@ const getLabel = (tableFormat: TableFormat, colName: string) => {
 
 function getColInfoParam<T extends keyof ColumnInfo>(tableFormat: TableFormat, colName: string, param: T) {
 	return tableFormat.columns[tableFormat.getColumnIndex(colName)][param];
-}
+};

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -155,7 +155,8 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 		const yParam = yAxis ? `&y=${yAxis}` : '';
 		const y2Param = y2Axis ? `&y2=${y2Axis}` : '';
 		const legendLabelsParams = legendLabels ? `&legendLabels=${legendLabels}` : '';
-		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}${iFrameBaseUrl}?objId=${objIds}&x=${xAxis}${yParam}${y2Param}&type=${type}&linking=${linking}${legendLabelsParams}`;
+		const legendLabelsY2Params = y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '';
+		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}${iFrameBaseUrl}?objId=${objIds}&x=${xAxis}${yParam}${y2Param}&type=${type}&linking=${linking}${legendLabelsParams}${legendLabelsY2Params}`;
 
 		if (!preview)
 			return null;


### PR DESCRIPTION
_Note: formatting changes have been removed pending discussion re: style guidelines, formatting guidelines, tooling, etc. They are in branch [`reformat-labelmaker`](https://github.com/ICOS-Carbon-Portal/data/tree/reformat-labelmaker). The conversation remains below as reference._

Provided in the search parameters are both `objId`, a comma-separated list of object IDs, and `legendLabels` (and `legendLabelsY2`), a corresponding list of legend labels for the primary Y-axis. 

Internally, the data objects are re-ordered so that the data object with the first recorded data (along the x-axis) is displayed first. However, the legend labels were associated with the object ID, so they were becoming decoupled during this reordering.

Thus, we now ensure that the legend label corresponding to the objectID in question is displayed.

Also add appropriate Y2 labels when adding Y2 axis instead of leaving them as file name, ensuring consistency with label names.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209555804864695