### PR TITLE
[preview] Improve URL hash synchronization

### DIFF
--- a/src/main/js/map-graph/main/store.js
+++ b/src/main/js/map-graph/main/store.js
@@ -57,7 +57,7 @@ export const updateURL = store => () => {
 			//Let calling page (through iframe) know what current url is
 			window.top.postMessage(newURL, '*');
 		} else {
-			history.pushState({urlPath: newURL}, "", newURL);
+			history.replaceState({urlPath: newURL}, "", newURL);
 		}
 	}
 };

--- a/src/main/js/netcdf/main/components/Map.tsx
+++ b/src/main/js/netcdf/main/components/Map.tsx
@@ -88,7 +88,7 @@ export default class Map extends Component<OurProps, OurState> {
 					//Let calling page (through iframe) know what current url is
 					window.top!.postMessage(newURL, '*');
 				} else {
-					history.pushState({urlPath: newURL}, "", newURL);
+					history.replaceState({urlPath: newURL}, "", newURL);
 				}
 			}
 		}

--- a/src/main/js/portal/main/actions/preview.ts
+++ b/src/main/js/portal/main/actions/preview.ts
@@ -9,7 +9,7 @@ import {getUrlsFromPids} from "../utils";
 
 export default function bootstrapPreview(user: WhoAmI, pids: Sha256Str[]): PortalThunkAction<void> {
 	return (dispatch, getState) => {
-		const {tsSettings, specTable, labelLookup, cart, itemsToAddToCart} = getState();
+		const {tsSettings, specTable, labelLookup, cart, itemsToAddToCart, previewSettings} = getState();
 
 		// specTable and labelLookup must be fetched from backend if app begins with a preview route
 		const specTablesPromise = specTable.isInitialized
@@ -31,7 +31,7 @@ export default function bootstrapPreview(user: WhoAmI, pids: Sha256Str[]): Porta
 		]);
 
 		promises.then(([knownDataObjInfos, extendedDataObjInfo, specTables, labelLookup]) => {
-				dispatch(new Payloads.BootstrapRoutePreview(pids, knownDataObjInfos.rows, extendedDataObjInfo, specTables, labelLookup));
+				dispatch(new Payloads.BootstrapRoutePreview(pids, knownDataObjInfos.rows, extendedDataObjInfo, specTables, labelLookup, previewSettings));
 				if (itemsToAddToCart) {
 					dispatch(addToCart(getUrlsFromPids(itemsToAddToCart)))
 				}
@@ -59,17 +59,5 @@ export function storeTsPreviewSetting(spec: string, type: string, val: string): 
 		saveTsSetting(user.email, spec, type, val).then(tsSettings => {
 			dispatch(new Payloads.BackendTsSettings(tsSettings));
 		});
-	};
-}
-
-export function setPreviewYAxis(y?: string): PortalThunkAction<void> {
-	return (dispatch) => {
-		dispatch(new Payloads.SetPreviewYAxis(y))
-	};
-}
-
-export function setPreviewY2Axis(y2?: string): PortalThunkAction<void> {
-	return (dispatch) => {
-		dispatch(new Payloads.SetPreviewY2Axis(y2))
 	};
 }

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -78,12 +78,12 @@ function shouldUpdateHeight(previewType?: PreviewType): boolean {
 }
 
 function settingsToQueryParams(previewSettings: PreviewSettings): string {
-	let queryParams = Object.keys(previewSettings).map((key) => `${key}=${previewSettings[key as keyof PreviewSettings]}`).join("&");
-	return queryParams;
+	const remapKey = (key: string) => `${key}=${previewSettings[key as keyof PreviewSettings]}`;
+	return Object.keys(previewSettings).map(remapKey).join("&");
 }
 
 function settingsToHash(objId: Sha256Str, previewSettings: PreviewSettings): string {
-	return encodeURIComponent(decodeURIComponent(JSON.stringify({ objId, ...previewSettings})));
+	return encodeURIComponent(decodeURIComponent(JSON.stringify({objId, ...previewSettings})));
 }
 
 function getPreviewIframeUrl(previewType: PreviewType, item: CartItem, previewSettings: PreviewSettings): UrlStr {

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -2,21 +2,24 @@ import React, {ChangeEvent, useState, useEffect, useRef, useCallback} from 'reac
 import config, {PreviewType} from '../../config';
 import {getLastSegmentInUrl} from "../../utils";
 import {State} from "../../models/State";
-import { UrlStr } from '../../backend/declarations';
+import { Sha256Str, UrlStr } from '../../backend/declarations';
 import { debounce } from 'icos-cp-utils';
 import CartItem from '../../models/CartItem';
+import { PreviewSettings } from '../../models/Preview';
 
 
 interface OurProps {
 	preview: State['preview'];
 	iframeSrcChange: (event: ChangeEvent<HTMLIFrameElement>) => void;
+	iframeUrl: UrlStr
+	previewSettings: PreviewSettings
 }
 
-export default function PreviewSelfContained({ preview, iframeSrcChange }: OurProps) {
+export default function PreviewSelfContained({ preview, iframeSrcChange, iframeUrl, previewSettings }: OurProps) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 
 	const [height, setHeight] = useState<number>(() => getInitialHeight(preview.type));
-	const src = useRef<string>(preview.type ? getPreviewIframeUrl(preview.type, preview.item) : "");
+	const src = useRef<string>(preview.type ? getPreviewIframeUrl(preview.type, preview.item, iframeUrl, previewSettings) : "");
 
 	const handleResize = useCallback(debounce(() => {
 		if (iframeRef.current) {
@@ -75,15 +78,29 @@ function shouldUpdateHeight(previewType?: PreviewType): boolean {
 	}
 }
 
-function getPreviewIframeUrl(previewType: PreviewType, item: CartItem): UrlStr {
+function settingsToQueryParams(previewSettings: PreviewSettings): string {
+	let queryParams = Object.keys(previewSettings).map((key) => `${key}=${previewSettings[key as keyof PreviewSettings]}`).join("&");
+	return queryParams;
+}
+
+function settingsToHash(objId: Sha256Str, previewSettings: PreviewSettings): string {
+	return encodeURIComponent(decodeURIComponent(JSON.stringify({ objId, ...previewSettings})));
+}
+
+function getPreviewIframeUrl(previewType: PreviewType, item: CartItem, iframeUrl: UrlStr, previewSettings: PreviewSettings): UrlStr {
 	const iFrameBaseUrl = config.iFrameBaseUrl[previewType];
 	// Use preview.item.url if present since that one has all client changes recorded in history
 	if (item.url) {
 		return iFrameBaseUrl + getLastSegmentInUrl(item.url);
 	}
 	const hashId = getLastSegmentInUrl(item.dobj);
-	if (previewType === config.PHENOCAM) {
-		return `${iFrameBaseUrl}?objId=${hashId}`;
+	switch (previewType) {
+		case config.PHENOCAM:
+			return `${iFrameBaseUrl}?objId=${hashId}${previewSettings.img ? `&img=${previewSettings.img}` : ''}`;
+		case config.MAPGRAPH:
+			return `${iFrameBaseUrl}${hashId}#${settingsToHash(hashId, previewSettings)}`;
+		case config.NETCDF:
+			return `${iFrameBaseUrl}${hashId}?${settingsToQueryParams(previewSettings)}`;
 	}
 	return iFrameBaseUrl + hashId;
 }

--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -11,15 +11,14 @@ import { PreviewSettings } from '../../models/Preview';
 interface OurProps {
 	preview: State['preview'];
 	iframeSrcChange: (event: ChangeEvent<HTMLIFrameElement>) => void;
-	iframeUrl: UrlStr
 	previewSettings: PreviewSettings
 }
 
-export default function PreviewSelfContained({ preview, iframeSrcChange, iframeUrl, previewSettings }: OurProps) {
+export default function PreviewSelfContained({ preview, iframeSrcChange, previewSettings }: OurProps) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 
 	const [height, setHeight] = useState<number>(() => getInitialHeight(preview.type));
-	const src = useRef<string>(preview.type ? getPreviewIframeUrl(preview.type, preview.item, iframeUrl, previewSettings) : "");
+	const src = useRef<string>(preview.type ? getPreviewIframeUrl(preview.type, preview.item, previewSettings) : "");
 
 	const handleResize = useCallback(debounce(() => {
 		if (iframeRef.current) {
@@ -87,7 +86,7 @@ function settingsToHash(objId: Sha256Str, previewSettings: PreviewSettings): str
 	return encodeURIComponent(decodeURIComponent(JSON.stringify({ objId, ...previewSettings})));
 }
 
-function getPreviewIframeUrl(previewType: PreviewType, item: CartItem, iframeUrl: UrlStr, previewSettings: PreviewSettings): UrlStr {
+function getPreviewIframeUrl(previewType: PreviewType, item: CartItem, previewSettings: PreviewSettings): UrlStr {
 	const iFrameBaseUrl = config.iFrameBaseUrl[previewType];
 	// Use preview.item.url if present since that one has all client changes recorded in history
 	if (item.url) {

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -145,11 +145,14 @@ export default function PreviewTimeSerie(props: OurProps) {
 		type ? `&type=${type}` : '',
 	];
 
-	const currentIframeUrl = encodeURI(window.document.location.origin
+	const currentIframeUrl = yAxis ? encodeURI(window.document.location.origin
 		+ iFrameBaseUrl
-		+ iframeParams.join(''));
+		+ iframeParams.join('')) : '';
 
 	const initialIframeUrl = useRef<string>(currentIframeUrl);
+	if (currentIframeUrl && !initialIframeUrl.current) {
+		initialIframeUrl.current = currentIframeUrl;
+	}
 
 	syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}, specSettings);
 

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -31,7 +31,6 @@ export default function PreviewTimeSerie(props: OurProps) {
 	
 	const tfCache: TableFormatCache = new TableFormatCache(commonConfig);
 	const [tableFormat, setTableFormat] = useState<TableFormat>();
-	
 
 	useEffect(() => {
 		if (preview.items.length > 0 && !tfCache.isInCache(preview.item.spec)) {
@@ -146,10 +145,12 @@ export default function PreviewTimeSerie(props: OurProps) {
 		type ? `&type=${type}` : '',
 	];
 
-	const iframeUrl = encodeURI(`${window.document.location.protocol}//`
+	const currentIframeUrl = encodeURI(`${window.document.location.protocol}//`
 		+ `${window.document.location.host}`
 		+ `${iFrameBaseUrl}`
 		+ `${iframeParams.join('')}`);
+
+	const initialIframeUrl = useRef<string>(currentIframeUrl);
 
 	syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}, specSettings);
 
@@ -179,7 +180,7 @@ export default function PreviewTimeSerie(props: OurProps) {
 				}
 				{yAxis &&
 					<PreviewControls
-						iframeUrl={iframeUrl}
+						iframeUrl={currentIframeUrl}
 						previewType={TIMESERIES}
 						csvDownloadUrl={csvDownloadUrl(preview.item, tableFormat)}
 						chartType={type}
@@ -196,7 +197,7 @@ export default function PreviewTimeSerie(props: OurProps) {
 						<div style={{ position: 'relative', padding: '20%' }}>
 							<iframe ref={iframeRef} onLoad={iframeSrcChange}
 								style={{ border: '1px solid #eee', position: 'absolute', top: 5, left: 0, width: '100%', height: '100%' }}
-								src={iframeUrl}
+								src={initialIframeUrl.current}
 							/>
 						</div>
 					</div>
@@ -227,6 +228,7 @@ type Axes = {
 	y2Axis?: string
 	type?: 'line' | 'scatter'
 }
+
 const getAxes = (options: PreviewOption[], preview: Preview, specSettings: TsSetting): Axes => {
 	const getColName = (colName: string) => {
 		const option = options.some((opt: PreviewOption) => opt.varTitle === colName);
@@ -251,6 +253,7 @@ type SelectorProps = {
 	defaultOptionLabel?: string
 	selectAction: (event: ChangeEvent<HTMLSelectElement>) => void
 }
+
 const Selector = (props: SelectorProps) => {
 	const value = props.selected ? decodeURIComponent(props.selected) : '0';
 	const defaultOptionLabel = props.defaultOptionLabel ?? "Select a parameter";

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -158,17 +158,20 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 
 		const showChartTypeControl = !previewExcludeChartType.datasets.includes(preview.item.dataset!);
 
-		const iframeParams = [`?objId=${objIds}`];
-		iframeParams.push(`&x=${xAxis}`);
-		iframeParams.push(yAxis ? `&y=${yAxis}` : '');
-		iframeParams.push(y2Axis ? `&y2=${y2Axis}` : '');
-		iframeParams.push(`&linking=${linking}`);
-		iframeParams.push(legendLabels ? `&legendLabels=${legendLabels}` : '');
-		iframeParams.push(y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '');
-		iframeParams.push(type ? `&type=${type}` : '');
+		const iframeParams = [`?objId=${objIds}`,
+			`&x=${xAxis}`,
+			yAxis ? `&y=${yAxis}` : '',
+			y2Axis ? `&y2=${y2Axis}` : '',
+			`&linking=${linking}`,
+			legendLabels ? `&legendLabels=${legendLabels}` : '',
+			y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '',
+			type ? `&type=${type}` : '',
+		];
 
-		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}`
-							+ `${iFrameBaseUrl}${iframeParams.join('')}`;
+		const iframeUrl = `${window.document.location.protocol}//`
+			+ `${window.document.location.host}`
+			+ `${iFrameBaseUrl}`
+			+ `${iframeParams.join('')}`;
 
 		this.syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}, specSettings);
 

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -16,8 +16,6 @@ interface OurProps {
 	extendedDobjInfo: State['extendedDobjInfo']
 	tsSettings: State['tsSettings']
 	storeTsPreviewSetting: (spec: string, type: string, val: string) => void
-	setPreviewYAxis: (y?: string) => void
-	setPreviewY2Axis: (y2?: string) => void
 	iframeSrcChange: (event: ChangeEvent<HTMLIFrameElement>) => void
 }
 
@@ -52,7 +50,7 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 	}
 
 	handleSelectAction(ev: ChangeEvent<HTMLSelectElement>){
-		const { preview, iframeSrcChange, storeTsPreviewSetting, setPreviewYAxis, setPreviewY2Axis } = this.props;
+		const { preview, iframeSrcChange, storeTsPreviewSetting } = this.props;
 		const {name, selectedIndex, options} = ev.target;
 
 		if ((selectedIndex > 0 || name === 'y2') && iframeSrcChange) {
@@ -71,13 +69,6 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 
 			if (selectedIndex > 0)
 				storeTsPreviewSetting(preview.item.spec, name, options[selectedIndex].value);
-
-			const value = selectedIndex > 0 ? options[selectedIndex].value : undefined;
-			if (name === 'y') {
-				setPreviewYAxis(value)
-			} else if (name === 'y2') {
-				setPreviewY2Axis(value)
-			}
 		}
 	}
 
@@ -171,7 +162,8 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 		const y2Param = y2Axis ? `&y2=${y2Axis}` : '';
 		const legendLabelsParams = legendLabels ? `&legendLabels=${legendLabels}` : '';
 		const legendLabelsY2Params = y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '';
-		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}${iFrameBaseUrl}?objId=${objIds}&x=${xAxis}${yParam}${y2Param}&type=${type}&linking=${linking}${legendLabelsParams}${legendLabelsY2Params}`;
+		const typeParam = type ? `&type=${type}` : '';
+		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}${iFrameBaseUrl}?objId=${objIds}&x=${xAxis}${yParam}${y2Param}${typeParam}&linking=${linking}${legendLabelsParams}${legendLabelsY2Params}`;
 
 		if (!preview)
 			return null;
@@ -264,7 +256,7 @@ const getAxes = (options: PreviewOption[], preview: Preview, specSettings: TsSet
 			xAxis: preview.item.getUrlSearchValue('x') || getColName(specSettings.x),
 			yAxis: preview.item.getUrlSearchValue('y') || getColName(specSettings.y),
 			y2Axis: preview.item.getUrlSearchValue('y2')  || getColName(specSettings.y2),
-			type: specSettings.type || preview.item.getUrlSearchValue('type') as Axes['type']
+			type: specSettings.type || preview.item.getUrlSearchValue('type') as Axes['type'] || "scatter"
 		}
 		: { xAxis: undefined, yAxis: undefined, y2Axis: undefined, type: undefined};
 };

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -145,10 +145,9 @@ export default function PreviewTimeSerie(props: OurProps) {
 		type ? `&type=${type}` : '',
 	];
 
-	const currentIframeUrl = encodeURI(`${window.document.location.protocol}//`
-		+ `${window.document.location.host}`
-		+ `${iFrameBaseUrl}`
-		+ `${iframeParams.join('')}`);
+	const currentIframeUrl = encodeURI(window.document.location.origin
+		+ iFrameBaseUrl
+		+ iframeParams.join(''));
 
 	const initialIframeUrl = useRef<string>(currentIframeUrl);
 

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -158,15 +158,17 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 
 		const showChartTypeControl = !previewExcludeChartType.datasets.includes(preview.item.dataset!);
 
-		const yParam = yAxis ? `&y=${yAxis}` : '';
-		const y2Param = y2Axis ? `&y2=${y2Axis}` : '';
-		const legendLabelsParams = legendLabels ? `&legendLabels=${legendLabels}` : '';
-		const legendLabelsY2Params = y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '';
-		const typeParam = type ? `&type=${type}` : '';
-		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}${iFrameBaseUrl}?objId=${objIds}&x=${xAxis}${yParam}${y2Param}${typeParam}&linking=${linking}${legendLabelsParams}${legendLabelsY2Params}`;
+		const iframeParams = [`?objId=${objIds}`];
+		iframeParams.push(`&x=${xAxis}`);
+		iframeParams.push(yAxis ? `&y=${yAxis}` : '');
+		iframeParams.push(y2Axis ? `&y2=${y2Axis}` : '');
+		iframeParams.push(`&linking=${linking}`);
+		iframeParams.push(legendLabels ? `&legendLabels=${legendLabels}` : '');
+		iframeParams.push(y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '');
+		iframeParams.push(type ? `&type=${type}` : '');
 
-		if (!preview)
-			return null;
+		const iframeUrl = `${window.document.location.protocol}//${window.document.location.host}`
+							+ `${iFrameBaseUrl}${iframeParams.join('')}`;
 
 		this.syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}, specSettings);
 

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -3,7 +3,7 @@ import {distinct, getLastSegmentInUrl, isDefined, wholeStringRegExp} from '../..
 import config, { previewExcludeChartType } from '../../config';
 import {ExtendedDobjInfo, State, TsSetting} from "../../models/State";
 import CartItem from "../../models/CartItem";
-import Preview, {PreviewOption, previewVarCompare} from "../../models/Preview";
+import Preview, {PreviewOption, PreviewSettings, previewVarCompare} from "../../models/Preview";
 import { lastUrlPart, TableFormat } from 'icos-cp-backend';
 import { UrlStr } from '../../backend/declarations';
 import TableFormatCache from '../../../../common/main/TableFormatCache';
@@ -135,21 +135,43 @@ export default function PreviewTimeSerie(props: OurProps) {
 
 	const showChartTypeControl = !previewExcludeChartType.datasets.includes(preview.item.dataset!);
 
-	const iframeParams = [`?objId=${objIds}`,
-		`&x=${xAxis}`,
-		yAxis ? `&y=${yAxis}` : '',
-		y2Axis ? `&y2=${y2Axis}` : '',
-		`&linking=${linking}`,
-		legendLabels ? `&legendLabels=${legendLabels}` : '',
-		y2Axis && legendLabels ? `&legendLabelsY2=${legendLabels}` : '',
-		type ? `&type=${type}` : '',
-	];
+	let params: PreviewSettings & { objId: string } = {
+		objId: objIds,
+		x: xAxis,
+		linking,
+		type,
+	};
 
-	const currentIframeUrl = yAxis ? encodeURI(window.document.location.origin
-		+ iFrameBaseUrl
-		+ iframeParams.join('')) : '';
+	if (yAxis) {
+		params.y = yAxis;
+	}
+
+	if (y2Axis) {
+		params.y2 = y2Axis;
+	}
+
+	if (legendLabels) {
+		params.legendLabels = legendLabels;
+	}
+
+	if (y2Axis && legendLabels) {
+		params.legendLabelsY2 = legendLabels;
+	}
+
+	const iframeParamsStr = Object.entries(params)
+		.map((param) => param.join('='))
+		.join("&");
+
+	const currentIframeUrl = yAxis ? 
+		encodeURI(
+			window.document.location.origin
+			+ iFrameBaseUrl
+			+ "?"
+			+ iframeParamsStr)
+		: '';
 
 	const initialIframeUrl = useRef<string>(currentIframeUrl);
+	
 	if (currentIframeUrl && !initialIframeUrl.current) {
 		initialIframeUrl.current = currentIframeUrl;
 	}

--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -168,10 +168,10 @@ export default class PreviewTimeSerie extends Component<OurProps, OurState> {
 			type ? `&type=${type}` : '',
 		];
 
-		const iframeUrl = `${window.document.location.protocol}//`
+		const iframeUrl = encodeURI(`${window.document.location.protocol}//`
 			+ `${window.document.location.host}`
 			+ `${iFrameBaseUrl}`
-			+ `${iframeParams.join('')}`;
+			+ `${iframeParams.join('')}`);
 
 		this.syncTsSettingStoreWithUrl({xAxis, yAxis, y2Axis, type}, specSettings);
 

--- a/src/main/js/portal/main/containers/Preview.tsx
+++ b/src/main/js/portal/main/containers/Preview.tsx
@@ -90,7 +90,7 @@ const PreviewRoute = (props: OurProps & { iframeSrcChange: (event: ChangeEvent<H
 		return <PreviewTimeSerie {...tsProps} />;
 
 	} else if (previewType === config.NETCDF || previewType === config.MAPGRAPH || previewType === config.PHENOCAM){
-		const scProps = pick(props, 'preview', 'iframeSrcChange', 'iframeUrl', 'previewSettings');
+		const scProps = pick(props, 'preview', 'iframeSrcChange', 'previewSettings');
 		return <>
 			<div className='row pb-3'>
 				<PreviewControls iframeUrl={props.iframeUrl} previewType={previewType} />

--- a/src/main/js/portal/main/containers/Preview.tsx
+++ b/src/main/js/portal/main/containers/Preview.tsx
@@ -8,7 +8,7 @@ import {Route, State} from "../models/State";
 import {UrlStr} from "../backend/declarations";
 import {PortalDispatch} from "../store";
 import { addToCart, removeFromCart, setPreviewUrl, updateRoute } from "../actions/common";
-import { storeTsPreviewSetting, setPreviewYAxis, setPreviewY2Axis } from "../actions/preview";
+import { storeTsPreviewSetting } from "../actions/preview";
 import { pick } from "../utils";
 import PreviewControls from '../components/preview/PreviewControls';
 import Message from '../components/ui/Message';
@@ -86,11 +86,11 @@ const PreviewRoute = (props: OurProps & { iframeSrcChange: (event: ChangeEvent<H
 	const previewType = props.preview.type;
 
 	if (previewType === config.TIMESERIES){
-		const tsProps = pick(props, 'preview', 'extendedDobjInfo', 'tsSettings', 'storeTsPreviewSetting', 'setPreviewYAxis', 'setPreviewY2Axis', 'iframeSrcChange');
+		const tsProps = pick(props, 'preview', 'extendedDobjInfo', 'tsSettings', 'storeTsPreviewSetting', 'iframeSrcChange',  'previewSettings');
 		return <PreviewTimeSerie {...tsProps} />;
 
 	} else if (previewType === config.NETCDF || previewType === config.MAPGRAPH || previewType === config.PHENOCAM){
-		const scProps = pick(props, 'preview', 'iframeSrcChange', 'iframeUrl');
+		const scProps = pick(props, 'preview', 'iframeSrcChange', 'iframeUrl', 'previewSettings');
 		return <>
 			<div className='row pb-3'>
 				<PreviewControls iframeUrl={props.iframeUrl} previewType={previewType} />
@@ -112,6 +112,7 @@ function stateToProps(state: State){
 		preview: state.preview,
 		extendedDobjInfo: state.extendedDobjInfo,
 		tsSettings: state.tsSettings,
+		previewSettings: state.previewSettings,
 	};
 }
 
@@ -119,8 +120,6 @@ function dispatchToProps(dispatch: PortalDispatch){
 	return {
 		setPreviewUrl: (url: UrlStr) => dispatch(setPreviewUrl(url)),
 		storeTsPreviewSetting: (spec: string, type: string, val: string) => dispatch(storeTsPreviewSetting(spec, type, val)),
-		setPreviewYAxis: (y?: string) => dispatch(setPreviewYAxis(y)),
-		setPreviewY2Axis: (y2?: string) => dispatch(setPreviewY2Axis(y2)),
 		addToCart: (ids: UrlStr[]) => dispatch(addToCart(ids)),
 		removeFromCart: (ids: UrlStr[]) => dispatch(removeFromCart(ids)),
 		updateRoute: (route: Route) => dispatch(updateRoute(route)),

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -54,24 +54,21 @@ export default class CartItem {
 		};
 	}
 
-	deconstructURL(url: string | undefined) {
+	deconstructURL(url?: string) {
 		if (url === undefined) return {};
 
-		if (url.includes("?")) {
-			const searchStr = url.split('?').pop() || '';
-			const keyValpairs = searchStr.split('&');
+		const webUrl = new URL(url);
 
-			return keyValpairs.reduce<IdxSig>((acc, curr) => {
-				const p = curr.split('=');
-				acc[p[0]] = p[1];
-				return acc;
-			}, {});
+		const searchParams = Object.fromEntries(webUrl.searchParams);
+		if (Object.keys(searchParams).length !== 0) {
+			return searchParams;
 		}
 
-		if (url.includes("#")) {
-			const hashStr = url.split("#").pop() || '';
-			return JSON.parse(decodeURIComponent(hashStr));
+		if (webUrl.hash) {
+			return JSON.parse(decodeURIComponent(webUrl.hash));
 		}
+
+		return {};
 	}
 
 	get hasKeyValPairs(){

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -57,15 +57,21 @@ export default class CartItem {
 	deconstructURL(url: string | undefined) {
 		if (url === undefined) return {};
 
-		const search = url.split('?').pop() || '';
-		const searchStr = search.replace(/^\?/, '');
-		const keyValpairs = searchStr.split('&');
+		if (url.includes("?")) {
+			const searchStr = url.split('?').pop() || '';
+			const keyValpairs = searchStr.split('&');
 
-		return keyValpairs.reduce<IdxSig>((acc, curr) => {
-			const p = curr.split('=');
-			acc[p[0]] = p[1];
-			return acc;
-		}, {});
+			return keyValpairs.reduce<IdxSig>((acc, curr) => {
+				const p = curr.split('=');
+				acc[p[0]] = p[1];
+				return acc;
+			}, {});
+		}
+
+		if (url.includes("#")) {
+			const hashStr = url.split("#").pop() || '';
+			return JSON.parse(decodeURIComponent(hashStr));
+		}
 	}
 
 	get hasKeyValPairs(){
@@ -142,6 +148,10 @@ export default class CartItem {
 
 	get submTime(){
 		return new Date(this._dataobject?.submTime ?? "");
+	}
+
+	get urlParams() {
+		return this._keyValPairs;
 	}
 
 	getUrlSearchValue(key: string) {

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -31,6 +31,7 @@ export type PreviewSettings = {
 	img?: string
 	// netcdf
 	varName?: string
+	extraDim?: string
 	date?: string
 	gamma?: string
 	center?: string
@@ -51,6 +52,7 @@ const previewSettingsKeys = [
 	'linking',
 	'img',
 	'varName',
+	'extraDim',
 	'date',
 	'gamma',
 	'center',

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -79,17 +79,17 @@ export default class Preview {
 		this.pids = this.items.map(item => getLastSegmentInUrl(item.dobj));
 		this.options = options ?? [];
 		this.type = type;
-		this.previewSettings = this.item?.urlParams ? Preview.sanitizePreviewSettings(this.item.urlParams) : {};
+		this.previewSettings = this.item?.urlParams ? Preview.allowlistPreviewSettings(this.item.urlParams) : {};
 	}
 
-	static sanitizePreviewSettings(urlParams: IdxSig): PreviewSettings {
-		const sanitizedParams: PreviewSettings = {};
+	static allowlistPreviewSettings(urlParams: IdxSig | PreviewSettings): PreviewSettings {
+		const allowedPreviewSettings: PreviewSettings = {};
 		for (const key in urlParams) {
 			if (previewSettingsKeys.includes(key)) {
-				sanitizedParams[key as keyof PreviewSettings] = urlParams[key];
+				allowedPreviewSettings[key as keyof PreviewSettings] = urlParams[key as keyof PreviewSettings];
 			}
 		}
-		return sanitizedParams;
+		return allowedPreviewSettings;
 	}
 
 	get serialize(): PreviewSerialized {

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -18,29 +18,6 @@ export function previewVarCompare(po1: PreviewOption, po2: PreviewOption): numbe
 	return po1.varTitle.localeCompare(po2.varTitle)
 }
 
-export type PreviewSettings = {
-	// dygraph-light - Time Series
-	x?: string
-	y?: string
-	y2?: string
-	type?: string
-	legendLabels?: string
-	legendLabelsY2?: string
-	linking?: string
-	// imagezipview - Phenocam/multi-image zip
-	img?: string
-	// netcdf
-	varName?: string
-	extraDim?: string
-	date?: string
-	gamma?: string
-	center?: string
-	zoom?: string
-	color?: string
-	// map-graph - uses y2 and center as well
-	y1?: string
-	map?: string
-}
 
 const previewSettingsKeys = [
 	'x',
@@ -60,7 +37,9 @@ const previewSettingsKeys = [
 	'color',
 	'y1',
 	'map'
-]
+] as readonly string[];
+
+export type PreviewSettings = Record<typeof previewSettingsKeys[number], string | undefined>;
 
 export interface PreviewSerialized {
 	items: CartItemSerialized[]
@@ -88,7 +67,7 @@ export default class Preview {
 		const allowedPreviewSettings: PreviewSettings = {};
 		for (const key in urlParams) {
 			if (previewSettingsKeys.includes(key)) {
-				allowedPreviewSettings[key as keyof PreviewSettings] = urlParams[key as keyof PreviewSettings];
+				allowedPreviewSettings[key] = urlParams[key];
 			}
 		}
 		return allowedPreviewSettings;

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -5,7 +5,7 @@ import deepEqual from 'deep-equal';
 import PreviewLookup, {PreviewInfo} from "./PreviewLookup";
 import Cart from "./Cart";
 import {ExtendedDobjInfo, ObjectsTable} from "./State";
-import {Sha256Str, UrlStr} from "../backend/declarations";
+import {IdxSig, Sha256Str, UrlStr} from "../backend/declarations";
 import { Value } from './SpecTable';
 
 
@@ -18,12 +18,53 @@ export function previewVarCompare(po1: PreviewOption, po2: PreviewOption): numbe
 	return po1.varTitle.localeCompare(po2.varTitle)
 }
 
+export type PreviewSettings = {
+	// dygraph-light - Time Series
+	x?: string
+	y?: string
+	y2?: string
+	type?: string
+	legendLabels?: string
+	legendLabelsY2?: string
+	linking?: string
+	// imagezipview - Phenocam/multi-image zip
+	img?: string
+	// netcdf
+	varName?: string
+	date?: string
+	gamma?: string
+	center?: string
+	zoom?: string
+	color?: string
+	// map-graph - uses y2 and center as well
+	y1?: string
+	map?: string
+}
+
+const previewSettingsKeys = [
+	'x',
+	'y',
+	'y2',
+	'type',
+	'legendLabels',
+	'legendLabelsY2',
+	'linking',
+	'img',
+	'varName',
+	'date',
+	'gamma',
+	'center',
+	'zoom',
+	'color',
+	'y1',
+	'map'
+]
+
 export interface PreviewSerialized {
 	items: CartItemSerialized[]
 	options: PreviewOption[]
 	type: PreviewType | undefined
-	yAxis: string | undefined
-	y2Axis: string | undefined
+	iframeParams: PreviewSettings
 }
 
 export default class Preview {
@@ -31,17 +72,24 @@ export default class Preview {
 	public pids: Sha256Str[];
 	public readonly options: PreviewOption[];
 	public readonly type: PreviewType | undefined;
-	public yAxis: string | undefined;
-	public y2Axis: string | undefined;
+	public previewSettings: PreviewSettings;
 
-
-	constructor(items?: CartItem[], options?: PreviewOption[], type?: PreviewType, yAxis?: string, y2Axis?: string){
+	constructor(items?: CartItem[], options?: PreviewOption[], type?: PreviewType){
 		this.items = items ?? [];
 		this.pids = this.items.map(item => getLastSegmentInUrl(item.dobj));
 		this.options = options ?? [];
 		this.type = type;
-		this.yAxis = yAxis;
-		this.y2Axis = y2Axis;
+		this.previewSettings = this.item?.urlParams ? Preview.sanitizeIframeParams(this.item.urlParams) : {};
+	}
+
+	static sanitizeIframeParams(iframeParams: IdxSig): PreviewSettings {
+		const sanitizedParams: PreviewSettings = {};
+		for (const key in iframeParams) {
+			if (previewSettingsKeys.includes(key)) {
+				sanitizedParams[key as keyof PreviewSettings] = iframeParams[key];
+			}
+		}
+		return sanitizedParams;
 	}
 
 	get serialize(): PreviewSerialized {
@@ -49,8 +97,7 @@ export default class Preview {
 			items: this.items.map(item => item.serialize),
 			options: this.options,
 			type: this.type,
-			yAxis: this.yAxis,
-			y2Axis: this.y2Axis
+			iframeParams: this.previewSettings,
 		};
 	}
 
@@ -58,10 +105,8 @@ export default class Preview {
 		const items: CartItem[] = jsonPreview.items.map(item => new CartItem(item.id, item.dataobject, item.type, item.url));
 		const options = jsonPreview.options;
 		const type = jsonPreview.type;
-		const yAxis = jsonPreview.yAxis;
-		const y2Axis = jsonPreview.y2Axis;
 
-		return new Preview(items, options, type, yAxis, y2Axis);
+		return new Preview(items, options, type);
 	}
 
 	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: ObjectsTable[], yAxis?: string, y2Axis?: string) {
@@ -105,12 +150,12 @@ export default class Preview {
 					let previewItems = items;
 					const xAxis = config.previewXaxisCols.find(x => options.options.some(op => op.varTitle === x));
 					if(xAxis){
-						const url = getNewTimeseriesUrl(items, xAxis, yAxis, y2Axis);
+						const url = getNewTimeseriesUrl(items, xAxis, this.previewSettings);
 						previewItems = items.map(i => i.withUrl(url));
 					}
-					return new Preview(previewItems, options.options, options.type, yAxis, y2Axis);
+					return new Preview(previewItems, options.options, options.type);
 			} else if (options.type === config.NETCDF || options.type === config.MAPGRAPH || options.type === config.PHENOCAM){
-				return new Preview(items, options.options, options.type, yAxis, y2Axis);
+				return new Preview(items, options.options, options.type);
 			}
 		} else {
 			return new Preview(ids.map(id => new CartItem(id)));
@@ -121,20 +166,20 @@ export default class Preview {
 
 	restore(lookup: PreviewLookup, cart: Cart, objectsTable: ObjectsTable[]) {
 		if (this.hasPids) {
-			return this.initPreview(lookup, cart, this.pids.map(pid => config.objectUriPrefix[config.envri] + pid), objectsTable, this.yAxis, this.y2Axis);
+			return this.initPreview(lookup, cart, this.pids.map(pid => config.objectUriPrefix[config.envri] + pid), objectsTable);
 		} else {
 			return this;
 		}
 	}
 
-
-	withPids(pids: Sha256Str[]){
+	withPids(pids: Sha256Str[], previewSettings?: PreviewSettings){
 		this.pids = pids;
+		this.previewSettings = previewSettings ?? {};
 		return this;
 	}
 
 	withItemUrl(url: UrlStr){
-		return new Preview(this.items.map(i => i.withUrl(url)), this.options, this.type, this.yAxis, this.y2Axis);
+		return new Preview(this.items.map(i => i.withUrl(url)), this.options, this.type);
 	}
 
 	get hasPids(){
@@ -207,5 +252,5 @@ export function batchPreviewAvailability(
 		if (i > 0 && preview.previewType !== config.TIMESERIES)
 			return noPreview("You can only batch-preview plain time series data objects")
 	}
-	return {previewType: previewTypes.values().next().value}
+	return {previewType: previewTypes.values().next().value!}
 }

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -64,7 +64,7 @@ export interface PreviewSerialized {
 	items: CartItemSerialized[]
 	options: PreviewOption[]
 	type: PreviewType | undefined
-	iframeParams: PreviewSettings
+	previewSettings: PreviewSettings
 }
 
 export default class Preview {
@@ -79,14 +79,14 @@ export default class Preview {
 		this.pids = this.items.map(item => getLastSegmentInUrl(item.dobj));
 		this.options = options ?? [];
 		this.type = type;
-		this.previewSettings = this.item?.urlParams ? Preview.sanitizeIframeParams(this.item.urlParams) : {};
+		this.previewSettings = this.item?.urlParams ? Preview.sanitizePreviewSettings(this.item.urlParams) : {};
 	}
 
-	static sanitizeIframeParams(iframeParams: IdxSig): PreviewSettings {
+	static sanitizePreviewSettings(urlParams: IdxSig): PreviewSettings {
 		const sanitizedParams: PreviewSettings = {};
-		for (const key in iframeParams) {
+		for (const key in urlParams) {
 			if (previewSettingsKeys.includes(key)) {
-				sanitizedParams[key as keyof PreviewSettings] = iframeParams[key];
+				sanitizedParams[key as keyof PreviewSettings] = urlParams[key];
 			}
 		}
 		return sanitizedParams;
@@ -97,7 +97,7 @@ export default class Preview {
 			items: this.items.map(item => item.serialize),
 			options: this.options,
 			type: this.type,
-			iframeParams: this.previewSettings,
+			previewSettings: this.previewSettings,
 		};
 	}
 

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -314,7 +314,7 @@ const getStateFromHash = () => {
 //No # in the beginning!
 const parseHash = (hash: string) => {
 	try {
-		return sanitizeJsonHash(JSON.parse(hash));
+		return allowlistJsonHash(JSON.parse(hash));
 	} catch(err) {
 		return {};
 	}
@@ -362,9 +362,9 @@ type JsonHashState = {
 	itemsToAddToCart?: Sha256Str[]
 }
 
-const sanitizeJsonHash = (hash: any): JsonHashState => {
-	const sanitizedHash : JsonHashState = {};
-	const ps: PreviewSettings = {}
+const allowlistJsonHash = (hash: any): JsonHashState => {
+	const allowedHash: JsonHashState = {};
+	const ps: PreviewSettings = {};
 
 	for (const key in hash) {
 		if (key === "yAxis") {
@@ -372,14 +372,14 @@ const sanitizeJsonHash = (hash: any): JsonHashState => {
 		} else if (key === "y2Axis") {
 			ps.y2 = hash[key];
 		} else if (hashKeys.includes(key)) {
-			sanitizedHash[key as keyof JsonHashState] = hash[key];
+			allowedHash[key as keyof JsonHashState] = hash[key];
 		}
 	}
-	sanitizedHash.previewSettings = (sanitizedHash.previewSettings ?
-		{ ...sanitizedHash.previewSettings, ...ps } :
-		ps)
+	allowedHash.previewSettings = (allowedHash.previewSettings ?
+		{ ...Preview.allowlistPreviewSettings(allowedHash.previewSettings), ...ps } :
+		ps);
 
-	return sanitizedHash;
+	return allowedHash;
 }
 
 const jsonToState = (state0: JsonHashState) => {

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -422,6 +422,7 @@ const specialCases = (state: Partial<StateSerialized>) => {
 		};
 	} else {
 		delete state.preview;
+		delete state.previewSettings;
 	}
 
 	if (state.route === 'cart'){

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -447,7 +447,7 @@ const hashUpdater = (store: Store) => () => {
 	const oldHash = getCurrentHash();
 
 	if (newHash !== oldHash) {
-		newHash = newHash === '' ? '' : "#" + newHash;
+		newHash = newHash === '' ? '' : "#" + encodeURIComponent(newHash);
 		portalHistoryState.replaceState(serialize(state), window.location.href.split('#')[0] + newHash).then(
 			_ => _,
 			reason => console.log(`Failed to add value to indexed database because ${reason}`)

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -445,13 +445,21 @@ const hashUpdater = (store: Store) => () => {
 	const state: State = store.getState();
 	let newHash = stateToHash(state);
 	const oldHash = getCurrentHash();
+	
 
 	if (newHash !== oldHash) {
 		newHash = newHash === '' ? '' : "#" + encodeURIComponent(newHash);
-		portalHistoryState.replaceState(serialize(state), window.location.href.split('#')[0] + newHash).then(
-			_ => _,
-			reason => console.log(`Failed to add value to indexed database because ${reason}`)
-		);
+		if (state.route !== hashToState().route) {
+			portalHistoryState.pushState(serialize(state), window.location.href.split('#')[0] + newHash).then(
+				_ => _,
+				reason => console.log(`Failed to add value to indexed database because ${reason}`)
+			);
+		} else {
+			portalHistoryState.replaceState(serialize(state), window.location.href.split('#')[0] + newHash).then(
+				_ => _,
+				reason => console.log(`Failed to add value to indexed database because ${reason}`)
+			);
+		}
 	}
 };
 

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -1,4 +1,4 @@
-import Preview from "./Preview";
+import Preview, { PreviewSettings } from "./Preview";
 import FilterTemporal, {SerializedFilterTemporal} from "./FilterTemporal";
 import CompositeSpecTable, {BasicsColNames, VariableMetaColNames, OriginsColNames} from "./CompositeSpecTable";
 import PreviewLookup from "./PreviewLookup";
@@ -39,12 +39,13 @@ const hashKeys = [
 	'filterKeywords',
 	'tabs',
 	'page',
-	'id',
 	'preview',
-	'searchOptions',
-	'mapProps',
+	'previewSettings',
+	'id',
 	'yAxis',
 	'y2Axis',
+	'searchOptions',
+	'mapProps',
 	'itemsToAddToCart'
 ];
 
@@ -161,8 +162,7 @@ export interface State {
 	metadata?: MetaData | MetaDataWStats
 	station: {} | undefined
 	preview: Preview
-	yAxis: string | undefined
-	y2Axis: string | undefined
+	previewSettings: PreviewSettings
 	itemsToAddToCart: Sha256Str[] | undefined
 	toasterData: {} | undefined
 	batchDownloadStatus: {
@@ -225,8 +225,7 @@ export const defaultState: State = {
 	metadata: undefined,
 	station: undefined,
 	preview: new Preview(),
-	yAxis: undefined,
-	y2Axis: undefined,
+	previewSettings: {},
 	itemsToAddToCart: undefined,
 	toasterData: undefined,
 	batchDownloadStatus: {
@@ -287,6 +286,7 @@ const deserialize = (jsonObj: StateSerialized, cart: Cart) => {
 		? new PreviewLookup(table, varInfo)
 		: PreviewLookup.init(specTable, jsonObj.labelLookup);
 	const baseDobjStats = SpecTable.deserialize(jsonObj.baseDobjStats)
+	const preview = Preview.deserialize(jsonObj.preview)
 
 	const props: State = {...jsonObj,
 		filterTemporal: FilterTemporal.deserialize(jsonObj.filterTemporal as SerializedFilterTemporal),
@@ -296,7 +296,8 @@ const deserialize = (jsonObj: StateSerialized, cart: Cart) => {
 		baseDobjStats,
 		paging: Paging.deserialize(jsonObj.paging),
 		cart,
-		preview: Preview.deserialize(jsonObj.preview),
+		preview: preview,
+		previewSettings: preview.previewSettings,
 		helpStorage: HelpStorage.deserialize(jsonObj.helpStorage),
 		exportQuery: {isFetchingCVS: false, sparqClientQuery: jsonObj.exportQuery.sparqClientQuery}
 	};
@@ -313,7 +314,7 @@ const getStateFromHash = () => {
 //No # in the beginning!
 const parseHash = (hash: string) => {
 	try {
-		return JSON.parse(hash);
+		return sanitizeJsonHash(JSON.parse(hash));
 	} catch(err) {
 		return {};
 	}
@@ -346,14 +347,41 @@ type JsonHashState = {
 	route?: Route
 	filterCategories?: CategFilters
 	filterTemporal?: SerializedFilterTemporal
+	filterPids?: Sha256Str
 	filterNumbers?: FilterNumberSerialized[]
+	filterKeywords?: string[]
 	tabs?: State['tabs']
 	page?: number
 	preview?: Sha256Str[]
+	previewSettings?: PreviewSettings
 	id?: UrlStr
 	yAxis?: string
 	y2Axis?: string
+	searchOptions?: SearchOptions
+	mapProps?: MapProps
+	itemsToAddToCart?: Sha256Str[]
 }
+
+const sanitizeJsonHash = (hash: any): JsonHashState => {
+	const sanitizedHash : JsonHashState = {};
+	const ps: PreviewSettings = {}
+
+	for (const key in hash) {
+		if (key === "yAxis") {
+			ps.y = hash[key];
+		} else if (key === "y2Axis") {
+			ps.y2 = hash[key];
+		} else if (hashKeys.includes(key)) {
+			sanitizedHash[key as keyof JsonHashState] = hash[key];
+		}
+	}
+	sanitizedHash.previewSettings = (sanitizedHash.previewSettings ?
+		{ ...sanitizedHash.previewSettings, ...ps } :
+		ps)
+
+	return sanitizedHash;
+}
+
 const jsonToState = (state0: JsonHashState) => {
 	const state = {...defaultState, ...state0};
 
@@ -364,9 +392,9 @@ const jsonToState = (state0: JsonHashState) => {
 		if (state0.filterNumbers){
 			state.filterNumbers = defaultState.filterNumbers.restore(state0.filterNumbers);
 		}
-		state.preview = new Preview().withPids(state0.preview ?? []);
-		state.preview.yAxis = state0.yAxis
-		state.preview.y2Axis = state0.y2Axis
+
+		state.preview = new Preview().withPids(state0.preview ?? [], state0.previewSettings ?? {});
+
 		if (state0.id){
 			state.id = config.objectUriPrefix[config.envri] + state0.id;
 		}
@@ -389,8 +417,7 @@ const specialCases = (state: Partial<StateSerialized>) => {
 		return {
 			route: state.route,
 			preview: state.preview,
-			yAxis: state.yAxis,
-			y2Axis: state.y2Axis,
+			previewSettings: state.previewSettings,
 			itemsToAddToCart: state.itemsToAddToCart
 		};
 	} else {
@@ -416,18 +443,15 @@ function getCurrentHash(){
 
 const hashUpdater = (store: Store) => () => {
 	const state: State = store.getState();
-	const newHash = stateToHash(state);
+	let newHash = stateToHash(state);
 	const oldHash = getCurrentHash();
 
 	if (newHash !== oldHash) {
-		if (newHash === '') {
-			portalHistoryState.pushState(serialize(state), window.location.href.split('#')[0]).then(
-				_ => _,
-				reason => console.log(`Failed to add value to indexed database because ${reason}`)
-			);
-		} else {
-			window.location.hash = encodeURIComponent(newHash);
-		}
+		newHash = newHash === '' ? '' : "#" + newHash;
+		portalHistoryState.replaceState(serialize(state), window.location.href.split('#')[0] + newHash).then(
+			_ => _,
+			reason => console.log(`Failed to add value to indexed database because ${reason}`)
+		);
 	}
 };
 

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -15,6 +15,7 @@ import FilterTemporal from "../models/FilterTemporal";
 import {SearchOption} from "../actions/types";
 import {FilterNumber} from "../models/FilterNumbers";
 import {PersistedMapPropsExtended} from "../models/InitMap";
+import { PreviewSettings } from "../models/Preview";
 
 
 export abstract class ActionPayload{}
@@ -40,7 +41,8 @@ export class BootstrapRoutePreview extends BootstrapRoutePayload{
 		readonly objectsTable: ObjectsTableLike,
 		readonly extendedDobjInfo: AsyncResult<typeof getExtendedDataObjInfo>,
 		readonly specTables?: SpecTableSerialized,
-		readonly labelLookup?: LabelLookup
+		readonly labelLookup?: LabelLookup,
+		readonly previewSettings?: PreviewSettings,
 	){super();}
 }
 
@@ -146,14 +148,6 @@ export class SetPreviewFromCart extends PreviewPayload{
 
 export class SetPreviewUrl extends PreviewPayload{
 	constructor(readonly url: UrlStr){super();}
-}
-
-export class SetPreviewYAxis extends PreviewPayload {
-	constructor(readonly yAxis?: string) { super(); }
-}
-
-export class SetPreviewY2Axis extends PreviewPayload {
-	constructor(readonly y2Axis?: string) { super(); }
 }
 
 export class UiToggleSorting extends UiPayload{

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -58,7 +58,7 @@ const handleRoutePreview = (state: State, payload: BootstrapRoutePreview): State
 	}))
 
 	const preview = state.preview
-			.withPids(payload.pids)
+			.withPids(payload.pids, payload.previewSettings)
 			.restore(previewLookup, cart, objectsTable);
 
 	const newPartialState: BootstrapState = {

--- a/src/main/js/portal/main/reducers/previewReducer.ts
+++ b/src/main/js/portal/main/reducers/previewReducer.ts
@@ -3,9 +3,7 @@ import {
 	PreviewPayload,
 	RestorePreview,
 	SetPreviewFromCart,
-	SetPreviewUrl,
-	SetPreviewYAxis,
-	SetPreviewY2Axis
+	SetPreviewUrl
 } from "./actionpayloads";
 import Preview from "../models/Preview";
 
@@ -23,20 +21,11 @@ export default function(state: State, payload: PreviewPayload): State{
 	if (payload instanceof SetPreviewUrl){
 		// Save exact state of Preview in history when it's URL changes.
 		// This will recreate all changes in the preview when navigating back to it.
+		const preview = state.preview.withItemUrl(payload.url);
+
 		return stateUtils.updateAndSave(state,{
-			preview: state.preview.withItemUrl(payload.url)
-		});
-	}
-
-	if (payload instanceof SetPreviewYAxis) {
-		return stateUtils.update(state, {
-			yAxis: payload.yAxis,
-		});
-	}
-
-	if (payload instanceof SetPreviewY2Axis) {
-		return stateUtils.update(state, {
-			y2Axis: payload.y2Axis,
+			preview: preview,
+			previewSettings: preview.previewSettings,
 		});
 	}
 
@@ -52,7 +41,7 @@ const handleRestorePreview = (state: State) => {
 const handleSetPreviewFromCart = (state: State, payload: SetPreviewFromCart): Partial<State> => {
 	const preview = state.previewLookup === undefined
 		? new Preview()
-		: state.preview.initPreview(state.previewLookup, state.cart, payload.ids, state.objectsTable, state.yAxis, state.y2Axis);
+		: state.preview.initPreview(state.previewLookup, state.cart, payload.ids, state.objectsTable);
 
 	return {
 		route: 'preview',

--- a/src/main/js/portal/main/utils.ts
+++ b/src/main/js/portal/main/utils.ts
@@ -5,15 +5,14 @@ import {CSSProperties} from "react";
 import CartItem from "./models/CartItem";
 import {DrawRectBbox, ExtendedDobjInfo} from "./models/State";
 import {Coordinate} from "ol/coordinate";
+import { PreviewSettings } from "./models/Preview";
 
-export const getNewTimeseriesUrl = (items: CartItem[], xAxis: string, yAxis?: string, y2Axis?: string) => {
+export const getNewTimeseriesUrl = (items: CartItem[], xAxis: string, iframeParams: PreviewSettings) => {
 	const objIds = items.map((item: CartItem) => getLastSegmentInUrl(item.dobj)).join();
 	return items[0].getNewUrl({
 		objId: objIds,
 		x: xAxis,
-		...(yAxis && {y: yAxis}),
-		...(y2Axis && {y2: y2Axis}),
-		type: 'scatter'
+		...iframeParams
 	});
 };
 

--- a/src/main/js/portal/main/utils.ts
+++ b/src/main/js/portal/main/utils.ts
@@ -7,12 +7,12 @@ import {DrawRectBbox, ExtendedDobjInfo} from "./models/State";
 import {Coordinate} from "ol/coordinate";
 import { PreviewSettings } from "./models/Preview";
 
-export const getNewTimeseriesUrl = (items: CartItem[], xAxis: string, iframeParams: PreviewSettings) => {
+export const getNewTimeseriesUrl = (items: CartItem[], xAxis: string, previewSettings: PreviewSettings) => {
 	const objIds = items.map((item: CartItem) => getLastSegmentInUrl(item.dobj)).join();
 	return items[0].getNewUrl({
 		objId: objIds,
 		x: xAxis,
-		...iframeParams
+		...previewSettings
 	});
 };
 

--- a/src/main/js/portal/tsconfig.json
+++ b/src/main/js/portal/tsconfig.json
@@ -7,7 +7,7 @@
     "noImplicitAny": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "lib": [ "ESNext", "DOM" ],
+    "lib": [ "ESNext", "DOM", "DOM.Iterable" ],
     "target": "ESNext",
     "allowJs": true,
     "jsx": "react",


### PR DESCRIPTION
When a preview iframe changes, we ensure that the URL hash is updated so that the URL for the preview page will generate the exact iframe shown to the user. This way, users can share URLs with each other (or bookmark a page and return to it) and ensure they will see the same preview.*

Adds explicit parameter checking when interacting with search or hash parameters and fixes type declarations to match usage. Reduces history pollution by using `replaceState` instead of `pushState` unless explicitly needed/wanted.

*There are a handful of cases where there isn't true. Two cases are: 1) parameters included in iframe URL but not respected on load (e.g. NetCDF previews don't respect the `color` parameter); 2) interactive options that are not included in iframe URL right now, but theoretically could be (e.g. changes to the "range" options in NetCDF previews, or zooming in or out on a time series Dygraph); in this case, we would need to decide which ones should be included.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209593710989303