### PR TITLE
Fixup: Remove keyword spec filtering completely

### DIFF
--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -93,16 +93,7 @@ export function getFilters(state: State, forStatCountsQuery: boolean = false): F
 		}
 
 		if (filterKeywords.length > 0){
-			const dobjKeywords = filterKeywords.filter(kw => keywords.dobjKeywords.includes(kw));
-			const kwSpecs = keywordsInfo.lookupSpecs(keywords, filterKeywords);
-			let specs = kwSpecs;
-
-			if (!forStatCountsQuery){
-				const specsFilt = specTable.basics.getDistinctColValues(SPECCOL);
-				specs = (Filter.and([kwSpecs, specsFilt]) || []).filter(Value.isString);
-			}
-
-			filters.push({category: 'keywords', dobjKeywords, specs});
+			filters.push({category: 'keywords', keywords: filterKeywords});
 		}
 
 		const geoFilter = getGeoFilter(state.mapProps)

--- a/src/main/js/portal/main/backend/keywordsInfo.ts
+++ b/src/main/js/portal/main/backend/keywordsInfo.ts
@@ -24,10 +24,6 @@ export default{
 	allKeywords: function(info: KeywordsInfo): string[]{
 		return distinct(Object.keys(info.specLookup).concat(info.dobjKeywords))
 			.sort((a, b) => a.localeCompare(b));
-	},
-
-	lookupSpecs(info: KeywordsInfo, keywords: string[]): UrlStr[]{
-		return distinct(keywords.flatMap(kw => info.specLookup[kw] || []));
 	}
 }
 

--- a/src/main/js/portal/main/models/FilterRequest.ts
+++ b/src/main/js/portal/main/models/FilterRequest.ts
@@ -31,8 +31,7 @@ export interface VariableFilterRequest{
 
 export interface KeywordFilterRequest{
 	category: "keywords"
-	dobjKeywords: string[]
-	specs: UrlStr[]
+	keywords: string[]
 }
 
 export interface GeoFilterRequest{

--- a/src/main/js/portal/main/sparqlQueries.ts
+++ b/src/main/js/portal/main/sparqlQueries.ts
@@ -332,7 +332,7 @@ function getFilterClauses(allFilters: FilterRequest[], supplyVarDefs: boolean): 
 function renderKeywordFilters(requests: KeywordFilterRequest[]): string {
 	const keywordValues =
 		requests.flatMap((req) =>
-			 req.dobjKeywords.map((kw) => `"${kw}"^^xsd:string`)
+			 req.keywords.map((kw) => `"${kw}"^^xsd:string`)
 		);
 
 	if (keywordValues.length === 0) {


### PR DESCRIPTION
Followup of https://github.com/ICOS-Carbon-Portal/data/pull/351
Fixes a current issue where keywords that are no related to data objects result in no filtering.

This removes the the filtering of keywords, which was previously necessary for differentiating between data object keywords and spec/project ones. Since the keyword filter now takes associated entities into account, all of this can go away.