### PR TITLE
[preview] Fix TimeSeries y2 select default option

### DIFF
--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -55,8 +55,9 @@ export default function PreviewTimeSerie(props: OurProps) {
 				iframeRef.current.contentWindow.postMessage(newUrl, "*");
 			}
 
-			if (selectedIndex > 0)
+			if (selectedIndex > 0 && name !== 'y2') {
 				storeTsPreviewSetting(preview.item.spec, name, options[selectedIndex].value);
+			}
 		}
 	}
 
@@ -81,14 +82,12 @@ export default function PreviewTimeSerie(props: OurProps) {
 	}
 
 	const syncTsSettingStoreWithUrl = (axes: Axes, specSettings: TsSetting) => {
-		const {xAxis, yAxis, y2Axis, type} = axes;
+		const {xAxis, yAxis, type} = axes;
 
 		if (yAxis && specSettings.y != yAxis)
 			storeTsPreviewSetting(preview.item.spec, 'y', yAxis);
 		if (xAxis && specSettings.x != xAxis)
 			storeTsPreviewSetting(preview.item.spec, 'x', xAxis);
-		if (y2Axis && specSettings.y2 != y2Axis)
-			storeTsPreviewSetting(preview.item.spec, 'y2', y2Axis);
 		if (type && specSettings.type != type)
 			storeTsPreviewSetting(preview.item.spec, 'type', type);
 	}
@@ -263,7 +262,7 @@ const getAxes = (options: PreviewOption[], preview: Preview, specSettings: TsSet
 		? {
 			xAxis: preview.item.getUrlSearchValue('x') || getColName(specSettings.x),
 			yAxis: preview.item.getUrlSearchValue('y') || getColName(specSettings.y),
-			y2Axis: preview.item.getUrlSearchValue('y2')  || getColName(specSettings.y2),
+			y2Axis: preview.item.getUrlSearchValue('y2') ?? undefined,
 			type: specSettings.type || preview.item.getUrlSearchValue('type') as Axes['type'] || "scatter"
 		}
 		: { xAxis: undefined, yAxis: undefined, y2Axis: undefined, type: undefined};


### PR DESCRIPTION
When selecting the parameter for y2 in time series previews and then de-selecting it, the select menu and full-screen URL were not updating properly. This is because we were storing the y2 setting in the specSettings and then using it if the y2 parameter was unset. The intention of this is to restore previously used selections when returning to a specific time series spec preview, but because there is currently no way to remove the y2 option when it is reset, this was not functioning properly and was overriding the selection.

This change removes the y2 parameter from storage and defaults to undefined if there is no value selected, which fixes the bug.