### PR TITLE
[portal] Rename Data Cart .zip file

### DIFF
--- a/src/main/js/portal/main/actions/cart.ts
+++ b/src/main/js/portal/main/actions/cart.ts
@@ -52,9 +52,15 @@ export function setCartName(newName: string): PortalThunkAction<void> {
 }
 
 function updateCart(email: string | null, cart: Cart): PortalThunkAction<Promise<any>> {
-	return dispatch => saveCart(email, cart).then(() =>
+	return dispatch => saveCart(email, cart).then(() => {
 		dispatch(new Payloads.BackendUpdateCart(cart))
-	);
+});
+}
+
+function updateLastCart(cart: Cart): PortalThunkAction<void> {
+	return dispatch => {
+		dispatch(new Payloads.BackendUpdateLastCart(cart))
+	};
 }
 
 export function logCartDownloadClick(fileName: string, pids: string[]) {
@@ -78,4 +84,19 @@ export function updateCheckedObjectsInCart(checkedObjectInCart: UrlStr | UrlStr[
 	return (dispatch) => {
 		dispatch(new Payloads.UiUpdateCheckedObjsInCart(checkedObjectInCart));
 	};
+}
+
+export function emptyCart(): PortalThunkAction<void> {
+	return (dispatch, getState) => {
+		const state = getState();
+		dispatch(updateLastCart(state.cart));
+		dispatch(updateCart(state.user.email, new Cart()));
+	}
+}
+
+export function restoreLastCart(): PortalThunkAction<void> {
+	return (dispatch, getState) => {
+		const state = getState();
+		dispatch(updateCart(state.user.email, state.lastCart ?? state.cart));
+	}
 }

--- a/src/main/js/portal/main/actions/cart.ts
+++ b/src/main/js/portal/main/actions/cart.ts
@@ -52,9 +52,9 @@ export function setCartName(newName: string): PortalThunkAction<void> {
 }
 
 function updateCart(email: string | null, cart: Cart): PortalThunkAction<Promise<any>> {
-	return dispatch => saveCart(email, cart).then(() => {
+	return dispatch => saveCart(email, cart).then(() =>
 		dispatch(new Payloads.BackendUpdateCart(cart))
-});
+	);
 }
 
 function updateLastCart(cart: Cart): PortalThunkAction<void> {

--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -1,6 +1,6 @@
 import stateUtils, {
 	MapProps,
-	ObjectsTable,
+	DataObject,
 	Profile,
 	Route,
 	State,
@@ -25,7 +25,7 @@ import {isInPidFilteringMode} from "../reducers/utils";
 import {saveToRestheart} from "../../../common/main/backend";
 import CartItem from "../models/CartItem";
 import {bootstrapRoute, init, loadApp} from "./main";
-import { DataObject } from "../../../common/main/metacore";
+import {DataObject as DO} from "../../../common/main/metacore";
 import {Filter, Value} from "../models/SpecTable";
 import keywordsInfo from "../backend/keywordsInfo";
 import {SPECCOL} from "../sparqlQueries";
@@ -214,7 +214,7 @@ export function addToCart(ids: UrlStr[]): PortalThunkAction<void> {
 
 		if (user.email) {
 			const newItems = ids.filter(id => !cart.hasItem(id)).map(id => {
-				const objInfo: ObjectsTable | undefined = objectsTable.find(o => o.dobj === id);
+				const objInfo: DataObject | undefined = objectsTable.find(o => o.dobj === id);
 
 				if (objInfo === undefined)
 					throw new Error(`Could not find objTable with id=${id} in ${objectsTable}`);
@@ -248,7 +248,7 @@ export function setMetadataItem(id: UrlStr): PortalThunkAction<void> {
 
 function fetchMetadataItem(id: UrlStr): PortalThunkAction<void> {
 	return (dispatch) => {
-		fetchJson<DataObject>(`${id}?format=json`).then(metadata => {
+		fetchJson<DO>(`${id}?format=json`).then(metadata => {
 			const metadataWithId = { ...metadata, id };
 			dispatch(new Payloads.BackendObjectMetadata(metadataWithId));
 		});
@@ -280,7 +280,7 @@ export function loadFromError(user: WhoAmI, errorId: string): PortalThunkAction<
 		getError(errorId).then(response => {
 			if (response && response.error && response.error.state) {
 				const stateJSON = JSON.parse(response.error.state);
-				const objectsTable = stateJSON.objectsTable.map((ot: ObjectsTable) => {
+				const objectsTable = stateJSON.objectsTable.map((ot: DataObject) => {
 					return Object.assign(ot, {
 						submTime: new Date(ot.submTime),
 						timeStart: new Date(ot.timeStart),

--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -1,6 +1,6 @@
 import stateUtils, {
 	MapProps,
-	DataObject,
+	KnownDataObject,
 	Profile,
 	Route,
 	State,
@@ -25,7 +25,7 @@ import {isInPidFilteringMode} from "../reducers/utils";
 import {saveToRestheart} from "../../../common/main/backend";
 import CartItem from "../models/CartItem";
 import {bootstrapRoute, init, loadApp} from "./main";
-import {DataObject as DO} from "../../../common/main/metacore";
+import { DataObject } from "../../../common/main/metacore";
 import {Filter, Value} from "../models/SpecTable";
 import keywordsInfo from "../backend/keywordsInfo";
 import {SPECCOL} from "../sparqlQueries";
@@ -214,7 +214,7 @@ export function addToCart(ids: UrlStr[]): PortalThunkAction<void> {
 
 		if (user.email) {
 			const newItems = ids.filter(id => !cart.hasItem(id)).map(id => {
-				const objInfo: DataObject | undefined = objectsTable.find(o => o.dobj === id);
+				const objInfo: KnownDataObject | undefined = objectsTable.find(o => o.dobj === id);
 
 				if (objInfo === undefined)
 					throw new Error(`Could not find objTable with id=${id} in ${objectsTable}`);
@@ -248,7 +248,7 @@ export function setMetadataItem(id: UrlStr): PortalThunkAction<void> {
 
 function fetchMetadataItem(id: UrlStr): PortalThunkAction<void> {
 	return (dispatch) => {
-		fetchJson<DO>(`${id}?format=json`).then(metadata => {
+		fetchJson<DataObject>(`${id}?format=json`).then(metadata => {
 			const metadataWithId = { ...metadata, id };
 			dispatch(new Payloads.BackendObjectMetadata(metadataWithId));
 		});
@@ -280,7 +280,7 @@ export function loadFromError(user: WhoAmI, errorId: string): PortalThunkAction<
 		getError(errorId).then(response => {
 			if (response && response.error && response.error.state) {
 				const stateJSON = JSON.parse(response.error.state);
-				const objectsTable = stateJSON.objectsTable.map((ot: DataObject) => {
+				const objectsTable = stateJSON.objectsTable.map((ot: KnownDataObject) => {
 					return Object.assign(ot, {
 						submTime: new Date(ot.submTime),
 						timeStart: new Date(ot.timeStart),

--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -280,11 +280,11 @@ export function loadFromError(user: WhoAmI, errorId: string): PortalThunkAction<
 		getError(errorId).then(response => {
 			if (response && response.error && response.error.state) {
 				const stateJSON = JSON.parse(response.error.state);
-				const objectsTable = stateJSON.objectsTable.map((ot: KnownDataObject) => {
-					return Object.assign(ot, {
-						submTime: new Date(ot.submTime),
-						timeStart: new Date(ot.timeStart),
-						timeEnd: new Date(ot.timeEnd)
+				const objectsTable = stateJSON.objectsTable.map((dobj: KnownDataObject) => {
+					return Object.assign(dobj, {
+						submTime: new Date(dobj.submTime),
+						timeStart: new Date(dobj.timeStart),
+						timeEnd: new Date(dobj.timeEnd)
 					});
 				});
 				const cart = restoreCart({cart: stateJSON.cart});

--- a/src/main/js/portal/main/components/CartPanel.tsx
+++ b/src/main/js/portal/main/components/CartPanel.tsx
@@ -87,18 +87,18 @@ export default class CartPanel extends Component<Props, State> {
 					</div>
 
 					{
-						props.cart.items.map((objInfo, i) => {
-							const extendedInfo = props.extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
+						props.cart.items.map((cartItem, i) => {
+							const extendedInfo = props.extendedDobjInfo.find(ext => ext.dobj === cartItem.dobj);
 							if (extendedInfo === undefined) return null;
 
-							const isChecked = props.checkedObjectsInCart.includes(objInfo.dobj);
+							const isChecked = props.checkedObjectsInCart.includes(cartItem.dobj);
 
 							return (
 								<SearchResultRegularRow
 									labelLookup={props.labelLookup}
 									extendedInfo={extendedInfo}
 									preview={props.preview}
-									objInfo={objInfo}
+									objInfo={cartItem.knownDataObject}
 									key={'dobj_' + i}
 									updateCheckedObjects={props.updateCheckedObjects}
 									isChecked={isChecked}

--- a/src/main/js/portal/main/components/buttons/CartIcon.tsx
+++ b/src/main/js/portal/main/components/buttons/CartIcon.tsx
@@ -1,12 +1,12 @@
 import React, { Component, CSSProperties } from 'react';
 import { UrlStr } from '../../backend/declarations';
 import { addingToCartProhibition } from '../../models/CartItem';
-import { DataObject } from '../../models/State';
+import { KnownDataObject } from '../../models/State';
 import { styles } from '../styles';
 
 type Props = {
 	style: CSSProperties
-	objInfo: DataObject
+	objInfo: KnownDataObject
 	addToCart: (ids: UrlStr[]) => void
 	removeFromCart: (ids: UrlStr[]) => void
 	isAddedToCart: boolean

--- a/src/main/js/portal/main/components/buttons/CartIcon.tsx
+++ b/src/main/js/portal/main/components/buttons/CartIcon.tsx
@@ -1,12 +1,12 @@
 import React, { Component, CSSProperties } from 'react';
 import { UrlStr } from '../../backend/declarations';
 import { addingToCartProhibition } from '../../models/CartItem';
-import { ObjectsTable } from '../../models/State';
+import { DataObject } from '../../models/State';
 import { styles } from '../styles';
 
 type Props = {
 	style: CSSProperties
-	objInfo: ObjectsTable
+	objInfo: DataObject
 	addToCart: (ids: UrlStr[]) => void
 	removeFromCart: (ids: UrlStr[]) => void
 	isAddedToCart: boolean

--- a/src/main/js/portal/main/components/buttons/DownloadButton.tsx
+++ b/src/main/js/portal/main/components/buttons/DownloadButton.tsx
@@ -1,42 +1,99 @@
-import React, { Component, CSSProperties } from 'react';
+import React, { CSSProperties, useEffect, useMemo, useState } from 'react';
+import { DataObject, ExtendedDobjInfo, LabelLookup } from '../../models/State';
+import { updateCheckedObjectsInCart } from '../../actions/cart';
 
 type Props = {
 	style: CSSProperties
 	checkedObjects: string[]
 	enabled: boolean
+	objectsTable: DataObject[]
+	extendedDobjInfo: ExtendedDobjInfo[]
+	labelLookup: LabelLookup
 }
 
-export default class DownloadButton extends Component<Props> {
-	constructor(props: Props) {
-		super(props);
-	}
+export default function DownloadButton(props: Props) {
+	const { style, enabled, checkedObjects, objectsTable, extendedDobjInfo, labelLookup } = props;
 
-	render() {
-		const { style, enabled, checkedObjects } = this.props;
-		const link = enabled ? getDownloadLink(checkedObjects) : undefined;
-		const btnType = !enabled ? 'btn-outline-secondary' : 'btn-warning';
-		const className = `btn ${btnType} ${enabled ? "" : "disabled"}`;
-		const btnStyle: CSSProperties = enabled ? {} : { pointerEvents: 'auto', cursor: 'not-allowed' };
+	type CheckedInfo = {
+		spec?: string
+		stationId?: string
+	};
 
-		return (
-			<div style={style}>
-				<a href={link} id="download-button" className={className} style={btnStyle}>
-					Download
-				</a>
-			</div>
-		);
-	}
-}
+	type CheckedInfoCache = Record<string, CheckedInfo>;
 
-const getDownloadLink = (objs: string[]): string => {
-	const dobjIds = objs.map(dobj => dobj.split('/').pop());
+	const [checkedInfoCache, setCheckedInfoCache] = useState<CheckedInfoCache>({});
 
-	if (dobjIds.length == 1) {
-		return `/objects/${dobjIds[0]}`;
-	} else {
+	useEffect(() => {
+		const newCache: CheckedInfoCache = {};
+		for (const checkedObject of checkedObjects) {
+			if (checkedInfoCache[checkedObject]) {
+				newCache[checkedObject] = checkedInfoCache[checkedObject];
+			} else {
+				const spec = objectsTable.find((dataObject) => (dataObject.dobj === checkedObject))?.spec;
+				const stationId = extendedDobjInfo.find((edobj) => edobj.dobj === checkedObject)?.stationId;
+				newCache[checkedObject] = {spec, stationId};
+			}
+		}
+
+		const newKeys = Object.keys(newCache).sort();
+		const oldKeys = Object.keys(checkedInfoCache).sort();
+		if (JSON.stringify(newKeys) !== JSON.stringify(oldKeys)) {
+			setCheckedInfoCache(newCache);
+		}
+	}, [checkedObjects]);
+
+	const filename: string = useMemo(() => {
+		const separator = "_";
+		const multiSeparatorRegExp = new RegExp(`[${separator}]+`, "g");
+		const endSeparatorRegExp = new RegExp(`[${separator}]$`);
+
+		const today = new Date();
+		const [year, month, day, hour, minute] = [
+			today.getFullYear(),
+			(today.getMonth()+1).toString().padStart(2,"0"),
+			today.getDate().toString().padStart(2,"0"),
+			today.getHours(),
+			today.getMinutes()
+		];
+
+		const timestamp = (`${year}-${month}-${day}_${hour}${minute}`);
+
+		const stationIdsArr: string[] = Object.values(checkedInfoCache).flatMap((info) => info.stationId ? [info.stationId] : []);
+		const stationIdsSet = new Set(stationIdsArr);
+		const stationId = stationIdsSet.size === 1 ? stationIdsArr[0] : "";
+		
+		const specsArr: string[] = Object.values(checkedInfoCache).flatMap((info) => info.spec ? [info.spec] : []);
+		const specsSet = new Set(specsArr);
+		const spec = specsSet.size === 1 ? specsArr[0] : "";
+
+		const specLabel = spec ? labelLookup[spec].label : "";
+		const postfix = (specLabel || stationId) ? "" : "downloaded_data";
+		const filenameArr = [timestamp, specLabel, stationId ?? "", postfix];
+		const filename = (filenameArr.join(separator)
+									.replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
+									.replaceAll(multiSeparatorRegExp, separator))
+									.replace(endSeparatorRegExp, "");
+
+		return filename;
+	}, [checkedInfoCache]);
+
+	const downloadLink = useMemo(() => {
+		const dobjIds = checkedObjects.map(dobj => dobj.split('/').pop());
 		const ids = encodeURIComponent(JSON.stringify(dobjIds));
-		const fileName = encodeURIComponent('My data cart');
 
-		return `/objects?ids=${ids}&fileName=${fileName}`;
-	}
-};
+		return `/objects?ids=${ids}&fileName=${encodeURIComponent(filename)}`;
+	}, [checkedObjects, filename]);
+
+	const link = enabled ? downloadLink : undefined;
+	const btnType = !enabled ? 'btn-outline-secondary' : 'btn-warning';
+	const className = `btn ${btnType} ${enabled ? "" : "disabled"}`;
+	const btnStyle: CSSProperties = enabled ? {} : { pointerEvents: 'auto', cursor: 'not-allowed' };
+
+	return (
+		<div style={style}>
+			<a href={link} id="download-button" className={className} style={btnStyle}>
+				Download
+			</a>
+		</div>
+	);
+}

--- a/src/main/js/portal/main/components/buttons/DownloadButton.tsx
+++ b/src/main/js/portal/main/components/buttons/DownloadButton.tsx
@@ -26,8 +26,12 @@ export default function DownloadButton(props: Props) {
 	let shouldSetCache = false;
 	for (const checkedObject of checkedObjects) {
 		if (!checkedInfoCache[checkedObject]) {
-			const spec = objectsTable.find((dataObject) => dataObject.dobj === checkedObject)?.spec;
-			const stationId = extendedDobjInfo.find((edobj) => edobj.dobj === checkedObject)?.stationId;
+			const spec = objectsTable.find(
+				(dataObject) => dataObject.dobj === checkedObject
+			)?.spec;
+			const stationId = extendedDobjInfo.find(
+				(edobj) => edobj.dobj === checkedObject
+			)?.stationId;
 			newCache[checkedObject] = {spec, stationId};
 			shouldSetCache = true;
 		}
@@ -51,7 +55,7 @@ export default function DownloadButton(props: Props) {
 		const endSeparatorRegExp = new RegExp(`[${separator}]$`);
 
 		const today = new Date();
-		const [year, month, day, hour, minute] = [
+		const [year, month, date, hour, minute] = [
 			today.getFullYear(),
 			(today.getMonth()+1).toString().padStart(2,"0"),
 			today.getDate().toString().padStart(2,"0"),
@@ -59,23 +63,25 @@ export default function DownloadButton(props: Props) {
 			today.getMinutes()
 		];
 
-		const timestamp = (`${year}-${month}-${day}_${hour}${minute}`);
+		const timestamp = (`${year}-${month}-${date}_${hour}${minute}`);
 
-		const stationIdsArr: string[] = Object.values(checkedObjectsInfo).flatMap((info) => info.stationId ? [info.stationId] : []);
+		const stationIdsArr: string[] = Object.values(checkedObjectsInfo)
+			.flatMap((info) => info.stationId ? [info.stationId] : []);
 		const stationIdsSet = new Set(stationIdsArr);
 		const stationId = stationIdsSet.size === 1 ? stationIdsArr[0] : "";
 		
-		const specsArr: string[] = Object.values(checkedObjectsInfo).flatMap((info) => info.spec ? [info.spec] : []);
+		const specsArr: string[] = Object.values(checkedObjectsInfo)
+			.flatMap((info) => info.spec ? [info.spec] : []);
 		const specsSet = new Set(specsArr);
 		const spec = specsSet.size === 1 ? specsArr[0] : "";
 
 		const specLabel = spec ? labelLookup[spec].label : "";
 		const postfix = (specLabel || stationId) ? "" : "downloaded_data";
-		const filenameArr = [timestamp, specLabel, stationId ?? "", postfix];
-		const filename = (filenameArr.join(separator)
-		                             .replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
-		                             .replaceAll(multiSeparatorRegExp, separator))
-		                             .replace(endSeparatorRegExp, "");
+		const filenameArr = [timestamp, specLabel, stationId, postfix];
+		const filename = filenameArr.join(separator)
+			.replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
+			.replaceAll(multiSeparatorRegExp, separator)
+			.replace(endSeparatorRegExp, "");
 
 		return filename;
 	}, [checkedObjectsInfo]);
@@ -91,7 +97,7 @@ export default function DownloadButton(props: Props) {
 	}, [checkedObjects, filename]);
 
 	const link = enabled ? downloadLink : undefined;
-	const btnType = !enabled ? 'btn-outline-secondary' : 'btn-warning';
+	const btnType = enabled ? 'btn-warning' : 'btn-outline-secondary';
 	const className = `btn ${btnType} ${enabled ? "" : "disabled"}`;
 	const btnStyle: CSSProperties = enabled ? {} : { pointerEvents: 'auto', cursor: 'not-allowed' };
 

--- a/src/main/js/portal/main/components/buttons/DownloadButton.tsx
+++ b/src/main/js/portal/main/components/buttons/DownloadButton.tsx
@@ -1,111 +1,51 @@
 import React, { CSSProperties, useMemo, useState } from 'react';
-import { DataObject, ExtendedDobjInfo, LabelLookup } from '../../models/State';
+import { KnownDataObject, ExtendedDobjInfo, LabelLookup } from '../../models/State';
 
 type Props = {
 	style: CSSProperties
-	checkedObjects: string[]
+	filename: string
+	readyObjectIds: string[]
 	enabled: boolean
-	objectsTable: DataObject[]
-	extendedDobjInfo: ExtendedDobjInfo[]
-	labelLookup: LabelLookup
+	onSubmitAsForm?: () => void
 }
 
 export default function DownloadButton(props: Props) {
-	const { style, enabled, checkedObjects, objectsTable, extendedDobjInfo, labelLookup } = props;
+	const { style, filename, enabled, readyObjectIds, onSubmitAsForm } = props;
 
-	type CheckedInfo = {
-		spec?: string
-		stationId?: string
-	};
-
-	type CheckedInfoCache = Record<string, CheckedInfo>;
-
-	const [checkedInfoCache, setCheckedInfoCache] = useState<CheckedInfoCache>({});
-
-	const newCache: CheckedInfoCache = {};
-	let shouldSetCache = false;
-	for (const checkedObject of checkedObjects) {
-		if (!checkedInfoCache[checkedObject]) {
-			const spec = objectsTable.find(
-				(dataObject) => dataObject.dobj === checkedObject
-			)?.spec;
-			const stationId = extendedDobjInfo.find(
-				(edobj) => edobj.dobj === checkedObject
-			)?.stationId;
-			newCache[checkedObject] = {spec, stationId};
-			shouldSetCache = true;
-		}
-	}
-
-	if (shouldSetCache) {
-		setCheckedInfoCache({ ...checkedInfoCache, ...newCache });
-	}
-
-	const checkedObjectsInfo: CheckedInfoCache = useMemo(() => {
-		const checkedInfo: CheckedInfoCache = {};
-		for (const checkedObject of checkedObjects) {
-			checkedInfo[checkedObject] = checkedInfoCache[checkedObject];
-		}
-		return checkedInfo;
-	}, [checkedInfoCache]);
-
-	const filename: string = useMemo(() => {
-		const separator = "_";
-		const multiSeparatorRegExp = new RegExp(`[${separator}]+`, "g");
-		const endSeparatorRegExp = new RegExp(`[${separator}]$`);
-
-		const today = new Date();
-		const [year, month, date, hour, minute] = [
-			today.getFullYear(),
-			(today.getMonth()+1).toString().padStart(2,"0"),
-			today.getDate().toString().padStart(2,"0"),
-			today.getHours(),
-			today.getMinutes()
-		];
-
-		const timestamp = (`${year}-${month}-${date}_${hour}${minute}`);
-
-		const stationIdsArr: string[] = Object.values(checkedObjectsInfo)
-			.flatMap((info) => info.stationId ? [info.stationId] : []);
-		const stationIdsSet = new Set(stationIdsArr);
-		const stationId = stationIdsSet.size === 1 ? stationIdsArr[0] : "";
-		
-		const specsArr: string[] = Object.values(checkedObjectsInfo)
-			.flatMap((info) => info.spec ? [info.spec] : []);
-		const specsSet = new Set(specsArr);
-		const spec = specsSet.size === 1 ? specsArr[0] : "";
-
-		const specLabel = spec ? labelLookup[spec].label : "";
-		const postfix = (specLabel || stationId) ? "" : "downloaded_data";
-		const filenameArr = [timestamp, specLabel, stationId, postfix];
-		const filename = filenameArr.join(separator)
-			.replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
-			.replaceAll(multiSeparatorRegExp, separator)
-			.replace(endSeparatorRegExp, "");
-
-		return filename;
-	}, [checkedObjectsInfo]);
+	const dobjIds = readyObjectIds.map(dobj => dobj.split('/').pop());
 
 	const downloadLink = useMemo(() => {
-		const dobjIds = checkedObjects.map(dobj => dobj.split('/').pop());
 		if (dobjIds.length == 1) {
 			return `/objects/${dobjIds[0]}`;
 		} else {
 			const ids = encodeURIComponent(JSON.stringify(dobjIds));
 			return `/objects?ids=${ids}&fileName=${encodeURIComponent(filename)}`;
 		}
-	}, [checkedObjects, filename]);
+	}, [dobjIds, filename]);
 
 	const link = enabled ? downloadLink : undefined;
 	const btnType = enabled ? 'btn-warning' : 'btn-outline-secondary';
 	const className = `btn ${btnType} ${enabled ? "" : "disabled"}`;
 	const btnStyle: CSSProperties = enabled ? {} : { pointerEvents: 'auto', cursor: 'not-allowed' };
+	//{marginBottom: 15, whiteSpace: 'normal'}
+	if (onSubmitAsForm) {
+		return (
+			<form action="/objects" method="post" onSubmit={onSubmitAsForm} target="_blank">
+				<input type="hidden" name="fileName" value={encodeURIComponent(filename)} />
+				<input type="hidden" name="ids" value={JSON.stringify(dobjIds)} />
 
-	return (
-		<div style={style}>
-			<a href={link} id="download-button" className={className} style={btnStyle}>
-				Download
-			</a>
-		</div>
-	);
+				<button className={className} style={btnStyle}>
+					<span className="fas fa-download" style={{marginRight:9}} />Download
+				</button>
+			</form>
+		);
+	} else {
+		return (
+			<div style={style}>
+				<a href={link} id="download-button" className={className} style={btnStyle}>
+					Download
+				</a>
+			</div>
+		);
+	}
 }

--- a/src/main/js/portal/main/components/buttons/DownloadButton.tsx
+++ b/src/main/js/portal/main/components/buttons/DownloadButton.tsx
@@ -82,9 +82,12 @@ export default function DownloadButton(props: Props) {
 
 	const downloadLink = useMemo(() => {
 		const dobjIds = checkedObjects.map(dobj => dobj.split('/').pop());
-		const ids = encodeURIComponent(JSON.stringify(dobjIds));
-
-		return `/objects?ids=${ids}&fileName=${encodeURIComponent(filename)}`;
+		if (dobjIds.length == 1) {
+			return `/objects/${dobjIds[0]}`;
+		} else {
+			const ids = encodeURIComponent(JSON.stringify(dobjIds));
+			return `/objects?ids=${ids}&fileName=${encodeURIComponent(filename)}`;
+		}
 	}, [checkedObjects, filename]);
 
 	const link = enabled ? downloadLink : undefined;

--- a/src/main/js/portal/main/components/preview/PreviewTitle.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTitle.tsx
@@ -16,7 +16,7 @@ type OurProps = StateProps & DispatchProps;
 class PreviewTitle extends Component<OurProps>{
 	render() {
 
-		const { items, extendedDobjInfo, labelLookup, cart } = this.props;
+		const { items, extendedDobjInfo, labelLookup, cart, objectsTable } = this.props;
 		if (items.length == 0 || items[0].type == undefined) return null;
 		const specLabel = labelLookup[items[0].spec]?.label ?? "Undefined data type";
 		const title = items.length > 1 ? specLabelDisplay(specLabel) : extendedDobjInfo[0].title ?? extendedDobjInfo[0].biblioInfo?.title ?? items[0].fileName;
@@ -50,6 +50,9 @@ class PreviewTitle extends Component<OurProps>{
 						style={{}}
 						checkedObjects={items.map((item: CartItem) => item.dobj)}
 						enabled={allowCartAdd}
+						objectsTable={objectsTable}
+						extendedDobjInfo={extendedDobjInfo}
+						labelLookup={labelLookup}
 					/>
 				</div>
 				<div className="col-md-12">
@@ -97,6 +100,7 @@ class PreviewTitle extends Component<OurProps>{
 function stateToProps(state: State) {
 	return {
 		items: state.preview.items,
+		objectsTable: state.objectsTable,
 		extendedDobjInfo: state.extendedDobjInfo,
 		labelLookup: state.labelLookup,
 		cart: state.cart,

--- a/src/main/js/portal/main/components/preview/PreviewTitle.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTitle.tsx
@@ -31,7 +31,7 @@ function PreviewTitle(props: OurProps) {
 	const metadataButton = items.length == 1 ? getUrlWithEnvironmentPrefix(items[0].dobj) : '';
 
 	const allowCartAdd = items
-		.map(addingToCartProhibition)
+		.map((x) => addingToCartProhibition(x.knownDataObject))
 		.every((cartProhibition) => cartProhibition.allowCartAdd);
 	const uiMessage = allowCartAdd ? "" : "One or more data objects in this preview cannot be downloaded";
 

--- a/src/main/js/portal/main/components/preview/PreviewTitle.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTitle.tsx
@@ -40,7 +40,7 @@ function PreviewTitle(props: OurProps) {
 	const buttonAction = areItemsInCart ? handleRemoveFromCart : handleAddToCart;
 
 	const localObjectsTable = items.flatMap((x) => x.knownDataObject ? [x.knownDataObject] : [])
-	const { filename } = useDownloadInfo({readyObjectIds: localObjectsTable.map((x) => x.dobj), objectsTable: localObjectsTable, 	
+	const { filename } = useDownloadInfo({readyObjectIds: localObjectsTable.map((x) => x.dobj), objectsTable: localObjectsTable,
 			extendedDobjInfo, labelLookup});
 
 	return (

--- a/src/main/js/portal/main/components/preview/PreviewTitle.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTitle.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from "react-redux";
 import { addToCart, removeFromCart } from '../../actions/common';
 import { UrlStr } from '../../backend/declarations';
@@ -8,99 +8,98 @@ import { PortalDispatch } from '../../store';
 import { getUrlWithEnvironmentPrefix, specLabelDisplay } from '../../utils';
 import CartBtn from '../buttons/CartBtn';
 import DownloadButton from '../buttons/DownloadButton';
+import { useDownloadInfo } from '../../hooks/useDownloadInfo';
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type OurProps = StateProps & DispatchProps;
 
-class PreviewTitle extends Component<OurProps>{
-	render() {
+function PreviewTitle(props: OurProps) {
+	function handleAddToCart(objInfo: UrlStr[]) {
+		props.addToCart(objInfo);
+	}
 
-		const { items, extendedDobjInfo, labelLookup, cart, objectsTable } = this.props;
-		if (items.length == 0 || items[0].type == undefined) return null;
-		const specLabel = labelLookup[items[0].spec]?.label ?? "Undefined data type";
-		const title = items.length > 1 ? specLabelDisplay(specLabel) : extendedDobjInfo[0].title ?? extendedDobjInfo[0].biblioInfo?.title ?? items[0].fileName;
-		const subtitle = items.length == 1 ? <div className="fs-3 text-muted">{extendedDobjInfo[0].biblioInfo?.temporalCoverageDisplay}</div> : null;
-		const metadataButton = items.length == 1 ? getUrlWithEnvironmentPrefix(items[0].dobj) : '';
+	function handleRemoveFromCart(objInfo: UrlStr[]) {
+		props.removeFromCart(objInfo);
+	}
 
-		const allowCartAdd = items
-			.map(addingToCartProhibition)
-			.every(cartProhibition => cartProhibition.allowCartAdd);
-		const uiMessage = allowCartAdd ? "" : "One or more data objects in this preview cannot be downloaded";
+	const { items, extendedDobjInfo, labelLookup, cart } = props;
+	if (items.length == 0 || items[0].type == undefined) return null;
+	const specLabel = labelLookup[items[0].spec]?.label ?? "Undefined data type";
+	const title = items.length > 1 ? specLabelDisplay(specLabel) : extendedDobjInfo[0].title ?? extendedDobjInfo[0].biblioInfo?.title ?? items[0].fileName;
+	const subtitle = items.length == 1 ? <div className="fs-3 text-muted">{extendedDobjInfo[0].biblioInfo?.temporalCoverageDisplay}</div> : null;
+	const metadataButton = items.length == 1 ? getUrlWithEnvironmentPrefix(items[0].dobj) : '';
 
-		const areItemsInCart: boolean = items.reduce((prevVal: boolean, item: CartItem) => cart.hasItem(item.dobj), false);
-		const actionButtonType = areItemsInCart ? 'remove' : 'add';
-		const buttonAction = areItemsInCart ? this.handleRemoveFromCart.bind(this) : this.handleAddToCart.bind(this);
+	const allowCartAdd = items
+		.map(addingToCartProhibition)
+		.every((cartProhibition) => cartProhibition.allowCartAdd);
+	const uiMessage = allowCartAdd ? "" : "One or more data objects in this preview cannot be downloaded";
 
-		return (
-			<>
-				<h1 className="col-md-8">
-					{title}
-				</h1>
-				<div className='col-auto ms-md-auto d-flex gap-1 py-2'>
-					<CartBtn
-						style={{}}
-						checkedObjects={items.map((item: CartItem) => item.dobj)}
-						clickAction={buttonAction}
-						enabled={allowCartAdd}
-						title={uiMessage}
-						type={actionButtonType}
-					/>
-					<DownloadButton
-						style={{}}
-						checkedObjects={items.map((item: CartItem) => item.dobj)}
-						enabled={allowCartAdd}
-						objectsTable={objectsTable}
-						extendedDobjInfo={extendedDobjInfo}
-						labelLookup={labelLookup}
-					/>
+	const areItemsInCart: boolean = items.reduce((prevVal: boolean, item: CartItem) => cart.hasItem(item.dobj), false);
+	const actionButtonType = areItemsInCart ? 'remove' : 'add';
+	const buttonAction = areItemsInCart ? handleRemoveFromCart : handleAddToCart;
+
+	const localObjectsTable = items.flatMap((x) => x.knownDataObject ? [x.knownDataObject] : [])
+	const { filename } = useDownloadInfo({readyObjectIds: localObjectsTable.map((x) => x.dobj), objectsTable: localObjectsTable, 	
+			extendedDobjInfo, labelLookup});
+
+	return (
+		<>
+			<h1 className="col-md-8">
+				{title}
+			</h1>
+			<div className='col-auto ms-md-auto d-flex gap-1 py-2'>
+				<CartBtn
+					style={{}}
+					checkedObjects={items.map((item: CartItem) => item.dobj)}
+					clickAction={buttonAction}
+					enabled={allowCartAdd}
+					title={uiMessage}
+					type={actionButtonType}
+				/>
+				<DownloadButton
+					style={{}}
+					filename={filename}
+					readyObjectIds={items.map((item: CartItem) => item.dobj)}
+					enabled={allowCartAdd}
+				/>
+			</div>
+			<div className="col-md-12">
+				<div className='d-sm-flex justify-content-between align-items-end mb-4 pb-2'>
+					<div>{subtitle}</div>
+
 				</div>
-				<div className="col-md-12">
-					<div className='d-sm-flex justify-content-between align-items-end mb-4 pb-2'>
-						<div>{subtitle}</div>
-
-					</div>
-					<ul className="nav nav-tabs">
-						<li className="nav-item">
-							{items.length == 1 ?
-								<a className="nav-link" href={metadataButton}>Metadata</a>
-								:
-								<details className="nav-link dropdown-details">
-									<summary>Metadata</summary>
-									<div className='dropdown' style={{ width: 'auto', left: 0, padding: '0.5rem 0' }}>
-										{items.map(item => {
-											return(
-												<a key={item.dobj} className='dropdown-item py-1 px-3' href={getUrlWithEnvironmentPrefix(item.dobj)}>
-													<div>{item.itemName}</div>
-												</a>
-											);
-										})}
-									</div>
-								</details>
-							}
-						</li>
-						<li className="nav-item">
-							<a className="nav-link active" aria-current="page" href="#">Preview</a>
-						</li>
-					</ul>
-				</div>
-			</>
-		);
-	}
-
-	handleAddToCart(objInfo: UrlStr[]) {
-		this.props.addToCart(objInfo);
-	}
-
-	handleRemoveFromCart(objInfo: UrlStr[]) {
-		this.props.removeFromCart(objInfo);
-	}
+				<ul className="nav nav-tabs">
+					<li className="nav-item">
+						{items.length == 1 ?
+							<a className="nav-link" href={metadataButton}>Metadata</a>
+							:
+							<details className="nav-link dropdown-details">
+								<summary>Metadata</summary>
+								<div className='dropdown' style={{ width: 'auto', left: 0, padding: '0.5rem 0' }}>
+									{items.map(item => {
+										return(
+											<a key={item.dobj} className='dropdown-item py-1 px-3' href={getUrlWithEnvironmentPrefix(item.dobj)}>
+												<div>{item.itemName}</div>
+											</a>
+										);
+									})}
+								</div>
+							</details>
+						}
+					</li>
+					<li className="nav-item">
+						<a className="nav-link active" aria-current="page" href="#">Preview</a>
+					</li>
+				</ul>
+			</div>
+		</>
+	);
 }
 
 function stateToProps(state: State) {
 	return {
 		items: state.preview.items,
-		objectsTable: state.objectsTable,
 		extendedDobjInfo: state.extendedDobjInfo,
 		labelLookup: state.labelLookup,
 		cart: state.cart,

--- a/src/main/js/portal/main/components/searchResult/SearchResultCompactRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultCompactRow.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import CartIcon from '../buttons/CartIcon';
 import PreviewIcon from '../buttons/PreviewIcon';
 import { formatBytes, formatDateWithOptionalTime, pick, getUrlWithEnvironmentPrefix } from '../../utils';
-import { ExtendedDobjInfo, ObjectsTable, WhoAmI } from "../../models/State";
+import { ExtendedDobjInfo, DataObject, WhoAmI } from "../../models/State";
 import config, { timezone } from '../../config';
 import Preview, { previewAvailability } from '../../models/Preview';
 import PreviewLookup from '../../models/PreviewLookup';
@@ -10,7 +10,7 @@ import { UrlStr } from '../../backend/declarations';
 import CollectionBtn from '../buttons/CollectionBtn';
 
 type Props =  {
-	objInfo: ObjectsTable,
+	objInfo: DataObject,
 	isAddedToCart: boolean,
 	preview: Preview,
 	extendedDobjInfo?: (ExtendedDobjInfo | undefined)[]

--- a/src/main/js/portal/main/components/searchResult/SearchResultCompactRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultCompactRow.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import CartIcon from '../buttons/CartIcon';
 import PreviewIcon from '../buttons/PreviewIcon';
 import { formatBytes, formatDateWithOptionalTime, pick, getUrlWithEnvironmentPrefix } from '../../utils';
-import { ExtendedDobjInfo, DataObject, WhoAmI } from "../../models/State";
+import { ExtendedDobjInfo, KnownDataObject, WhoAmI } from "../../models/State";
 import config, { timezone } from '../../config';
 import Preview, { previewAvailability } from '../../models/Preview';
 import PreviewLookup from '../../models/PreviewLookup';
@@ -10,7 +10,7 @@ import { UrlStr } from '../../backend/declarations';
 import CollectionBtn from '../buttons/CollectionBtn';
 
 type Props =  {
-	objInfo: DataObject,
+	objInfo: KnownDataObject,
 	isAddedToCart: boolean,
 	preview: Preview,
 	extendedDobjInfo?: (ExtendedDobjInfo | undefined)[]

--- a/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
@@ -3,7 +3,7 @@ import CheckBtn from '../buttons/CheckBtn';
 import { isSmallDevice, getLastSegmentInUrl, linesToShowStyle, getUrlWithEnvironmentPrefix } from '../../utils';
 import {LinkifyText} from '../LinkifyText';
 import config from '../../config';
-import { ObjectsTable, ExtendedDobjInfo, LabelLookup } from "../../models/State";
+import { DataObject, ExtendedDobjInfo, LabelLookup } from "../../models/State";
 import Preview from '../../models/Preview';
 import CartItem, { addingToCartProhibition } from '../../models/CartItem';
 import { UrlStr } from '../../backend/declarations';
@@ -29,12 +29,12 @@ const iconLevel = [
 ];
 
 interface OurProps {
-	objInfo: ObjectsTable | CartItem
+	objInfo: DataObject | CartItem
 	extendedInfo: ExtendedDobjInfo
 	preview: Preview
 	updateCheckedObjects: (ids: string) => void
 	isChecked: boolean
-	checkedObjects?: ObjectsTable[]
+	checkedObjects?: DataObject[]
 	labelLookup: LabelLookup
 	isCartView: Boolean
 }

--- a/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
@@ -29,7 +29,7 @@ const iconLevel = [
 ];
 
 interface OurProps {
-	objInfo: KnownDataObject | CartItem
+	objInfo: KnownDataObject | undefined
 	extendedInfo: ExtendedDobjInfo
 	preview: Preview
 	updateCheckedObjects: (ids: string) => void
@@ -44,6 +44,9 @@ export default class SearchResultRegularRow extends Component<OurProps> {
 	render(){
 		const props = this.props;
 		const objInfo = props.objInfo;
+		if (objInfo === undefined) {
+			return;
+		}
 		const extendedInfo = props.extendedInfo.theme && props.extendedInfo.themeIcon
 				? props.extendedInfo
 				: { ...props.extendedInfo, theme: 'Other data', themeIcon: 'https://static.icos-cp.eu/images/themes/oth.svg' }

--- a/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
@@ -3,7 +3,7 @@ import CheckBtn from '../buttons/CheckBtn';
 import { isSmallDevice, getLastSegmentInUrl, linesToShowStyle, getUrlWithEnvironmentPrefix } from '../../utils';
 import {LinkifyText} from '../LinkifyText';
 import config from '../../config';
-import { DataObject, ExtendedDobjInfo, LabelLookup } from "../../models/State";
+import { KnownDataObject, ExtendedDobjInfo, LabelLookup } from "../../models/State";
 import Preview from '../../models/Preview';
 import CartItem, { addingToCartProhibition } from '../../models/CartItem';
 import { UrlStr } from '../../backend/declarations';
@@ -29,12 +29,12 @@ const iconLevel = [
 ];
 
 interface OurProps {
-	objInfo: DataObject | CartItem
+	objInfo: KnownDataObject | CartItem
 	extendedInfo: ExtendedDobjInfo
 	preview: Preview
 	updateCheckedObjects: (ids: string) => void
 	isChecked: boolean
-	checkedObjects?: DataObject[]
+	checkedObjects?: KnownDataObject[]
 	labelLookup: LabelLookup
 	isCartView: Boolean
 }

--- a/src/main/js/portal/main/components/ui/Message.tsx
+++ b/src/main/js/portal/main/components/ui/Message.tsx
@@ -3,16 +3,24 @@ import React, { Component, ReactNode } from 'react';
 type Props = {
 	title: string
 	onclick: () => void
+	onclickSecondary?: () => void
 }
 
 export default class Message extends Component<Props>{
+	
 	render() {
+		const buttonSecondary = this.props.onclickSecondary ? 
+			(<button className="btn btn-lg btn-warning d-block mx-auto my-3" onClick={this.props.onclickSecondary}>
+				Restore previous cart
+			</button>) :
+			<></>;
 		return (
-			<div className="text-center" style={{ margin: '5vh 0' }}>
+			<div className="text-center" style={{ margin: '5vh 0', }}>
 				<h1 className='pb-3'>{this.props.title}</h1>
-				<button className="btn btn-lg btn-primary" onClick={this.props.onclick}>
+				<button className="btn btn-lg btn-primary d-block mx-auto my-3" onClick={this.props.onclick}>
 					Find data
 				</button>
+				{ buttonSecondary }
 			</div>
 		)
 	}

--- a/src/main/js/portal/main/containers/DataCart.tsx
+++ b/src/main/js/portal/main/containers/DataCart.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import CartPanel from '../components/CartPanel';
-import {setCartName, fetchIsBatchDownloadOk, updateCheckedObjectsInCart, logCartDownloadClick} from '../actions/cart';
+import {setCartName, fetchIsBatchDownloadOk, updateCheckedObjectsInCart, logCartDownloadClick, emptyCart, restoreLastCart} from '../actions/cart';
 import {formatBytes, getLastSegmentsInUrls} from '../utils';
 import {Sha256Str, UrlStr} from "../backend/declarations";
 import {PortalDispatch} from "../store";
@@ -45,6 +45,11 @@ function DataCart(props: DataCartProps) {
 		logCartDownloadClick(name, pids);
 		// only do if cart download successful:
 		//props.removeFromCart(localObjectsTable.map((x) => x.dobj));
+		props.emptyCart();
+	}
+
+	function handleRestore() {
+		props.restoreLastCart();
 	}
 
 	const cart = props.cart.name ? props.cart : props.cart.withName(downloadInfo.filename);
@@ -54,8 +59,6 @@ function DataCart(props: DataCartProps) {
 		? 'Download cart content'
 		: 'Accept license and download cart content';
 	const hashes = JSON.stringify(cart.pids);
-
-	console.log(props.cart.items)
 
 	return (
 		<div>
@@ -94,7 +97,8 @@ function DataCart(props: DataCartProps) {
 				:
 				<Message
 					title="Your cart is empty"
-					onclick={() => (handleRouteClick('search'))} />
+					onclick={() => (handleRouteClick('search'))} 
+					onclickSecondary={props.lastCart ? handleRestore : undefined}/>
 			}
 		</div>
 	);
@@ -103,6 +107,7 @@ function DataCart(props: DataCartProps) {
 function stateToProps(state: State){
 	return {
 		cart: state.cart,
+		lastCart: state.lastCart,
 		previewLookup: state.previewLookup,
 		labelLookup: state.labelLookup,
 		user: state.user,
@@ -119,6 +124,8 @@ function dispatchToProps(dispatch: PortalDispatch | Function){
 		fetchIsBatchDownloadOk: () => dispatch(fetchIsBatchDownloadOk),
 		updateCheckedObjectsInCart: (ids: UrlStr[]) => dispatch(updateCheckedObjectsInCart(ids)),
 		removeFromCart: (ids: UrlStr[]) => dispatch(removeFromCart(ids)),
+		emptyCart: () => dispatch(emptyCart()),
+		restoreLastCart: () => dispatch(restoreLastCart()),
 	};
 }
 

--- a/src/main/js/portal/main/containers/DataCart.tsx
+++ b/src/main/js/portal/main/containers/DataCart.tsx
@@ -1,7 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import CartPanel from '../components/CartPanel';
-import {setCartName, fetchIsBatchDownloadOk, updateCheckedObjectsInCart, logCartDownloadClick, emptyCart, restoreLastCart} from '../actions/cart';
+import {setCartName, fetchIsBatchDownloadOk, updateCheckedObjectsInCart, 
+		logCartDownloadClick, emptyCart, restoreLastCart} from '../actions/cart';
 import {formatBytes, getLastSegmentsInUrls} from '../utils';
 import {Sha256Str, UrlStr} from "../backend/declarations";
 import {PortalDispatch} from "../store";
@@ -43,8 +44,6 @@ function DataCart(props: DataCartProps) {
 	function handleDownloadLog() {
 		const {name, pids} = props.cart;
 		logCartDownloadClick(name, pids);
-		// only do if cart download successful:
-		//props.removeFromCart(localObjectsTable.map((x) => x.dobj));
 		props.emptyCart();
 	}
 

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import { connect } from 'react-redux';
-import { ObjectsTable, State} from "../../models/State";
+import { DataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
 import {getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
@@ -117,7 +117,7 @@ class SearchResultRegular extends Component<OurProps> {
 
 					<div>
 						{
-							objectsTable.map((objInfo: ObjectsTable, i) => {
+							objectsTable.map((objInfo: DataObject, i) => {
 								const extendedInfo = extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
 
 								return extendedInfo && (

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -1,4 +1,4 @@
-import React, {Component, useState} from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -109,6 +109,9 @@ class SearchResultRegular extends Component<OurProps> {
 								style={{}}
 								checkedObjects={checkedObjectsInSearch}
 								enabled={checkedObjectsInSearch.length > 0}
+								objectsTable={objectsTable}
+								extendedDobjInfo={extendedDobjInfo}
+								labelLookup={labelLookup}
 							/>
 
 						</div>

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -1,6 +1,6 @@
-import React, {Component} from 'react';
+import React, {Component, useState} from 'react';
 import { connect } from 'react-redux';
-import { DataObject, State} from "../../models/State";
+import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
 import {getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
@@ -13,6 +13,7 @@ import HelpButton from "../help/HelpButton";
 import SearchResultRegularRow from "../../components/searchResult/SearchResultRegularRow";
 import { addingToCartProhibition } from '../../models/CartItem';
 import DownloadButton from '../../components/buttons/DownloadButton';
+import { useDownloadInfo } from '../../hooks/useDownloadInfo';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
@@ -32,125 +33,124 @@ const dropdownLookup = {
 	submTime: 'Submission time'
 };
 
-class SearchResultRegular extends Component<OurProps> {
-	render(){
-		const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
-			toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
-			updateCheckedObjects, handlePreview, handleAddToCart,
-			handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = this.props;
+function SearchResultRegular(props: OurProps) {
+	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
+		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
+		updateCheckedObjects, handlePreview, handleAddToCart,
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = props;
 
-		const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
-		const checkedUriSet = new Set<string>(checkedObjectsInSearch)
-		const checkedObjects = objectsTable.filter(o => checkedUriSet.has(o.dobj))
+	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
+	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
+	const checkedObjects = objectsTable.filter(o => checkedUriSet.has(o.dobj));
 
-		return (
-			<div className="card">
-				<Paging
-					searchOptions={searchOptions}
-					type="header"
-					paging={paging}
-					requestStep={requestStep}
-					getAllFilteredDataObjects={getAllFilteredDataObjects}
-					exportQuery={exportQuery}
-				/>
+	const { filename } = useDownloadInfo({readyObjectIds: checkedObjectsInSearch, objectsTable, 	
+		extendedDobjInfo, labelLookup});
 
-				<div className="card-body">
+	return (
+		<div className="card">
+			<Paging
+				searchOptions={searchOptions}
+				type="header"
+				paging={paging}
+				requestStep={requestStep}
+				getAllFilteredDataObjects={getAllFilteredDataObjects}
+				exportQuery={exportQuery}
+			/>
 
-					<div className="panel-srollable-controls d-flex justify-content-between flex-wrap">
-						<div className="d-flex mb-2">
-							<CheckAllBoxes
-								checkCount={checkedObjectsInSearch.length}
-								totalCount={paging.pageCount}
-								onChange={handleAllCheckboxesChange}
-								disabled={objectsTable.every(o => !addingToCartProhibition(o).allowCartAdd)} />
+			<div className="card-body">
 
-							<Dropdown
-								isSorter={true}
-								isEnabled={true}
-								selectedItemKey={sorting.varName}
-								isAscending={sorting.ascending}
-								itemClickAction={toggleSort}
-								lookup={dropdownLookup}
-							/>
+				<div className="panel-srollable-controls d-flex justify-content-between flex-wrap">
+					<div className="d-flex mb-2">
+						<CheckAllBoxes
+							checkCount={checkedObjectsInSearch.length}
+							totalCount={paging.pageCount}
+							onChange={handleAllCheckboxesChange}
+							disabled={objectsTable.every(o => !addingToCartProhibition(o).allowCartAdd)} />
 
-							{checkedObjectsInSearch.length > 0 &&
-								<span style={{ marginLeft: 12, marginTop: 7 }}>{checkedObjectsInSearch.length} {objectText} selected</span>
-							}
-						</div>
+						<Dropdown
+							isSorter={true}
+							isEnabled={true}
+							selectedItemKey={sorting.varName}
+							isAscending={sorting.ascending}
+							itemClickAction={toggleSort}
+							lookup={dropdownLookup}
+						/>
 
-						<div className="d-flex mb-3">
-
-							<div style={{position:'relative', top:7, margin: '0 10px'}}>
-								<HelpButton
-									name={'preview'}
-									title="View help about Preview"
-									overrideStyles={{ paddingLeft: 0 }}
-								/>
-							</div>
-
-							<PreviewBtn
-								style={{ marginRight: 10 }}
-								checkedObjects={checkedObjects}
-								previewLookup={previewLookup}
-								clickAction={handlePreview}
-							/>
-
-							{user.email &&
-								<CartBtn
-									style={{ marginRight: 10 }}
-									checkedObjects={checkedObjectsInSearch}
-									clickAction={handleAddToCart}
-									enabled={checkedObjectsInSearch.length > 0}
-									type='add'
-								/>
-							}
-
-							<DownloadButton
-								style={{}}
-								checkedObjects={checkedObjectsInSearch}
-								enabled={checkedObjectsInSearch.length > 0}
-								objectsTable={objectsTable}
-								extendedDobjInfo={extendedDobjInfo}
-								labelLookup={labelLookup}
-							/>
-
-						</div>
-
-					</div>
-
-					<div>
-						{
-							objectsTable.map((objInfo: DataObject, i) => {
-								const extendedInfo = extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
-
-								return extendedInfo && (
-									<SearchResultRegularRow
-										labelLookup={labelLookup}
-										extendedInfo={extendedInfo}
-										preview={preview}
-										objInfo={objInfo}
-										key={'dobj_' + i}
-										updateCheckedObjects={updateCheckedObjects}
-										isChecked={checkedObjectsInSearch.includes(objInfo.dobj)}
-										checkedObjects={checkedObjects}
-										isCartView={false}
-									/>
-								);
-							})
+						{checkedObjectsInSearch.length > 0 &&
+							<span style={{ marginLeft: 12, marginTop: 7 }}>{checkedObjectsInSearch.length} {objectText} selected</span>
 						}
 					</div>
+
+					<div className="d-flex mb-3">
+
+						<div style={{position:'relative', top:7, margin: '0 10px'}}>
+							<HelpButton
+								name={'preview'}
+								title="View help about Preview"
+								overrideStyles={{ paddingLeft: 0 }}
+							/>
+						</div>
+
+						<PreviewBtn
+							style={{ marginRight: 10 }}
+							checkedObjects={checkedObjects}
+							previewLookup={previewLookup}
+							clickAction={handlePreview}
+						/>
+
+						{user.email &&
+							<CartBtn
+								style={{ marginRight: 10 }}
+								checkedObjects={checkedObjectsInSearch}
+								clickAction={handleAddToCart}
+								enabled={checkedObjectsInSearch.length > 0}
+								type='add'
+							/>
+						}
+
+						<DownloadButton
+							style={{}}
+							filename={filename}
+							enabled={checkedObjectsInSearch.length > 0}
+							readyObjectIds={checkedObjectsInSearch}
+						/>
+
+					</div>
+
 				</div>
-				<Paging
-					searchOptions={undefined}
-					type="footer"
-					paging={paging}
-					requestStep={requestStep}
-					getAllFilteredDataObjects={getAllFilteredDataObjects}
-					exportQuery={exportQuery}
-				/>
+
+				<div>
+					{
+						objectsTable.map((objInfo: KnownDataObject, i) => {
+							const extendedInfo = extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
+
+							return extendedInfo && (
+								<SearchResultRegularRow
+									labelLookup={labelLookup}
+									extendedInfo={extendedInfo}
+									preview={preview}
+									objInfo={objInfo}
+									key={'dobj_' + i}
+									updateCheckedObjects={updateCheckedObjects}
+									isChecked={checkedObjectsInSearch.includes(objInfo.dobj)}
+									checkedObjects={checkedObjects}
+									isCartView={false}
+								/>
+							);
+						})
+					}
+				</div>
 			</div>
-		);
-	}
+			<Paging
+				searchOptions={undefined}
+				type="footer"
+				paging={paging}
+				requestStep={requestStep}
+				getAllFilteredDataObjects={getAllFilteredDataObjects}
+				exportQuery={exportQuery}
+			/>
+		</div>
+	);
 }
 
 function stateToProps(state: State){

--- a/src/main/js/portal/main/hooks/useDownloadInfo.ts
+++ b/src/main/js/portal/main/hooks/useDownloadInfo.ts
@@ -1,0 +1,95 @@
+import { useMemo, useState, useEffect } from 'react';
+import { KnownDataObject, ExtendedDobjInfo, LabelLookup } from '../models/State';
+
+
+type ReadyInfo = {
+	spec?: string;
+	stationId?: string;
+};
+
+type InfoCache = Record<string, ReadyInfo>;
+
+interface Props {
+	readyObjectIds: string[];
+	objectsTable: KnownDataObject[]
+	extendedDobjInfo: ExtendedDobjInfo[]
+	labelLookup: LabelLookup
+}
+
+export function useDownloadInfo(props: Props) {
+    const { readyObjectIds, objectsTable, extendedDobjInfo, labelLookup } = props;
+	const [infoCache, setInfoCache] = useState<InfoCache>({});
+
+	useEffect(() => {
+		const newCache: InfoCache = {};
+		let updateCache = false;
+
+		for (const readyObjectId of readyObjectIds) {
+			if (!infoCache[readyObjectId]) {
+				const spec = objectsTable.find(
+					(dataObject) => dataObject.dobj === readyObjectId
+				)?.spec;
+
+				const stationId = extendedDobjInfo.find(
+					(edobj) => edobj.dobj === readyObjectId
+				)?.stationId;
+
+				newCache[readyObjectId] = { spec, stationId };
+				updateCache = true;
+			}
+		}
+
+		if (updateCache) {
+			setInfoCache((prev) => ({ ...prev, ...newCache }));
+		}
+	}, [readyObjectIds, objectsTable, extendedDobjInfo]);
+
+	const readyObjectsInfo: InfoCache = useMemo(() => {
+		const readyInfo: InfoCache = {};
+		for (const readyObjectId of readyObjectIds) {
+			if (infoCache[readyObjectId]) {
+				readyInfo[readyObjectId] = infoCache[readyObjectId];
+			}
+		}
+		return readyInfo;
+	}, [infoCache, readyObjectIds]);
+
+	const filename: string = useMemo(() => {
+		const separator = "_";
+		const multiSeparatorRegExp = new RegExp(`[${separator}]+`, "g");
+		const endSeparatorRegExp = new RegExp(`[${separator}]$`);
+
+		const today = new Date();
+		const [year, month, date, hour, minute] = [
+			today.getFullYear(),
+			(today.getMonth() + 1).toString().padStart(2,"0"),
+			today.getDate().toString().padStart(2,"0"),
+			today.getHours().toString().padStart(2,"0"),
+			today.getMinutes().toString().padStart(2,"0")
+		];
+
+		const timestamp = `${year}-${month}-${date}_${hour}${minute}`;
+
+		const stationIdsArr: string[] = Object.values(readyObjectsInfo)
+			.flatMap((info) => info.stationId ? [info.stationId] : [""]);
+		const stationId = (new Set(stationIdsArr)).size === 1 ? stationIdsArr[0] : "";
+		
+		const specsArr: string[] = Object.values(readyObjectsInfo)
+			.flatMap((info) => info.spec ? [info.spec] : [""]);
+		const spec = (new Set(specsArr)).size === 1 ? specsArr[0] : "";
+
+		const specLabel = spec ? labelLookup[spec].label : "";
+		const postfix = (specLabel || stationId) ? "" : "downloaded_data";
+		const filenameArr = [timestamp, specLabel, stationId, postfix];
+		const filename = filenameArr.join(separator)
+			.replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
+			.replaceAll(multiSeparatorRegExp, separator)
+			.replace(endSeparatorRegExp, "");
+
+		console.log(filenameArr);
+
+		return filename;
+	}, [readyObjectsInfo]);
+
+	return { filename };
+}

--- a/src/main/js/portal/main/hooks/useDownloadInfo.ts
+++ b/src/main/js/portal/main/hooks/useDownloadInfo.ts
@@ -73,7 +73,7 @@ export function useDownloadInfo(props: Props) {
 		const stationIdsArr: string[] = Object.values(readyObjectsInfo)
 			.flatMap((info) => info.stationId ? [info.stationId] : [""]);
 		const stationId = (new Set(stationIdsArr)).size === 1 ? stationIdsArr[0] : "";
-		
+
 		const specsArr: string[] = Object.values(readyObjectsInfo)
 			.flatMap((info) => info.spec ? [info.spec] : [""]);
 		const spec = (new Set(specsArr)).size === 1 ? specsArr[0] : "";
@@ -85,8 +85,6 @@ export function useDownloadInfo(props: Props) {
 			.replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
 			.replaceAll(multiSeparatorRegExp, separator)
 			.replace(endSeparatorRegExp, "");
-
-		console.log(filenameArr);
 
 		return filename;
 	}, [readyObjectsInfo]);

--- a/src/main/js/portal/main/models/Cart.ts
+++ b/src/main/js/portal/main/models/Cart.ts
@@ -6,7 +6,7 @@ export default class Cart {
 	readonly _ts: string;
 
 	constructor(name: string | undefined = undefined, items: CartItem[] | undefined = undefined){
-		this._name = name || 'My data cart';
+		this._name = name || "";
 		this._items = items || [];
 		this._ts = (items ? Date.now() + '' : '0');
 	}

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -1,25 +1,6 @@
 import {IdxSig, UrlStr} from "../backend/declarations";
 import { PreviewType, themeUris } from "../config";
-
-export interface DataObject {
-	dobj: string,
-	hasNextVersion: boolean,
-	dataset: string,
-	fileName: string,
-	format: string,
-	formatLabel: string,
-	level: number,
-	size: string,
-	spec: string,
-	specLabel: string,
-	submTime: string,
-	theme: string,
-	themeLabel: string,
-	timeEnd: string,
-	timeStart: string,
-	type: PreviewType | undefined,
-	temporalResolution: string
-}
+import { DataObject } from "./State";
 
 export interface CartItemSerialized {
 	id: string
@@ -176,9 +157,7 @@ export type CartProhibition = {
 	allowCartAdd: boolean
 	uiMessage?: string
 }
-export function addingToCartProhibition(
-	dobj: {theme: UrlStr, level: number, hasNextVersion: boolean, submTime: Date}
-): CartProhibition {
+export function addingToCartProhibition(dobj: DataObject | CartItem): CartProhibition {
 
 	if(dobj.submTime.getTime() > Date.now())
 		return {allowCartAdd: false, uiMessage: "This data object is under moratorium"}

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -168,8 +168,11 @@ export type CartProhibition = {
 	allowCartAdd: boolean
 	uiMessage?: string
 }
-export function addingToCartProhibition(dobj: KnownDataObject | CartItem): CartProhibition {
+export function addingToCartProhibition(dobj: KnownDataObject | undefined): CartProhibition {
 
+	if(dobj === undefined) {
+		return { allowCartAdd: false, uiMessage: "This data object has not yet been loaded" }
+	}
 	if(dobj.submTime.getTime() > Date.now())
 		return {allowCartAdd: false, uiMessage: "This data object is under moratorium"}
 

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -1,10 +1,10 @@
 import {IdxSig, UrlStr} from "../backend/declarations";
 import { PreviewType, themeUris } from "../config";
-import { DataObject } from "./State";
+import { KnownDataObject } from "./State";
 
 export interface CartItemSerialized {
 	id: string
-	dataobject: DataObject | undefined
+	dataobject: KnownDataObject | undefined
 	type: PreviewType | undefined
 	url: UrlStr | undefined
 	keyValPairs: IdxSig
@@ -12,12 +12,12 @@ export interface CartItemSerialized {
 
 export default class CartItem {
 	private readonly _id: UrlStr;
-	private readonly _dataobject: DataObject | undefined;
+	private readonly _dataobject: KnownDataObject | undefined;
 	private readonly _type: PreviewType | undefined;
 	private readonly _url: UrlStr | undefined;
 	private readonly _keyValPairs: IdxSig;
 
-	constructor(id: string, dataobject?: DataObject, type?: PreviewType, url?: string){
+	constructor(id: string, dataobject?: KnownDataObject, type?: PreviewType, url?: string){
 		this._id = id;
 		this._dataobject = dataobject;
 		this._type = type;
@@ -58,6 +58,10 @@ export default class CartItem {
 
 	get dobj() {
 		return this._id;
+	}
+
+	get knownDataObject() {
+		return this._dataobject;
 	}
 
 	get hasNextVersion() {
@@ -164,7 +168,7 @@ export type CartProhibition = {
 	allowCartAdd: boolean
 	uiMessage?: string
 }
-export function addingToCartProhibition(dobj: DataObject | CartItem): CartProhibition {
+export function addingToCartProhibition(dobj: KnownDataObject | CartItem): CartProhibition {
 
 	if(dobj.submTime.getTime() > Date.now())
 		return {allowCartAdd: false, uiMessage: "This data object is under moratorium"}

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -4,7 +4,7 @@ import config, {PreviewType} from "../config";
 import deepEqual from 'deep-equal';
 import PreviewLookup, {PreviewInfo} from "./PreviewLookup";
 import Cart from "./Cart";
-import {ExtendedDobjInfo, DataObject} from "./State";
+import {ExtendedDobjInfo, KnownDataObject} from "./State";
 import {IdxSig, Sha256Str, UrlStr} from "../backend/declarations";
 import { Value } from './SpecTable';
 
@@ -90,7 +90,7 @@ export default class Preview {
 		return new Preview(items, options, type);
 	}
 
-	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: DataObject[], yAxis?: string, y2Axis?: string) {
+	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: KnownDataObject[], yAxis?: string, y2Axis?: string) {
 		const objects = ids.map(id => {
 			const objInfo = objectsTable.find(ot => ot.dobj.endsWith(id));
 
@@ -145,7 +145,7 @@ export default class Preview {
 		throw new Error('Could not initialize Preview');
 	}
 
-	restore(lookup: PreviewLookup, cart: Cart, objectsTable: DataObject[]) {
+	restore(lookup: PreviewLookup, cart: Cart, objectsTable: KnownDataObject[]) {
 		if (this.hasPids) {
 			return this.initPreview(lookup, cart, this.pids.map(pid => config.objectUriPrefix[config.envri] + pid), objectsTable);
 		} else {

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -4,7 +4,7 @@ import config, {PreviewType} from "../config";
 import deepEqual from 'deep-equal';
 import PreviewLookup, {PreviewInfo} from "./PreviewLookup";
 import Cart from "./Cart";
-import {ExtendedDobjInfo, ObjectsTable} from "./State";
+import {ExtendedDobjInfo, DataObject} from "./State";
 import {Sha256Str, UrlStr} from "../backend/declarations";
 import { Value } from './SpecTable';
 
@@ -64,7 +64,7 @@ export default class Preview {
 		return new Preview(items, options, type, yAxis, y2Axis);
 	}
 
-	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: ObjectsTable[], yAxis?: string, y2Axis?: string) {
+	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: DataObject[], yAxis?: string, y2Axis?: string) {
 		const objects = ids.map(id => {
 			const objInfo = objectsTable.find(ot => ot.dobj.endsWith(id));
 
@@ -119,7 +119,7 @@ export default class Preview {
 		throw new Error('Could not initialize Preview');
 	}
 
-	restore(lookup: PreviewLookup, cart: Cart, objectsTable: ObjectsTable[]) {
+	restore(lookup: PreviewLookup, cart: Cart, objectsTable: DataObject[]) {
 		if (this.hasPids) {
 			return this.initPreview(lookup, cart, this.pids.map(pid => config.objectUriPrefix[config.envri] + pid), objectsTable, this.yAxis, this.y2Axis);
 		} else {

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -90,25 +90,25 @@ export type ExtendedDobjInfo = {
 }
 
 export type DataObject = {
-	dobj: string,
-	hasNextVersion: boolean,
-	hasVarInfo?: boolean,
-	dataset: string,
-	fileName: string,
-	format: string,
-	formatLabel?: string,
-	level: number,
-	size: string,
-	spec: string,
-	specLabel?: string,
-	submTime: Date,
-	theme: string,
-	themeLabel?: string,
-	timeEnd: Date,
-	timeStart: Date,
-	type?: string, //this is currently always the same as spec, but maybe was supposed to be PreviewType at some point
-	temporalResolution?: string,
-	extendedDobjInfo?: ExtendedDobjInfo,
+	dobj: string
+	hasNextVersion: boolean
+	hasVarInfo?: boolean
+	dataset: string
+	fileName: string
+	format: string
+	formatLabel?: string
+	level: number
+	size: string
+	spec: string
+	specLabel?: string
+	submTime: Date
+	theme: string
+	themeLabel?: string
+	timeEnd: Date
+	timeStart: Date
+	type?: string //this is currently always the same as spec, but maybe was supposed to be PreviewType at some point
+	temporalResolution?: string
+	extendedDobjInfo?: ExtendedDobjInfo
 }
 
 export interface MetaData extends DO {

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -176,7 +176,8 @@ export interface State {
 		ascending: boolean
 	}
 	paging: Paging
-	cart: Cart
+	cart: Cart 
+	lastCart: Cart | undefined
 	id: UrlStr | undefined
 	metadata?: MetaData | MetaDataWStats
 	station: {} | undefined
@@ -240,6 +241,7 @@ export const defaultState: State = {
 	},
 	paging: new Paging({objCount: 0}),
 	cart: new Cart(),
+	lastCart: undefined,
 	id: undefined,
 	metadata: undefined,
 	station: undefined,
@@ -290,6 +292,7 @@ const serialize = (state: State) => {
 		baseDobjStats: state.baseDobjStats.serialize,
 		paging: state.paging.serialize,
 		cart: undefined,
+		lastCart: undefined,
 		preview: state.preview.serialize,
 		helpStorage: state.helpStorage.serialize
 	};

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -15,7 +15,7 @@ import deepequal from 'deep-equal';
 import {AsyncResult, UrlStr, Sha256Str} from "../backend/declarations";
 import {Store} from "redux";
 import {fetchKnownDataObjects} from "../backend";
-import {DataObject as DO, References} from "../../../common/main/metacore";
+import {DataObject, References} from "../../../common/main/metacore";
 import SpecTable, {Filter, Row} from "./SpecTable";
 import {getLastSegmentInUrl, pick} from "../utils";
 import {FilterNumber, FilterNumbers, FilterNumberSerialized} from "./FilterNumbers";
@@ -90,7 +90,7 @@ export type ExtendedDobjInfo = {
 	biblioInfo?: References
 }
 
-export type DataObject = {
+export type KnownDataObject = {
 	dobj: string
 	hasNextVersion: boolean
 	hasVarInfo?: boolean
@@ -112,7 +112,7 @@ export type DataObject = {
 	extendedDobjInfo?: ExtendedDobjInfo
 }
 
-export interface MetaData extends DO {
+export interface MetaData extends DataObject {
 	id: UrlStr
 }
 
@@ -170,7 +170,7 @@ export interface State {
 	mapProps: MapProps
 	extendedDobjInfo: ExtendedDobjInfo[]
 	formatToRdfGraph: {}
-	objectsTable: DataObject[]
+	objectsTable: KnownDataObject[]
 	sorting: {
 		varName: string,
 		ascending: boolean

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -15,7 +15,6 @@ import deepequal from 'deep-equal';
 import {AsyncResult, UrlStr, Sha256Str} from "../backend/declarations";
 import {Store} from "redux";
 import {fetchKnownDataObjects} from "../backend";
-import {DataObject} from "./CartItem";
 import {DataObject as DO, References} from "../../../common/main/metacore";
 import SpecTable, {Filter, Row} from "./SpecTable";
 import {getLastSegmentInUrl, pick} from "../utils";
@@ -72,25 +71,45 @@ export interface User extends WhoAmI {
 	profile: Profile | {}
 }
 
-type KnownDataObject = AsyncResult<typeof fetchKnownDataObjects>['rows'][0]
 export type ExtendedDobjInfo = {
 	dobj: UrlStr
-	station: string | undefined
-	stationId: string | undefined
-	samplingHeight: number | undefined
-	samplingPoint: string | undefined
-	theme: string | undefined
-	themeIcon: string | undefined
-	title: string | undefined
-	description: string | undefined
-	specComments: string | undefined
-	columnNames: string[] | undefined
-	site: string | undefined
-	hasVarInfo: boolean | undefined
-	dois: UrlStr[] | undefined
-	biblioInfo: References | undefined
+	station?: string
+	stationId?: string
+	samplingHeight?: number
+	samplingPoint?: string
+	theme?: string
+	themeIcon?: string
+	title?: string
+	description?: string
+	specComments?: string
+	columnNames?: string[]
+	site?: string
+	hasVarInfo?: boolean
+	dois?: UrlStr[]
+	biblioInfo?: References
 }
-export type ObjectsTable = KnownDataObject & ExtendedDobjInfo & DataObject & Row<BasicsColNames>;
+
+export type DataObject = {
+	dobj: string,
+	hasNextVersion: boolean,
+	hasVarInfo?: boolean,
+	dataset: string,
+	fileName: string,
+	format: string,
+	formatLabel?: string,
+	level: number,
+	size: string,
+	spec: string,
+	specLabel?: string,
+	submTime: Date,
+	theme: string,
+	themeLabel?: string,
+	timeEnd: Date,
+	timeStart: Date,
+	type?: string, //this is currently always the same as spec, but maybe was supposed to be PreviewType at some point
+	temporalResolution?: string,
+	extendedDobjInfo?: ExtendedDobjInfo,
+}
 
 export interface MetaData extends DO {
 	id: UrlStr
@@ -150,7 +169,7 @@ export interface State {
 	mapProps: MapProps
 	extendedDobjInfo: ExtendedDobjInfo[]
 	formatToRdfGraph: {}
-	objectsTable: ObjectsTable[]
+	objectsTable: DataObject[]
 	sorting: {
 		varName: string,
 		ascending: boolean

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -74,20 +74,20 @@ export interface User extends WhoAmI {
 
 export type ExtendedDobjInfo = {
 	dobj: UrlStr
-	station?: string
-	stationId?: string
-	samplingHeight?: number
-	samplingPoint?: string
-	theme?: string
-	themeIcon?: string
-	title?: string
-	description?: string
-	specComments?: string
-	columnNames?: string[]
-	site?: string
-	hasVarInfo?: boolean
-	dois?: UrlStr[]
-	biblioInfo?: References
+	station: string | undefined
+	stationId: string | undefined
+	samplingHeight: number | undefined
+	samplingPoint: string | undefined
+	theme: string | undefined
+	themeIcon: string | undefined
+	title: string | undefined
+	description: string | undefined
+	specComments: string | undefined
+	columnNames: string[] | undefined
+	site: string | undefined
+	hasVarInfo: boolean | undefined
+	dois: UrlStr[] | undefined
+	biblioInfo: References | undefined
 }
 
 export type KnownDataObject = {

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -1,5 +1,5 @@
 import {Action} from "redux";
-import { LabelLookup, MetaData, MetaDataWStats, StateSerialized, DataObject, TsSettings, WhoAmI} from "../models/State";
+import { LabelLookup, MetaData, MetaDataWStats, StateSerialized, KnownDataObject, TsSettings, WhoAmI} from "../models/State";
 import {Sha256Str, AsyncResult, UrlStr} from "../backend/declarations";
 import {
 	fetchKnownDataObjects,
@@ -96,7 +96,7 @@ export class BackendBatchDownload extends BackendPayload{
 	constructor(readonly isBatchDownloadOk: boolean, readonly user: WhoAmI){super();}
 }
 
-export type ObjectsTableLike = AsyncResult<typeof fetchKnownDataObjects>['rows'] | DataObject[];
+export type ObjectsTableLike = AsyncResult<typeof fetchKnownDataObjects>['rows'] | KnownDataObject[];
 export class BackendObjectsFetched extends BackendPayload{
 	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
 }

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -92,6 +92,10 @@ export class BackendUpdateCart extends BackendPayload{
 	constructor(readonly cart: Cart){super();}
 }
 
+export class BackendUpdateLastCart extends BackendPayload{
+	constructor(readonly cart: Cart){super();}
+}
+
 export class BackendBatchDownload extends BackendPayload{
 	constructor(readonly isBatchDownloadOk: boolean, readonly user: WhoAmI){super();}
 }

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -1,5 +1,5 @@
 import {Action} from "redux";
-import { LabelLookup, MetaData, MetaDataWStats, StateSerialized, StationPos4326Lookup, TsSettings, WhoAmI} from "../models/State";
+import { LabelLookup, MetaData, MetaDataWStats, StateSerialized, DataObject, TsSettings, WhoAmI} from "../models/State";
 import {Sha256Str, AsyncResult, UrlStr} from "../backend/declarations";
 import {
 	fetchKnownDataObjects,
@@ -8,7 +8,6 @@ import {
 } from "../backend";
 import {ColNames, OriginsColNames, SpecTableSerialized} from "../models/CompositeSpecTable";
 import SpecTable, {Filter} from "../models/SpecTable";
-import {DataObject} from "../models/CartItem";
 import {HelpItem} from "../models/HelpStorage";
 import Cart from "../models/Cart";
 import FilterTemporal from "../models/FilterTemporal";

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -11,6 +11,7 @@ import {
 	BackendTsSettings,
 	BackendBatchDownload,
 	BackendUpdateCart,
+	BackendUpdateLastCart,
 	BackendExportQuery
 } from "./actionpayloads";
 import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
@@ -84,6 +85,15 @@ export default function(state: State, payload: BackendPayload): State {
 		return stateUtils.update(state,{
 			cart: payload.cart,
 			checkedObjectsInCart: state.checkedObjectsInCart.filter(uri => payload.cart.ids.includes(uri))
+		});
+	}
+
+	if (payload instanceof BackendUpdateLastCart){
+		console.log("presumably updating state with lastCart")
+		console.log(payload);
+		return stateUtils.update(state,{
+			lastCart: payload.cart,
+			checkedObjectsInCart: []
 		});
 	}
 

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -13,7 +13,7 @@ import {
 	BackendUpdateCart,
 	BackendExportQuery
 } from "./actionpayloads";
-import stateUtils, {CategFilters, ObjectsTable, State} from "../models/State";
+import stateUtils, {CategFilters, DataObject, State} from "../models/State";
 import config, {CategoryType} from "../config";
 import CompositeSpecTable, { ColNames } from "../models/CompositeSpecTable";
 import Paging from "../models/Paging";
@@ -105,7 +105,7 @@ const handleExtendedDataObjInfo = (state: State, payload: BackendExtendedDataObj
 };
 
 const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
-	const objectsTable = payload.objectsTable as ObjectsTable[];
+	const objectsTable = payload.objectsTable as DataObject[];
 	const extendedObjectsTable = objectsTable.map(ot => {
 		const spec = state.specTable.getTableRows('basics').find(r => r.spec === ot.spec);
 		return {...ot, ...spec};

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -88,9 +88,7 @@ export default function(state: State, payload: BackendPayload): State {
 		});
 	}
 
-	if (payload instanceof BackendUpdateLastCart){
-		console.log("presumably updating state with lastCart")
-		console.log(payload);
+	if (payload instanceof BackendUpdateLastCart) {
 		return stateUtils.update(state,{
 			lastCart: payload.cart,
 			checkedObjectsInCart: []

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -13,7 +13,7 @@ import {
 	BackendUpdateCart,
 	BackendExportQuery
 } from "./actionpayloads";
-import stateUtils, {CategFilters, DataObject, State} from "../models/State";
+import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
 import config, {CategoryType} from "../config";
 import CompositeSpecTable, { ColNames } from "../models/CompositeSpecTable";
 import Paging from "../models/Paging";
@@ -105,7 +105,7 @@ const handleExtendedDataObjInfo = (state: State, payload: BackendExtendedDataObj
 };
 
 const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
-	const objectsTable = payload.objectsTable as DataObject[];
+	const objectsTable = payload.objectsTable as KnownDataObject[];
 	const extendedObjectsTable = objectsTable.map(ot => {
 		const spec = state.specTable.getTableRows('basics').find(r => r.spec === ot.spec);
 		return {...ot, ...spec};

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -1,4 +1,4 @@
-import stateUtils, {State, ObjectsTable} from "../models/State";
+import stateUtils, {State, DataObject} from "../models/State";
 import {
 	BootstrapRouteCart,
 	BootstrapRouteMetadata,
@@ -39,7 +39,7 @@ export default function(state: State, payload: BootstrapRoutePayload): State {
 }
 
 const getObjectsTable = (specTable: CompositeSpecTable, objectsTable: ObjectsTableLike) => {
-	return (objectsTable as ObjectsTable[]).map(ot => {
+	return (objectsTable as DataObject[]).map(ot => {
 		const spec = specTable.getTableRows('basics').find(r => r.spec === ot.spec);
 		return {...ot, ...spec};
 	});

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -1,4 +1,4 @@
-import stateUtils, {State, DataObject} from "../models/State";
+import stateUtils, {State, KnownDataObject} from "../models/State";
 import {
 	BootstrapRouteCart,
 	BootstrapRouteMetadata,
@@ -39,7 +39,7 @@ export default function(state: State, payload: BootstrapRoutePayload): State {
 }
 
 const getObjectsTable = (specTable: CompositeSpecTable, objectsTable: ObjectsTableLike) => {
-	return (objectsTable as DataObject[]).map(ot => {
+	return (objectsTable as KnownDataObject[]).map(ot => {
 		const spec = specTable.getTableRows('basics').find(r => r.spec === ot.spec);
 		return {...ot, ...spec};
 	});

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -39,9 +39,9 @@ export default function(state: State, payload: BootstrapRoutePayload): State {
 }
 
 const getObjectsTable = (specTable: CompositeSpecTable, objectsTable: ObjectsTableLike) => {
-	return (objectsTable as KnownDataObject[]).map(ot => {
-		const spec = specTable.getTableRows('basics').find(r => r.spec === ot.spec);
-		return {...ot, ...spec};
+	return (objectsTable as KnownDataObject[]).map(dobj => {
+		const spec = specTable.getTableRows('basics').find(r => r.spec === dobj.spec);
+		return {...dobj, ...spec};
 	});
 };
 


### PR DESCRIPTION
Changes the name of the downloaded file link from "My data" to be based on timestamp, station (if all the same), and spec (if all the same).

First, the `ObjectsTable` type is renamed to `DataObject`. Note that the global `objectsTable` still exists, but is now a `DataObject[]` instead of an `ObjectsTable[]`; thus it is still a table of objects. There were three types that were very similar (`KnownDataObject`, `DataObject`, and `ObjectsTable`), and they were not being used consistently (and runtime violations of types was occurring). Now, they are all `DataObject`s, and thus the code is a bit cleaner and easier to read.

`DownloadButton` is refactored into a functional component to enable use of `useState` and `useMemo`. It now keeps a cache of objects that have been checked in order to generate the filename. This is necessary because `objectsTable` changes based on the pagination, so checked objects from previous pages would no longer have accessible info.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209841505647694