### PR TITLE
[portal][imagezipview] Enable controlling imagezipview from portal

### DIFF
--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -64,7 +64,7 @@ export default function PreviewSelfContained({ preview, iframeSrcChange }: OurPr
 }
 
 function getInitialHeight(previewType?: PreviewType): number {
-	switch(previewType) {
+	switch(previewType){
 		case config.NETCDF: return Math.max(window.innerHeight - 100, 480);
 		case config.MAPGRAPH: return 1100;
 		case config.PHENOCAM: return 1100;

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -1,7 +1,7 @@
-import React, { ChangeEvent, useState, useEffect, useRef, useCallback } from 'react';
-import config, { PreviewType } from '../../config';
-import { getLastSegmentInUrl } from "../../utils";
-import { State } from "../../models/State";
+import React, {ChangeEvent, useState, useEffect, useRef, useCallback} from 'react';
+import config, {PreviewType} from '../../config';
+import {getLastSegmentInUrl} from "../../utils";
+import {State} from "../../models/State";
 import { UrlStr } from '../../backend/declarations';
 import { debounce } from 'icos-cp-utils';
 import CartItem from '../../models/CartItem';
@@ -64,7 +64,7 @@ export default function PreviewSelfContained({ preview, iframeSrcChange }: OurPr
 }
 
 function getInitialHeight(previewType?: PreviewType): number {
-	switch (previewType) {
+	switch(previewType) {
 		case config.NETCDF: return Math.max(window.innerHeight - 100, 480);
 		case config.MAPGRAPH: return 1100;
 		case config.PHENOCAM: return 1100;
@@ -83,8 +83,12 @@ function shouldUpdateHeight(previewType?: PreviewType): boolean {
 function getPreviewIframeUrl(previewType: PreviewType, item: CartItem): UrlStr {
 	const iFrameBaseUrl = config.iFrameBaseUrl[previewType];
 	// Use preview.item.url if present since that one has all client changes recorded in history
-	if (item.url) return iFrameBaseUrl + getLastSegmentInUrl(item.url);
+	if (item.url) {
+		return iFrameBaseUrl + getLastSegmentInUrl(item.url);
+	}
 	const hashId = getLastSegmentInUrl(item.dobj);
-	if (previewType === config.PHENOCAM) return `${iFrameBaseUrl}?objId=${hashId}`;
+	if (previewType === config.PHENOCAM) {
+		return `${iFrameBaseUrl}?objId=${hashId}`;
+	}
 	return iFrameBaseUrl + hashId;
 }

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, useEffect, useRef } from 'react';
+import React, { ChangeEvent, useState, useEffect, useRef, KeyboardEvent } from 'react';
 import config, { PreviewType } from '../../config';
 import { getLastSegmentInUrl } from "../../utils";
 import { State } from "../../models/State";
@@ -23,10 +23,18 @@ export default function PreviewSelfContained({ preview, iframeSrcChange }: OurPr
 		}
 	});
 
+	const handleKeydown = (event: KeyboardEvent) => {
+		if(event.target instanceof Element && event.target.tagName === "INPUT") return;
+
+		iframeRef.current?.contentWindow?.postMessage({keydown: event.key});
+	};
+
 	useEffect(() => {
 		events.current.addToTarget(window, "resize", handleResize);
+		events.current.addToTarget(document, "keydown", handleKeydown);
 		return () => {
 			events.current.removeFromTarget(window, "resize", handleResize);
+			events.current.removeFromTarget(document, "keydown", handleKeydown);
 		};
 	}, []);
 

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -1,78 +1,65 @@
-import React, {ChangeEvent, Component, CSSProperties} from 'react';
-import config, {PreviewType} from '../../config';
-import {getLastSegmentInUrl} from "../../utils";
-import {State} from "../../models/State";
+import React, { ChangeEvent, useState, useEffect, useRef } from 'react';
+import config, { PreviewType } from '../../config';
+import { getLastSegmentInUrl } from "../../utils";
+import { State } from "../../models/State";
 import { UrlStr } from '../../backend/declarations';
 import { debounce, Events } from 'icos-cp-utils';
 import CartItem from '../../models/CartItem';
 
 
 interface OurProps {
-	preview: State['preview']
-	iframeSrcChange: (event: ChangeEvent<HTMLIFrameElement>) => void
+	preview: State['preview'];
+	iframeSrcChange: (event: ChangeEvent<HTMLIFrameElement>) => void;
 }
 
-type OurState = {
-	height: number | undefined
-}
+export default function PreviewSelfContained({ preview, iframeSrcChange }: OurProps) {
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const events = useRef(new Events());
+	const [height, setHeight] = useState<number>(() => getInitialHeight(preview.type));
 
-export default class PreviewSelfContained extends Component<OurProps, OurState>{
-	private ref = React.createRef<HTMLIFrameElement>();
-	private events: any
-	private handleResize: () => void
-
-	constructor(props: OurProps) {
-		super(props);
-
-		this.state = {
-			height: getHeight(props.preview.type)
-		};
-
-		this.events = new Events();
-
-		this.handleResize = debounce(() => {
-			this.ref.current && this.setHeight(this.ref.current)
-		});
-		this.events.addToTarget(window, "resize", this.handleResize);
-	}
-
-	setHeight(iframe: HTMLIFrameElement) {
-		if (shouldUpdateHeight(this.props.preview.type)) {
-			setTimeout(() => {
-				iframe.contentWindow && this.setState({ height: iframe.contentWindow.document.body.scrollHeight + 25 })
-			}, 100)
+	const handleResize = debounce(() => {
+		if (iframeRef.current) {
+			updateHeight(iframeRef.current);
 		}
-	}
+	});
 
-	onLoad(event: ChangeEvent<HTMLIFrameElement>) {
-		this.props.iframeSrcChange(event)
-		this.setHeight(event.target)
-	}
+	useEffect(() => {
+		events.current.addToTarget(window, "resize", handleResize);
+		return () => {
+			events.current.removeFromTarget(window, "resize", handleResize);
+		};
+	}, []);
 
-	shouldComponentUpdate(nextProps: OurProps, nextState: OurState){
-		// Prevent preview component from updating iframe src if we are viewing the same data object
-		return this.props.preview.item.dobj !== nextProps.preview.item.dobj
-			|| this.state.height !== nextState.height;
-	}
+	const updateHeight = (iframe: HTMLIFrameElement) => {
+		if (shouldUpdateHeight(preview.type)) {
+			setTimeout(() => {
+				if (iframe.contentWindow) {
+					setHeight(iframe.contentWindow.document.body.scrollHeight + 25);
+				}
+			}, 300);
+		}
+	};
 
-	render(){
-		const {preview} = this.props;
-		const previewType = preview.type;
+	const handleLoad = (event: ChangeEvent<HTMLIFrameElement>) => {
+		iframeSrcChange(event);
+		updateHeight(event.target);
+	};
 
-		if (previewType === undefined) return null;
+	const previewType = preview.type;
+	if (previewType === undefined) return null;
 
-		const src = getPreviewIframeUrl(previewType, preview.item)
+	const src = getPreviewIframeUrl(previewType, preview.item);
 
-		return (
-			<div className="row" style={{ width: '100%', height: this.state.height }}>
-				<iframe ref={this.ref} onLoad={this.onLoad.bind(this)} src={src} />
-			</div>
-		);
-	}
+	return (
+		<div className="row" style={{ height }}>
+			<iframe ref={iframeRef} onLoad={handleLoad} src={src} />
+		</div>
+	);
+
 }
 
-function getHeight(previewType?: PreviewType): number {
-	switch(previewType){
+function getInitialHeight(previewType?: PreviewType): number {
+	switch (previewType) {
 		case config.NETCDF: return Math.max(window.innerHeight - 100, 480);
 		case config.MAPGRAPH: return 1100;
 		case config.PHENOCAM: return 1100;
@@ -88,11 +75,11 @@ function shouldUpdateHeight(previewType?: PreviewType): boolean {
 	}
 }
 
-function getPreviewIframeUrl(previewType: PreviewType, item: CartItem): UrlStr{
-	const iFrameBaseUrl = config.iFrameBaseUrl[previewType]
+function getPreviewIframeUrl(previewType: PreviewType, item: CartItem): UrlStr {
+	const iFrameBaseUrl = config.iFrameBaseUrl[previewType];
 	// Use preview.item.url if present since that one has all client changes recorded in history
-	if(item.url) return iFrameBaseUrl + getLastSegmentInUrl(item.url)
-	const hashId = getLastSegmentInUrl(item.dobj)
-	if(previewType === config.PHENOCAM) return `${iFrameBaseUrl}?objId=${hashId}`
-	return iFrameBaseUrl + hashId
+	if (item.url) return iFrameBaseUrl + getLastSegmentInUrl(item.url);
+	const hashId = getLastSegmentInUrl(item.dobj);
+	if (previewType === config.PHENOCAM) return `${iFrameBaseUrl}?objId=${hashId}`;
+	return iFrameBaseUrl + hashId;
 }

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.html
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.7.2/css/all.css">
   </head>
   <body>
-    <div class="m-2">
-      <div class="d-flex mb-2 align-items-center justify-content-between w-100">
+    <div>
+      <div class="d-flex mb-2 ms-auto align-items-center justify-content-between" style="width: fit-content;">
         <div class="btn-group">
           <button title="To previous image" type="button" id="previous-button"
               class="btn btn-outline-secondary" disabled>
@@ -21,7 +21,7 @@
         </div>
         <select id="zipimageselect" class="form-select col" style="max-width: fit-content;"></select>
       </div>
-      <img id="multiimagezipframe" class="mw-100" />
+      <img id="multiimagezipframe" class="mw-100 " />
     </div>
     <script type="text/javascript" src="./imagezipview.js"></script>
   </body>

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.html
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.html
@@ -21,7 +21,7 @@
         </div>
         <select id="zipimageselect" class="form-select col" style="max-width: fit-content;"></select>
       </div>
-      <img id="multiimagezipframe" class="mw-100 " />
+      <img id="multiimagezipframe" class="mw-100" />
     </div>
     <script type="text/javascript" src="./imagezipview.js"></script>
   </body>

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.js
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.js
@@ -28,18 +28,46 @@
 		next.disabled = idx >= zipEntries.length - 1;
 	}
 
-	select.addEventListener('change', _ => updateDisplayedImage());
-	previous.addEventListener('click', _ => updateDisplayedImage(-1));
-	next.addEventListener('click', _ => updateDisplayedImage(1));
-
-	document.addEventListener("keydown", event => {
-		if (event.target.id === "zipimageselect") return;
-		if (event.key === "ArrowLeft") {
-			updateDisplayedImage(-1);
-		} else if (event.key === "ArrowRight") {
-			updateDisplayedImage(1);
+	function handleKeydown(event) {
+		if (event.target?.id === "zipimageselect") return;
+		switch (event.key) {
+			case "ArrowLeft":
+			case "A":
+			case "a":
+				updateDisplayedImage(-1);
+				break;
+			case "ArrowRight":
+			case "D":
+			case "d":
+				updateDisplayedImage(1);
+				break;
 		}
-	});
+	}
+
+	function handleMessage(event) {
+		if(event.isTrusted && event.data.keydown) {
+			handleKeydown(new KeyboardEvent("keydown", {key: event.data.keydown}));
+		}
+	}
+
+	function handleImgLoad(event) {
+		const img = event.target;
+		if(event.type === "error") {
+			img.alt = "This image could not be loaded; it may be missing or corrupt. Check the original data source for more information.";
+		} else {
+			img.alt = "";
+		}
+	}
+
+	select.addEventListener('change', () => updateDisplayedImage());
+	previous.addEventListener('click', () => updateDisplayedImage(-1));
+	next.addEventListener('click', () => updateDisplayedImage(1));
+
+	document.addEventListener("keydown", handleKeydown);
+	window.addEventListener("message", handleMessage);
+
+	image.addEventListener("load", handleImgLoad);
+	image.addEventListener("error", handleImgLoad);
 
 	fetch(`/zip/${urlParams.get('objId')}/listContents`)
 		.then(resp => resp.json())
@@ -57,5 +85,5 @@
 				select.appendChild(option);
 			});
 		})
-		.then(_ => updateDisplayedImage(), err => console.log(err));
+		.then(() => updateDisplayedImage(), err => console.error(err));
 })()

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.js
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.js
@@ -1,4 +1,4 @@
-(function(){
+(() => {
 	const select = document.getElementById('zipimageselect');
 	const image =  document.getElementById('multiimagezipframe');
 	const urlParams = new URLSearchParams(window.location.search);
@@ -86,4 +86,4 @@
 			});
 		})
 		.then(() => updateDisplayedImage(), err => console.error(err));
-})()
+})();

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.js
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.js
@@ -29,18 +29,19 @@
 	}
 
 	function handleKeydown(event) {
-		if (event.target?.id === "zipimageselect") return;
-		switch (event.key) {
-			case "ArrowLeft":
-			case "A":
-			case "a":
-				updateDisplayedImage(-1);
-				break;
-			case "ArrowRight":
-			case "D":
-			case "d":
-				updateDisplayedImage(1);
-				break;
+		if (event.target?.id !== "zipimageselect") {
+			switch (event.key) {
+				case "ArrowLeft":
+				case "A":
+				case "a":
+					updateDisplayedImage(-1);
+					break;
+				case "ArrowRight":
+				case "D":
+				case "d":
+					updateDisplayedImage(1);
+					break;
+			}
 		}
 	}
 


### PR DESCRIPTION
Let the user control the imagezipview preview from the keyboard without needing to focus on imagezipview. Fixes bugs, handles missing images gracefully, and improves consistency with the style of the imagezipview iframe and the portal.

Details:

- Enables the portal to send keystrokes to the imagezipview iframe, so controlling the images can be done using arrow keys without needing the iframe to have focus. Adds WASD controls as well (A and D for left/right).
- Changes the navigation controls for the images to be right-aligned completely, making them more in line with the existing options for the preview.
- Refactors `PreviewSelfContained.tsx`, changing it from a class-based to function-based component. We should be able to perform these refactors piecemeal in order to bring the React code up to a more modern standard -- this is kind of the first example of doing this.
- Fixes a bug with the resize handler, where it would trigger too late for map graph previews. (It is a modification of the existing strategy; it would be better to use the `MutationObserver` API to watch the iframe's `scrollHeight` and trigger an event when it changes, instead of using a resize handler at all. This was beyond the scope of this PR, though.)
- Adds error handling for missing images, ensuring an alt tag is applied to inform the user that the image is missing, instead of just showing an empty broken image icon.

_Note: While I tried to limit any stylistic code decisions, there are definitely still some subjective changes to the code in here. We are still working on establishing some kind of guidelines which will clarify how to handle those, and they can be easily changed at that point._
