### PR TITLE
[Discussion] Parsing instead of validating PreviewSettings

### DIFF
--- a/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTimeSerie.tsx
@@ -3,7 +3,7 @@ import {distinct, getLastSegmentInUrl, isDefined, wholeStringRegExp} from '../..
 import config, { previewExcludeChartType } from '../../config';
 import {ExtendedDobjInfo, State, TsSetting} from "../../models/State";
 import CartItem from "../../models/CartItem";
-import Preview, {PreviewOption, PreviewSettings, previewVarCompare} from "../../models/Preview";
+import Preview, {PreviewOption, previewVarCompare} from "../../models/Preview";
 import { lastUrlPart, TableFormat } from 'icos-cp-backend';
 import { UrlStr } from '../../backend/declarations';
 import TableFormatCache from '../../../../common/main/TableFormatCache';
@@ -134,7 +134,7 @@ export default function PreviewTimeSerie(props: OurProps) {
 
 	const showChartTypeControl = !previewExcludeChartType.datasets.includes(preview.item.dataset!);
 
-	let params: PreviewSettings & { objId: string } = {
+	let params: Record<string, string | undefined> = {
 		objId: objIds,
 		x: xAxis,
 		linking,
@@ -161,7 +161,7 @@ export default function PreviewTimeSerie(props: OurProps) {
 		.map((param) => param.join('='))
 		.join("&");
 
-	const currentIframeUrl = yAxis ? 
+	const currentIframeUrl = yAxis ?
 		encodeURI(
 			window.document.location.origin
 			+ iFrameBaseUrl

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -1,11 +1,11 @@
 import CartItem, {CartItemSerialized} from './CartItem';
-import {getNewTimeseriesUrl, getLastSegmentInUrl, isDefined} from '../utils';
+import {getNewTimeseriesUrl, getLastSegmentInUrl} from '../utils';
 import config, {PreviewType} from "../config";
 import deepEqual from 'deep-equal';
 import PreviewLookup, {PreviewInfo} from "./PreviewLookup";
 import Cart from "./Cart";
-import {ExtendedDobjInfo, ObjectsTable} from "./State";
-import {IdxSig, Sha256Str, UrlStr} from "../backend/declarations";
+import {ObjectsTable} from "./State";
+import {Sha256Str, UrlStr} from "../backend/declarations";
 import { Value } from './SpecTable';
 
 
@@ -18,34 +18,25 @@ export function previewVarCompare(po1: PreviewOption, po2: PreviewOption): numbe
 	return po1.varTitle.localeCompare(po2.varTitle)
 }
 
-
-const previewSettingsKeys = [
-	'x',
-	'y',
-	'y2',
-	'type',
-	'legendLabels',
-	'legendLabelsY2',
-	'linking',
-	'img',
-	'varName',
-	'extraDim',
-	'date',
-	'gamma',
-	'center',
-	'zoom',
-	'color',
-	'y1',
-	'map'
-] as readonly string[];
-
-export type PreviewSettings = Record<typeof previewSettingsKeys[number], string | undefined>;
-export type PreviewSettings2 = Record<string, string | undefined>;
-
-// Asserts that PreviewSettings and PreviewSettings2 are equal. Stolen from StackOverflow, but verified to work.
-type static_assert<T extends true> = never;
-type _check = static_assert<PreviewSettings extends PreviewSettings2 ? true : false>;
-type _check2 = static_assert<PreviewSettings2 extends PreviewSettings ? true : false>;
+export type PreviewSettings = {
+	x: string,
+	y: string,
+	y2: string,
+	type: string,
+	legendLabels: string,
+	legendLabelsY2: string,
+	linking: string,
+	img: string,
+	varName: string,
+	extraDim: string,
+	date: string,
+	gamma: string,
+	center: string,
+	zoom: string,
+	color: string,
+	y1: string,
+	map: string
+};
 
 
 export interface PreviewSerialized {
@@ -67,21 +58,29 @@ export default class Preview {
 		this.pids = this.items.map(item => getLastSegmentInUrl(item.dobj));
 		this.options = options ?? [];
 		this.type = type;
-		Preview.allowlistPreviewSettings({}); // Should this compile?
-		Preview.allowlistPreviewSettings({something: "yep"}); // This compiles. Probably shouldn't.
-		Preview.allowlistPreviewSettings({something: 123}); // This doesn't compile. Expected since value is not a string.
-
-		this.previewSettings = this.item?.urlParams ? Preview.allowlistPreviewSettings(this.item.urlParams) : {};
+		this.previewSettings = Preview.parsePreviewSettings(this.item?.urlParams || {});
 	}
 
-	static allowlistPreviewSettings(urlParams: PreviewSettings): PreviewSettings {
-		const allowedPreviewSettings: PreviewSettings = {};
-		for (const key in urlParams) {
-			if (previewSettingsKeys.includes(key)) {
-				allowedPreviewSettings[key] = urlParams[key];
-			}
-		}
-		return allowedPreviewSettings;
+	static parsePreviewSettings(params: Record<string, string>): PreviewSettings {
+		return {
+			x: params['x'],
+			y: params['y'],
+			y2: params['y2'],
+			type: params['type'],
+			legendLabels: params['legendLabels'],
+			legendLabelsY2: params['legendLabelsY2'],
+			linking: params['linking'],
+			img: params['img'],
+			varName: params['varName'],
+			extraDim: params['extraDim'],
+			date: params['date'],
+			gamma: params['gamma'],
+			center: params['gamma'],
+			zoom: params['zoom'],
+			color: params['color'],
+			y1: params['y1'],
+			map: params['map']
+		};
 	}
 
 	get serialize(): PreviewSerialized {
@@ -164,9 +163,9 @@ export default class Preview {
 		}
 	}
 
-	withPids(pids: Sha256Str[], previewSettings?: PreviewSettings){
+	withPids(pids: Sha256Str[], previewSettings: PreviewSettings){
 		this.pids = pids;
-		this.previewSettings = previewSettings ?? {};
+		this.previewSettings = previewSettings ?? Preview.parsePreviewSettings({});
 		return this;
 	}
 

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -19,23 +19,23 @@ export function previewVarCompare(po1: PreviewOption, po2: PreviewOption): numbe
 }
 
 export type PreviewSettings = {
-	x: string,
-	y: string,
-	y2: string,
-	type: string,
-	legendLabels: string,
-	legendLabelsY2: string,
-	linking: string,
-	img: string,
-	varName: string,
-	extraDim: string,
-	date: string,
-	gamma: string,
-	center: string,
-	zoom: string,
-	color: string,
-	y1: string,
-	map: string
+	x: string | undefined,
+	y: string | undefined,
+	y2: string | undefined,
+	type: string | undefined,
+	legendLabels: string | undefined,
+	legendLabelsY2: string | undefined,
+	linking: string | undefined,
+	img: string | undefined,
+	varName: string | undefined,
+	extraDim: string | undefined,
+	date: string | undefined,
+	gamma: string | undefined,
+	center: string | undefined,
+	zoom: string | undefined,
+	color: string | undefined,
+	y1: string | undefined,
+	map: string | undefined
 };
 
 

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -61,7 +61,7 @@ export default class Preview {
 		this.previewSettings = Preview.parsePreviewSettings(this.item?.urlParams || {});
 	}
 
-	static parsePreviewSettings(params: Record<string, string>): PreviewSettings {
+	static parsePreviewSettings(params: Record<string, string | undefined>): PreviewSettings {
 		return {
 			x: params['x'],
 			y: params['y'],
@@ -163,7 +163,7 @@ export default class Preview {
 		}
 	}
 
-	withPids(pids: Sha256Str[], previewSettings: PreviewSettings){
+	withPids(pids: Sha256Str[], previewSettings?: PreviewSettings){
 		this.pids = pids;
 		this.previewSettings = previewSettings ?? Preview.parsePreviewSettings({});
 		return this;

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -40,6 +40,13 @@ const previewSettingsKeys = [
 ] as readonly string[];
 
 export type PreviewSettings = Record<typeof previewSettingsKeys[number], string | undefined>;
+export type PreviewSettings2 = Record<string, string | undefined>;
+
+// Asserts that PreviewSettings and PreviewSettings2 are equal. Stolen from StackOverflow, but verified to work.
+type static_assert<T extends true> = never;
+type _check = static_assert<PreviewSettings extends PreviewSettings2 ? true : false>;
+type _check2 = static_assert<PreviewSettings2 extends PreviewSettings ? true : false>;
+
 
 export interface PreviewSerialized {
 	items: CartItemSerialized[]
@@ -60,10 +67,14 @@ export default class Preview {
 		this.pids = this.items.map(item => getLastSegmentInUrl(item.dobj));
 		this.options = options ?? [];
 		this.type = type;
+		Preview.allowlistPreviewSettings({}); // Should this compile?
+		Preview.allowlistPreviewSettings({something: "yep"}); // This compiles. Probably shouldn't.
+		Preview.allowlistPreviewSettings({something: 123}); // This doesn't compile. Expected since value is not a string.
+
 		this.previewSettings = this.item?.urlParams ? Preview.allowlistPreviewSettings(this.item.urlParams) : {};
 	}
 
-	static allowlistPreviewSettings(urlParams: IdxSig | PreviewSettings): PreviewSettings {
+	static allowlistPreviewSettings(urlParams: PreviewSettings): PreviewSettings {
 		const allowedPreviewSettings: PreviewSettings = {};
 		for (const key in urlParams) {
 			if (previewSettingsKeys.includes(key)) {

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -225,7 +225,7 @@ export const defaultState: State = {
 	metadata: undefined,
 	station: undefined,
 	preview: new Preview(),
-	previewSettings: {},
+	previewSettings: Preview.parsePreviewSettings({}),
 	itemsToAddToCart: undefined,
 	toasterData: undefined,
 	batchDownloadStatus: {
@@ -364,7 +364,7 @@ type JsonHashState = {
 
 const allowlistJsonHash = (hash: any): JsonHashState => {
 	const allowedHash: JsonHashState = {};
-	const ps: PreviewSettings = {};
+	const ps: PreviewSettings = Preview.parsePreviewSettings({});
 
 	for (const key in hash) {
 		if (key === "yAxis") {
@@ -376,7 +376,7 @@ const allowlistJsonHash = (hash: any): JsonHashState => {
 		}
 	}
 	allowedHash.previewSettings = (allowedHash.previewSettings ?
-		{ ...Preview.allowlistPreviewSettings(allowedHash.previewSettings), ...ps } :
+		{ ...Preview.parsePreviewSettings(allowedHash.previewSettings), ...ps } :
 		ps);
 
 	return allowedHash;
@@ -393,7 +393,7 @@ const jsonToState = (state0: JsonHashState) => {
 			state.filterNumbers = defaultState.filterNumbers.restore(state0.filterNumbers);
 		}
 
-		state.preview = new Preview().withPids(state0.preview ?? [], state0.previewSettings ?? {});
+		state.preview = new Preview().withPids(state0.preview ?? [], state0.previewSettings);
 
 		if (state0.id){
 			state.id = config.objectUriPrefix[config.envri] + state0.id;

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -9,6 +9,7 @@ import CompositeSpecTable from "../models/CompositeSpecTable";
 import PreviewLookup from "../models/PreviewLookup";
 import Cart from "../models/Cart";
 import CartItem from "../models/CartItem";
+import Preview from "../models/Preview";
 
 // Make sure state updates here forces isRunningInit to false
 type BootstrapState = Partial<State> & {isRunningInit: false}
@@ -57,7 +58,7 @@ const handleRoutePreview = (state: State, payload: BootstrapRoutePreview): State
 		return new CartItem(id, objInfo);
 	}))
 
-	const previewSettings = state.route === "preview" ? state.previewSettings : {};
+	const previewSettings = state.route === "preview" ? state.previewSettings : Preview.parsePreviewSettings({});
 	const preview = state.preview
 			.withPids(payload.pids, previewSettings)
 			.restore(previewLookup, cart, objectsTable);


### PR DESCRIPTION
I am opening this partly as a practical improvement, but mainly as the start for some discussion points and knowledge sharing. It's also an opportunity for me to learn TypeScript a bit better and get more familiar with the frontend code.

The main point I wanted to bring up is based on the famous blog post [Parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/). Follow-up version featuring javascript: https://mtsknn.fi/blog/parse-dont-just-validate/. I highly recommend reading either of them for anyone who has not, but the summary is: `Don't validate input. Instead produce a parsed object, or an error if you cannot`. I noticed that we are doing it the opposite way for `PreviewSettings`, and discussing/improving it may be a good example for future development in `data`.

The only changes I made here, initially are:
- Change `PreviewSettings` into a proper structural type
- Explicitly parse into it, rather than looping over keys
- Change assignments of `{}` to `parsePreviewSettings({})`

I believe the behavior of the code should still be equivalent, but there are already some notable things that pop out:
- The old type of `PreviewSettings` was actually just: `Record<string, string | undefined>`, which is probably not what was intended. Proof in https://github.com/ICOS-Carbon-Portal/data/commit/9f95e9fec7b6b862981b176c50ff475f6bb096eb.
- Because the type now properly includes the members, we get an error about `x` being overwritten here: https://github.com/ICOS-Carbon-Portal/data/blob/master/src/main/js/portal/main/utils.ts#L14. That is maybe correct, but could probably be made clearer. The way I read it, in the old version where we just had a bare object, the `x` acts as a default value if `previewSettings` does not contain it, but that's a bit tricky to see at first glance.
- We also get another type error on the same line, since the type of `PreviewSettings.x` is `string | undefined`, while `getNewUrl` requires an `IdxSig` which requires all values to be defined. This is a result of us changing `PreviewSettings` from an object with optional keys, to an object where all keys are present, but values may be `undefined`. This, in my opinion, is what we want, so that we have more structure and can deal with cases like this explicitly. Otherwise I see no real reason for the `PreviewSettings` type at all, since with all keys optional, it cannot save us from typoes etc. down the line.


**Further discussion**
The key change here is about making `PreviewSettings` into a proper type, which can be parsed into, and also parsing into it. The second part of that is not done in this PR, yet.
I can see the convenience of the original implementation, using reflection to accept values from query params, but I actually don't see how the type `PreviewSettings` helps give any guarantees about correctness of the code. In order to get value out of the structure, we have to parse into it, giving proper types to the members, rather than `string`. At that point, the loop-based approach breaks down.

Secondly, it would be possible to have this code compile by removing `undefined` from the types in `PreviewData`, and change to `parsePreviewSettings(params: Record<string, string>)`. That, however, is not entirely accurate, since access to `params[...]` can give `undefined` for missing keys. This would produce an error if we enable `noUncheckedIndexedAccess`, which I think we should aim for.