### PR TITLE
[preview][imagezipview] Provide persistent URL for specific image previews

### DIFF
--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -16,6 +16,10 @@ export default function PreviewSelfContained({ preview, iframeSrcChange }: OurPr
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 
 	const [height, setHeight] = useState<number>(() => getInitialHeight(preview.type));
+	const src = useRef<string>((() => {
+		if (!preview.type) return "";
+		return getPreviewIframeUrl(preview.type, preview.item);
+	})());
 
 	const handleResize = useCallback(debounce(() => {
 		if (iframeRef.current) {
@@ -49,15 +53,9 @@ export default function PreviewSelfContained({ preview, iframeSrcChange }: OurPr
 		setTimeout(() => updateHeight(event.target), 300);
 	};
 
-	if (!preview?.type) {
-		return null;
-	}
-
-	const src = getPreviewIframeUrl(preview.type, preview.item);
-
 	return (
 		<div className="row" style={{ height }}>
-			<iframe ref={iframeRef} onLoad={handleLoad} src={src} loading="lazy" />
+			<iframe ref={iframeRef} onLoad={handleLoad} src={src.current} loading="lazy" />
 		</div>
 	);
 

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -16,10 +16,7 @@ export default function PreviewSelfContained({ preview, iframeSrcChange }: OurPr
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 
 	const [height, setHeight] = useState<number>(() => getInitialHeight(preview.type));
-	const src = useRef<string>((() => {
-		if (!preview.type) return "";
-		return getPreviewIframeUrl(preview.type, preview.item);
-	})());
+	const src = useRef<string>(preview.type ? getPreviewIframeUrl(preview.type, preview.item) : "");
 
 	const handleResize = useCallback(debounce(() => {
 		if (iframeRef.current) {

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.js
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.js
@@ -9,45 +9,48 @@
 
 	const fullScreen = (window.self === window.top);
 
-	if(fullScreen) {
+	if (fullScreen) {
 		document.getElementById("container").className += " m-2"
 	}
 
-	function updateDisplayedImage(step=0, imgIndex=null) {
-		if(zipEntries.length === 0) return;
+	function getCurrentURL() {
+		return `${window.location.origin}${window.location.pathname}?${urlParams.toString()}`;
+	}
 
-		// Use local idx variable to prevent auto-wrap to 0 on incrementing over bounds
-		let idx = select.selectedIndex;
-		console.log(imgIndex);
-
-		if (imgIndex !== null) {
-			select.selectedIndex = parseInt(imgIndex);
-			idx = select.selectedIndex;
-		} else {
-			idx += step;
-
-			if (idx < 0) {
-				idx = 0;
-			} else if (idx >= zipEntries.length) {
-				idx = zipEntries.length-1;
-			}
-
-			if (idx !== select.selectedIndex && !fullScreen) {
-				urlParams.set("img", idx);
-				notifySrcChanged();
-			}
-			select.selectedIndex = idx;
-
-		}
-		
+	function setInitialImage(imgIndex=0) {
+		select.selectedIndex = parseInt(imgIndex);
+		const idx = select.selectedIndex;
 		image.src = zipEntries[idx].path;
 			
 		previous.disabled = idx <= 0;
 		next.disabled = idx >= zipEntries.length - 1;
 	}
 
-	function notifySrcChanged(imageIndex) {
-		window.parent.postMessage(`${window.location.origin}${window.location.pathname}?${urlParams.toString()}`);
+	function updateDisplayedImage(step=0) {
+		if (zipEntries.length === 0) return;
+
+		// Use local idx variable to prevent auto-wrap to 0 on incrementing over bounds
+		let idx = select.selectedIndex;
+
+		idx += step;
+
+		if (idx < 0) {
+			idx = 0;
+		} else if (idx >= zipEntries.length) {
+			idx = zipEntries.length-1;
+		}
+
+		if (idx !== select.selectedIndex && !fullScreen) {
+			urlParams.set("img", idx);
+			window.parent.postMessage(getCurrentURL());
+		}
+
+		select.selectedIndex = idx;
+
+		image.src = zipEntries[idx].path;
+			
+		previous.disabled = idx <= 0;
+		next.disabled = idx >= zipEntries.length - 1;
 	}
 
 	function handleKeydown(event) {
@@ -75,7 +78,7 @@
 
 	function handleImgLoad(event) {
 		const img = event.target;
-		if(event.type === "error") {
+		if (event.type === "error") {
 			img.alt = "This image could not be loaded; it may be missing or corrupt. Check the original data source for more information.";
 		} else {
 			img.alt = "";
@@ -108,5 +111,5 @@
 				select.appendChild(option);
 			});
 		})
-		.then(() => updateDisplayedImage(0, urlParams.get("img")), err => console.error(err));
+		.then(() => setInitialImage(urlParams.get("img")), err => console.error(err));
 })();

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.js
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.js
@@ -31,7 +31,6 @@
 
 		// Use local idx variable to prevent auto-wrap to 0 on incrementing over bounds
 		let idx = select.selectedIndex;
-
 		idx += step;
 
 		if (idx < 0) {
@@ -48,7 +47,7 @@
 		select.selectedIndex = idx;
 
 		image.src = zipEntries[idx].path;
-			
+
 		previous.disabled = idx <= 0;
 		next.disabled = idx >= zipEntries.length - 1;
 	}

--- a/src/main/resources/frontendapps/imagezipview/imagezipview.js
+++ b/src/main/resources/frontendapps/imagezipview/imagezipview.js
@@ -13,25 +13,41 @@
 		document.getElementById("container").className += " m-2"
 	}
 
-	function updateDisplayedImage(step=0) {
+	function updateDisplayedImage(step=0, imgIndex=null) {
 		if(zipEntries.length === 0) return;
 
 		// Use local idx variable to prevent auto-wrap to 0 on incrementing over bounds
 		let idx = select.selectedIndex;
-		idx += step;
+		console.log(imgIndex);
 
-		if(idx < 0) {
-			idx = 0;
-		} else if (idx >= zipEntries.length) {
-			idx = zipEntries.length-1;
+		if (imgIndex !== null) {
+			select.selectedIndex = parseInt(imgIndex);
+			idx = select.selectedIndex;
+		} else {
+			idx += step;
+
+			if (idx < 0) {
+				idx = 0;
+			} else if (idx >= zipEntries.length) {
+				idx = zipEntries.length-1;
+			}
+
+			if (idx !== select.selectedIndex && !fullScreen) {
+				urlParams.set("img", idx);
+				notifySrcChanged();
+			}
+			select.selectedIndex = idx;
+
 		}
-
-		select.selectedIndex = idx;
 		
 		image.src = zipEntries[idx].path;
 			
 		previous.disabled = idx <= 0;
 		next.disabled = idx >= zipEntries.length - 1;
+	}
+
+	function notifySrcChanged(imageIndex) {
+		window.parent.postMessage(`${window.location.origin}${window.location.pathname}?${urlParams.toString()}`);
 	}
 
 	function handleKeydown(event) {
@@ -92,5 +108,5 @@
 				select.appendChild(option);
 			});
 		})
-		.then(() => updateDisplayedImage(), err => console.error(err));
+		.then(() => updateDisplayedImage(0, urlParams.get("img")), err => console.error(err));
 })();


### PR DESCRIPTION
Updates the iframe URL provided via the full-screen button and embed links when the image is changed within the imagezipview previews (multi-image zip).

Specifically, changes behavior to set the iframe src on the first render, but not update it when the persistent src changes. The iframe keeps its own state, and stays in sync with the portal by reporting the img index back whenever it changes. The portal then uses that persistent ID in providing the URL and embed iframe src link.

Without this change, the iframe would refresh every time the src is changed as the component would re-render when the preview prop changed.

This change also fixes a bug with NetCDF previews, which are experiencing that exact issue, where the iframe is refreshing every time the src is changed.