### PR TITLE
[preview] Fix improper URI encoding in Preview URL generation

### DIFF
--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -108,8 +108,21 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 		return {...regexMatch, varTitle: actColName};
 	}
 
+	private syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}: Axes, specSettings: TsSetting) {
+		const { preview, storeTsPreviewSetting } = this.props;
+
+		if (yAxis && specSettings.y != yAxis)
+			storeTsPreviewSetting(preview.item.spec, 'y', yAxis);
+		if (xAxis && specSettings.x != xAxis)
+			storeTsPreviewSetting(preview.item.spec, 'x', xAxis);
+		if (y2Axis && specSettings.y2 != y2Axis)
+			storeTsPreviewSetting(preview.item.spec, 'y2', y2Axis);
+		if (type && specSettings.type != type)
+			storeTsPreviewSetting(preview.item.spec, 'type', type);
+	}
+
 	render(){
-		const { preview, extendedDobjInfo, tsSettings, storeTsPreviewSetting } = this.props;
+		const { preview, extendedDobjInfo, tsSettings } = this.props;
 		const { tableFormat } = this.state;
 
 		// Add station information
@@ -161,8 +174,7 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 		if (!preview)
 			return null;
 
-		if (yAxis && specSettings.y != yAxis)
-			storeTsPreviewSetting(preview.item.spec, 'y', yAxis);
+		this.syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}, specSettings);
 
 		return (
 			<>
@@ -248,7 +260,7 @@ const getAxes = (options: PreviewOption[], preview: Preview, specSettings: TsSet
 		? {
 			xAxis: preview.item.getUrlSearchValue('x') || getColName(specSettings.x),
 			yAxis: preview.item.getUrlSearchValue('y') || getColName(specSettings.y),
-			y2Axis: preview.item.getUrlSearchValue('y2'),
+			y2Axis: preview.item.getUrlSearchValue('y2')  || getColName(specSettings.y2),
 			type: specSettings.type || preview.item.getUrlSearchValue('type') as Axes['type']
 		}
 		: { xAxis: undefined, yAxis: undefined, y2Axis: undefined, type: undefined};

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -167,7 +167,7 @@ export default class CartItem {
 		const host = new URL('/dygraph-light', document.baseURI).href;
 
 		return `${host}/?` + Object.keys(newKeyVal)
-			.map(key => `${key}=${encodeURIComponent(newKeyVal[key])}`)
+			.map(key => `${key}=${encodeURIComponent(decodeURIComponent(newKeyVal[key]))}`)
 			.join('&');
 	}
 }

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -110,7 +110,7 @@ export interface TabsState {tabName?: string, selectedTabId?: string, searchTab?
 //TODO Investigate whether the type should be Filter, and whether Value needs to have 'number' on the list of types
 export type CategFilters = {[key in CategoryType]?: string[] | null}
 
-export type TsSetting = { 'x': string } & { 'y': string } & { 'type': 'line' | 'scatter' }
+export type TsSetting = { 'x': string } & { 'y': string } & { 'y2': string } & { 'type': 'line' | 'scatter' }
 export type TsSettings = {
 	[key: string]: TsSetting
 }


### PR DESCRIPTION
Fixes two issues regarding time series preview y variable drop-down selectors not rendering properly when changing the other and breaking previews when switching from scatter to line.

Ensures strings are unencoded before encoding them for the iframe URL, fixes type declaration of `TsSetting` to reflect current usage, and explicitly synchronizes state with iframe URL.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209629143269162
  - https://app.asana.com/0/0/1209605164054306