### PR TITLE
[portal] Remove previewSettings from state when leaving preview page

### DIFF
--- a/src/main/js/portal/main/actions/preview.ts
+++ b/src/main/js/portal/main/actions/preview.ts
@@ -9,7 +9,7 @@ import {getUrlsFromPids} from "../utils";
 
 export default function bootstrapPreview(user: WhoAmI, pids: Sha256Str[]): PortalThunkAction<void> {
 	return (dispatch, getState) => {
-		const {tsSettings, specTable, labelLookup, cart, itemsToAddToCart, previewSettings} = getState();
+		const {tsSettings, specTable, labelLookup, cart, itemsToAddToCart} = getState();
 
 		// specTable and labelLookup must be fetched from backend if app begins with a preview route
 		const specTablesPromise = specTable.isInitialized
@@ -31,7 +31,7 @@ export default function bootstrapPreview(user: WhoAmI, pids: Sha256Str[]): Porta
 		]);
 
 		promises.then(([knownDataObjInfos, extendedDataObjInfo, specTables, labelLookup]) => {
-				dispatch(new Payloads.BootstrapRoutePreview(pids, knownDataObjInfos.rows, extendedDataObjInfo, specTables, labelLookup, previewSettings));
+				dispatch(new Payloads.BootstrapRoutePreview(pids, knownDataObjInfos.rows, extendedDataObjInfo, specTables, labelLookup));
 				if (itemsToAddToCart) {
 					dispatch(addToCart(getUrlsFromPids(itemsToAddToCart)))
 				}

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -450,11 +450,7 @@ const hashUpdater = (store: Store) => () => {
 
 	if (newHash !== oldHash) {
 		newHash = newHash === '' ? '' : "#" + encodeURIComponent(newHash);
-		const prevRoute = hashToState().route;
-		if (state.route !== prevRoute) {
-			if (prevRoute === "preview") {
-				state.previewSettings = {};
-			}
+		if (state.route !== hashToState().route) {
 			portalHistoryState.pushState(serialize(state), window.location.href.split('#')[0] + newHash).then(
 				_ => _,
 				reason => console.log(`Failed to add value to indexed database because ${reason}`)

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -450,7 +450,11 @@ const hashUpdater = (store: Store) => () => {
 
 	if (newHash !== oldHash) {
 		newHash = newHash === '' ? '' : "#" + encodeURIComponent(newHash);
-		if (state.route !== hashToState().route) {
+		const prevRoute = hashToState().route;
+		if (state.route !== prevRoute) {
+			if (prevRoute === "preview") {
+				state.previewSettings = {};
+			}
 			portalHistoryState.pushState(serialize(state), window.location.href.split('#')[0] + newHash).then(
 				_ => _,
 				reason => console.log(`Failed to add value to indexed database because ${reason}`)

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -42,7 +42,6 @@ export class BootstrapRoutePreview extends BootstrapRoutePayload{
 		readonly extendedDobjInfo: AsyncResult<typeof getExtendedDataObjInfo>,
 		readonly specTables?: SpecTableSerialized,
 		readonly labelLookup?: LabelLookup,
-		readonly previewSettings?: PreviewSettings,
 	){super();}
 }
 

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -57,7 +57,7 @@ const handleRoutePreview = (state: State, payload: BootstrapRoutePreview): State
 		return new CartItem(id, objInfo);
 	}))
 
-	const previewSettings = state.route !== "preview" ? {} : payload.previewSettings;
+	const previewSettings = state.route !== "preview" ? {} : state.previewSettings;
 	const preview = state.preview
 			.withPids(payload.pids, previewSettings)
 			.restore(previewLookup, cart, objectsTable);

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -57,8 +57,9 @@ const handleRoutePreview = (state: State, payload: BootstrapRoutePreview): State
 		return new CartItem(id, objInfo);
 	}))
 
+	const previewSettings = state.route !== "preview" ? {} : payload.previewSettings;
 	const preview = state.preview
-			.withPids(payload.pids, payload.previewSettings)
+			.withPids(payload.pids, previewSettings)
 			.restore(previewLookup, cart, objectsTable);
 
 	const newPartialState: BootstrapState = {
@@ -69,6 +70,7 @@ const handleRoutePreview = (state: State, payload: BootstrapRoutePreview): State
 		extendedDobjInfo: payload.extendedDobjInfo,
 		preview,
 		previewLookup,
+		previewSettings,
 		cart,
 		isRunningInit: false
 	};

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -57,7 +57,7 @@ const handleRoutePreview = (state: State, payload: BootstrapRoutePreview): State
 		return new CartItem(id, objInfo);
 	}))
 
-	const previewSettings = state.route !== "preview" ? {} : state.previewSettings;
+	const previewSettings = state.route === "preview" ? state.previewSettings : {};
 	const preview = state.preview
 			.withPids(payload.pids, previewSettings)
 			.restore(previewLookup, cart, objectsTable);


### PR DESCRIPTION
Ensure previewSettings are reset when leaving a preview page.

When navigating within the data portal, if you go to a preview and make changes, then go back to search, then preview a different kind of data object, those settings persist. This can lead to unexpected consequences (e.g. a time series trying to show a variable that does not exist for that data format).

This change removes previewSettings when navigating away from a "preview" route page, ensuring it is always fresh when generating a new preview from the search results page. Previously used settings persist in the browser history, so a user could use the back arrows to go back to an older preview (with settings) if they were trying to restore those and accidentally navigated away.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210047442144301