### PR TITLE
[portal] Streamline KnownDataObject/ObjectsTable type

### DIFF
--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -1,6 +1,6 @@
 import stateUtils, {
 	MapProps,
-	ObjectsTable,
+	KnownDataObject,
 	Profile,
 	Route,
 	State,
@@ -203,7 +203,7 @@ export function addToCart(ids: UrlStr[]): PortalThunkAction<void> {
 
 		if (user.email) {
 			const newItems = ids.filter(id => !cart.hasItem(id)).map(id => {
-				const objInfo: ObjectsTable | undefined = objectsTable.find(o => o.dobj === id);
+				const objInfo: KnownDataObject | undefined = objectsTable.find(o => o.dobj === id);
 
 				if (objInfo === undefined)
 					throw new Error(`Could not find objTable with id=${id} in ${objectsTable}`);
@@ -269,11 +269,11 @@ export function loadFromError(user: WhoAmI, errorId: string): PortalThunkAction<
 		getError(errorId).then(response => {
 			if (response && response.error && response.error.state) {
 				const stateJSON = JSON.parse(response.error.state);
-				const objectsTable = stateJSON.objectsTable.map((ot: ObjectsTable) => {
-					return Object.assign(ot, {
-						submTime: new Date(ot.submTime),
-						timeStart: new Date(ot.timeStart),
-						timeEnd: new Date(ot.timeEnd)
+				const objectsTable = stateJSON.objectsTable.map((kdobj: KnownDataObject) => {
+					return Object.assign(kdobj, {
+						submTime: new Date(kdobj.submTime),
+						timeStart: new Date(kdobj.timeStart),
+						timeEnd: new Date(kdobj.timeEnd)
 					});
 				});
 				const cart = restoreCart({cart: stateJSON.cart});

--- a/src/main/js/portal/main/components/CartPanel.tsx
+++ b/src/main/js/portal/main/components/CartPanel.tsx
@@ -87,18 +87,18 @@ export default class CartPanel extends Component<Props, State> {
 					</div>
 
 					{
-						props.cart.items.map((objInfo, i) => {
-							const extendedInfo = props.extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
+						props.cart.items.map((cartItem, i) => {
+							const extendedInfo = props.extendedDobjInfo.find(ext => ext.dobj === cartItem.dobj);
 							if (extendedInfo === undefined) return null;
 
-							const isChecked = props.checkedObjectsInCart.includes(objInfo.dobj);
+							const isChecked = props.checkedObjectsInCart.includes(cartItem.dobj);
 
 							return (
 								<SearchResultRegularRow
 									labelLookup={props.labelLookup}
 									extendedInfo={extendedInfo}
 									preview={props.preview}
-									objInfo={objInfo}
+									objInfo={cartItem.knownDataObject}
 									key={'dobj_' + i}
 									updateCheckedObjects={props.updateCheckedObjects}
 									isChecked={isChecked}

--- a/src/main/js/portal/main/components/buttons/CartIcon.tsx
+++ b/src/main/js/portal/main/components/buttons/CartIcon.tsx
@@ -1,12 +1,12 @@
 import React, { Component, CSSProperties } from 'react';
 import { UrlStr } from '../../backend/declarations';
 import { addingToCartProhibition } from '../../models/CartItem';
-import { ObjectsTable } from '../../models/State';
+import { KnownDataObject } from '../../models/State';
 import { styles } from '../styles';
 
 type Props = {
 	style: CSSProperties
-	objInfo: ObjectsTable
+	objInfo: KnownDataObject
 	addToCart: (ids: UrlStr[]) => void
 	removeFromCart: (ids: UrlStr[]) => void
 	isAddedToCart: boolean

--- a/src/main/js/portal/main/components/preview/PreviewTitle.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTitle.tsx
@@ -24,7 +24,7 @@ class PreviewTitle extends Component<OurProps>{
 		const metadataButton = items.length == 1 ? getUrlWithEnvironmentPrefix(items[0].dobj) : '';
 
 		const allowCartAdd = items
-			.map(addingToCartProhibition)
+			.map((cartItem) => addingToCartProhibition(cartItem.knownDataObject))
 			.every(cartProhibition => cartProhibition.allowCartAdd);
 		const uiMessage = allowCartAdd ? "" : "One or more data objects in this preview cannot be downloaded";
 

--- a/src/main/js/portal/main/components/searchResult/SearchResultCompactRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultCompactRow.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import CartIcon from '../buttons/CartIcon';
 import PreviewIcon from '../buttons/PreviewIcon';
 import { formatBytes, formatDateWithOptionalTime, pick, getUrlWithEnvironmentPrefix } from '../../utils';
-import { ExtendedDobjInfo, ObjectsTable, WhoAmI } from "../../models/State";
+import { ExtendedDobjInfo, KnownDataObject, WhoAmI } from "../../models/State";
 import config, { timezone } from '../../config';
 import Preview, { previewAvailability } from '../../models/Preview';
 import PreviewLookup from '../../models/PreviewLookup';
@@ -10,7 +10,7 @@ import { UrlStr } from '../../backend/declarations';
 import CollectionBtn from '../buttons/CollectionBtn';
 
 type Props =  {
-	objInfo: ObjectsTable,
+	objInfo: KnownDataObject,
 	isAddedToCart: boolean,
 	preview: Preview,
 	extendedDobjInfo?: (ExtendedDobjInfo | undefined)[]

--- a/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
@@ -3,7 +3,7 @@ import CheckBtn from '../buttons/CheckBtn';
 import { isSmallDevice, getLastSegmentInUrl, linesToShowStyle, getUrlWithEnvironmentPrefix } from '../../utils';
 import {LinkifyText} from '../LinkifyText';
 import config from '../../config';
-import { ObjectsTable, ExtendedDobjInfo, LabelLookup } from "../../models/State";
+import { KnownDataObject, ExtendedDobjInfo, LabelLookup } from "../../models/State";
 import Preview from '../../models/Preview';
 import CartItem, { addingToCartProhibition } from '../../models/CartItem';
 import { UrlStr } from '../../backend/declarations';
@@ -29,12 +29,12 @@ const iconLevel = [
 ];
 
 interface OurProps {
-	objInfo: ObjectsTable | CartItem
+	objInfo: KnownDataObject | undefined
 	extendedInfo: ExtendedDobjInfo
 	preview: Preview
 	updateCheckedObjects: (ids: string) => void
 	isChecked: boolean
-	checkedObjects?: ObjectsTable[]
+	checkedObjects?: KnownDataObject[]
 	labelLookup: LabelLookup
 	isCartView: Boolean
 }
@@ -44,6 +44,9 @@ export default class SearchResultRegularRow extends Component<OurProps> {
 	render(){
 		const props = this.props;
 		const objInfo = props.objInfo;
+		if (objInfo === undefined) {
+			return;
+		}
 		const extendedInfo = props.extendedInfo.theme && props.extendedInfo.themeIcon
 				? props.extendedInfo
 				: { ...props.extendedInfo, theme: 'Other data', themeIcon: 'https://static.icos-cp.eu/images/themes/oth.svg' }

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import { connect } from 'react-redux';
-import { ObjectsTable, State} from "../../models/State";
+import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
 import {getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
@@ -117,7 +117,7 @@ class SearchResultRegular extends Component<OurProps> {
 
 					<div>
 						{
-							objectsTable.map((objInfo: ObjectsTable, i) => {
+							objectsTable.map((objInfo: KnownDataObject, i) => {
 								const extendedInfo = extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
 
 								return extendedInfo && (

--- a/src/main/js/portal/main/models/CartItem.ts
+++ b/src/main/js/portal/main/models/CartItem.ts
@@ -1,29 +1,10 @@
 import {IdxSig, UrlStr} from "../backend/declarations";
 import { PreviewType, themeUris } from "../config";
-
-export interface DataObject {
-	dobj: string,
-	hasNextVersion: boolean,
-	dataset: string,
-	fileName: string,
-	format: string,
-	formatLabel: string,
-	level: number,
-	size: string,
-	spec: string,
-	specLabel: string,
-	submTime: string,
-	theme: string,
-	themeLabel: string,
-	timeEnd: string,
-	timeStart: string,
-	type: PreviewType | undefined,
-	temporalResolution: string
-}
+import { KnownDataObject} from "./State";
 
 export interface CartItemSerialized {
 	id: string
-	dataobject: DataObject | undefined
+	dataobject: KnownDataObject | undefined
 	type: PreviewType | undefined
 	url: UrlStr | undefined
 	keyValPairs: IdxSig
@@ -31,12 +12,12 @@ export interface CartItemSerialized {
 
 export default class CartItem {
 	private readonly _id: UrlStr;
-	private readonly _dataobject: DataObject | undefined;
+	private readonly _dataobject: KnownDataObject | undefined;
 	private readonly _type: PreviewType | undefined;
 	private readonly _url: UrlStr | undefined;
 	private readonly _keyValPairs: IdxSig;
 
-	constructor(id: string, dataobject?: DataObject, type?: PreviewType, url?: string){
+	constructor(id: string, dataobject?: KnownDataObject, type?: PreviewType, url?: string){
 		this._id = id;
 		this._dataobject = dataobject;
 		this._type = type;
@@ -77,6 +58,10 @@ export default class CartItem {
 
 	get dobj() {
 		return this._id;
+	}
+
+	get knownDataObject() {
+		return this._dataobject;
 	}
 
 	get hasNextVersion() {
@@ -183,15 +168,19 @@ export type CartProhibition = {
 	allowCartAdd: boolean
 	uiMessage?: string
 }
-export function addingToCartProhibition(
-	dobj: {theme: UrlStr, level: number, hasNextVersion: boolean, submTime: Date}
-): CartProhibition {
 
-	if(dobj.submTime.getTime() > Date.now())
-		return {allowCartAdd: false, uiMessage: "This data object is under moratorium"}
+export function addingToCartProhibition(dobj: KnownDataObject | undefined): CartProhibition {
+	if(dobj === undefined) {
+		return { allowCartAdd: false, uiMessage: "This data object has not yet been loaded" }
+	}
 
-	if (dobj.level === 0 && dobj.theme === themeUris.atmospheric)
+	if(dobj.submTime.getTime() > Date.now()) {
+		return { allowCartAdd: false, uiMessage: "This data object is under moratorium" }
+	}
+
+	if (dobj.level === 0 && dobj.theme === themeUris.atmospheric) {
 		return { allowCartAdd: false, uiMessage: "Raw atmospheric data are only available on request at the moment" };
+	}
 
 	return { allowCartAdd: true };
 }

--- a/src/main/js/portal/main/models/Preview.ts
+++ b/src/main/js/portal/main/models/Preview.ts
@@ -4,7 +4,7 @@ import config, {PreviewType} from "../config";
 import deepEqual from 'deep-equal';
 import PreviewLookup, {PreviewInfo} from "./PreviewLookup";
 import Cart from "./Cart";
-import {ExtendedDobjInfo, ObjectsTable} from "./State";
+import {ExtendedDobjInfo, KnownDataObject} from "./State";
 import {IdxSig, Sha256Str, UrlStr} from "../backend/declarations";
 import { Value } from './SpecTable';
 
@@ -90,7 +90,7 @@ export default class Preview {
 		return new Preview(items, options, type);
 	}
 
-	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: ObjectsTable[], yAxis?: string, y2Axis?: string) {
+	initPreview(lookup: PreviewLookup, cart: Cart, ids: UrlStr[], objectsTable: KnownDataObject[], yAxis?: string, y2Axis?: string) {
 		const objects = ids.map(id => {
 			const objInfo = objectsTable.find(ot => ot.dobj.endsWith(id));
 
@@ -145,7 +145,7 @@ export default class Preview {
 		throw new Error('Could not initialize Preview');
 	}
 
-	restore(lookup: PreviewLookup, cart: Cart, objectsTable: ObjectsTable[]) {
+	restore(lookup: PreviewLookup, cart: Cart, objectsTable: KnownDataObject[]) {
 		if (this.hasPids) {
 			return this.initPreview(lookup, cart, this.pids.map(pid => config.objectUriPrefix[config.envri] + pid), objectsTable);
 		} else {

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -12,11 +12,9 @@ import config, {
 	numberFilterKeys
 } from "../config";
 import deepequal from 'deep-equal';
-import {AsyncResult, UrlStr, Sha256Str} from "../backend/declarations";
+import { UrlStr, Sha256Str } from "../backend/declarations";
 import {Store} from "redux";
-import {fetchKnownDataObjects} from "../backend";
-import {DataObject} from "./CartItem";
-import {DataObject as DO, References} from "../../../common/main/metacore";
+import { DataObject, References } from "../../../common/main/metacore";
 import SpecTable, {Filter, Row} from "./SpecTable";
 import {getLastSegmentInUrl, pick} from "../utils";
 import {FilterNumber, FilterNumbers, FilterNumberSerialized} from "./FilterNumbers";
@@ -72,7 +70,28 @@ export interface User extends WhoAmI {
 	profile: Profile | {}
 }
 
-type KnownDataObject = AsyncResult<typeof fetchKnownDataObjects>['rows'][0]
+export type KnownDataObject = {
+	dobj: string
+	hasNextVersion: boolean
+	hasVarInfo?: boolean
+	dataset: string
+	fileName: string
+	format: string
+	formatLabel?: string
+	level: number
+	size: string
+	spec: string
+	specLabel?: string
+	submTime: Date
+	theme: string
+	themeLabel?: string
+	timeEnd: Date
+	timeStart: Date
+	type?: string //this is currently always the same as spec, but maybe was supposed to be PreviewType at some point
+	temporalResolution?: string
+	extendedDobjInfo?: ExtendedDobjInfo
+}
+
 export type ExtendedDobjInfo = {
 	dobj: UrlStr
 	station: string | undefined
@@ -90,9 +109,8 @@ export type ExtendedDobjInfo = {
 	dois: UrlStr[] | undefined
 	biblioInfo: References | undefined
 }
-export type ObjectsTable = KnownDataObject & ExtendedDobjInfo & DataObject & Row<BasicsColNames>;
 
-export interface MetaData extends DO {
+export interface MetaData extends DataObject {
 	id: UrlStr
 }
 
@@ -150,7 +168,7 @@ export interface State {
 	mapProps: MapProps
 	extendedDobjInfo: ExtendedDobjInfo[]
 	formatToRdfGraph: {}
-	objectsTable: ObjectsTable[]
+	objectsTable: KnownDataObject[]
 	sorting: {
 		varName: string,
 		ascending: boolean

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -1,5 +1,13 @@
 import {Action} from "redux";
-import { LabelLookup, MetaData, MetaDataWStats, StateSerialized, StationPos4326Lookup, TsSettings, WhoAmI} from "../models/State";
+import {
+	KnownDataObject,
+	LabelLookup,
+	MetaData,
+	MetaDataWStats,
+	StateSerialized,
+	TsSettings,
+	WhoAmI
+} from "../models/State";
 import {Sha256Str, AsyncResult, UrlStr} from "../backend/declarations";
 import {
 	fetchKnownDataObjects,
@@ -8,7 +16,6 @@ import {
 } from "../backend";
 import {ColNames, OriginsColNames, SpecTableSerialized} from "../models/CompositeSpecTable";
 import SpecTable, {Filter} from "../models/SpecTable";
-import {DataObject} from "../models/CartItem";
 import {HelpItem} from "../models/HelpStorage";
 import Cart from "../models/Cart";
 import FilterTemporal from "../models/FilterTemporal";
@@ -95,7 +102,7 @@ export class BackendBatchDownload extends BackendPayload{
 	constructor(readonly isBatchDownloadOk: boolean, readonly user: WhoAmI){super();}
 }
 
-export type ObjectsTableLike = AsyncResult<typeof fetchKnownDataObjects>['rows'] | DataObject[];
+export type ObjectsTableLike = AsyncResult<typeof fetchKnownDataObjects>['rows'] | KnownDataObject[];
 export class BackendObjectsFetched extends BackendPayload{
 	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
 }

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -14,7 +14,7 @@ import {
 	BackendUpdateCart,
 	BackendExportQuery
 } from "./actionpayloads";
-import stateUtils, {CategFilters, ObjectsTable, State} from "../models/State";
+import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
 import config, {CategoryType} from "../config";
 import CompositeSpecTable, { ColNames } from "../models/CompositeSpecTable";
 import Paging from "../models/Paging";
@@ -112,7 +112,7 @@ const handleExtendedDataObjInfo = (state: State, payload: BackendExtendedDataObj
 };
 
 const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
-	const objectsTable = payload.objectsTable as ObjectsTable[];
+	const objectsTable = payload.objectsTable as KnownDataObject[];
 	const extendedObjectsTable = objectsTable.map(ot => {
 		const spec = state.specTable.getTableRows('basics').find(r => r.spec === ot.spec);
 		return {...ot, ...spec};

--- a/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
+++ b/src/main/js/portal/main/reducers/bootstrapRouteReducer.ts
@@ -1,4 +1,4 @@
-import stateUtils, {State, ObjectsTable} from "../models/State";
+import stateUtils, {State, KnownDataObject} from "../models/State";
 import {
 	BootstrapRouteCart,
 	BootstrapRouteMetadata,
@@ -39,9 +39,9 @@ export default function(state: State, payload: BootstrapRoutePayload): State {
 }
 
 const getObjectsTable = (specTable: CompositeSpecTable, objectsTable: ObjectsTableLike) => {
-	return (objectsTable as ObjectsTable[]).map(ot => {
-		const spec = specTable.getTableRows('basics').find(r => r.spec === ot.spec);
-		return {...ot, ...spec};
+	return (objectsTable as KnownDataObject[]).map(kdobj => {
+		const spec = specTable.getTableRows('basics').find(r => r.spec === kdobj.spec);
+		return {...kdobj, ...spec};
 	});
 };
 


### PR DESCRIPTION
The type `ObjectsTable` is a constructed type that is currently not obeyed by our runtime code; thus, it will be changed to reflect reality and ensure type safety. Here, we redefine it to `KnownDataObject`, a previously used type which is expanded to accomodate optional properties and explicitly defined to prevent conflicts and `never` types.

Additionally, `ObjectsTable` is not a great name; a single `ObjectsTable` is not a table of multiple objects, but instead the information about a single object. Note that an array of `KnownDataObjects` is still often known as an `objectsTable`; this makes sense, as it is a table of known data objects, but this could be changed if it is unclear.

---------

The previous definition of `ObjectsTable` was:
```ts
type ObjectsTable = KnownDataObject & ExtendedDobjInfo & DataObject & Row<BasicsColNames>;
```

Which combines four types into a single type:
- `models/State.ts` - `KnownDataObject`
- `models/State.ts` - `ExtendedDobjInfo`
- `models/CartItem.ts` - `DataObject`
- `models/SpecTable.ts` - `Row`

The actual computed type of  `ObjectsTable` is:
```ts
type ObjectsTable = {
    // From all 4 types (merged properties)
    dobj: string; // From KnownDataObject & ExtendedDobjInfo & DataObject
    dataset: string; // From DataObject & Row<BasicColNames>
    fileName: string; // From KnownDataObject & DataObject
    hasNextVersion: boolean; // From KnownDataObject & DataObject
    hasVarInfo: boolean; // From KnownDataObject & ExtendedDobjInfo
    level: number; // From DataObject & Row<BasicColNames>
    spec: string; // From KnownDataObject & DataObject & Row<BasicColNames>
    theme: string; // From DataObject & Row<BasicColNames>
    
    // From KnownDataObject and DataObject (conflicts make these unusable)
    size: never; // number (KnownDataObject) vs string (DataObject)
    submTime: never; // Date (KnownDataObject) vs string (DataObject)
    timeStart: never; // Date (KnownDataObject) vs string (DataObject)
    timeEnd: never; // Date (KnownDataObject) vs string (DataObject)
    
    // From ExtendedDobjInfo
    biblioInfo: References | undefined;
    columnNames: string[] | undefined;
    description: string | undefined;
    dois: UrlStr[] | undefined;
    samplingHeight: number | undefined;
    samplingPoint: string | undefined;
    specComments: string | undefined;
    station: string | undefined;
    stationId: string | undefined;
    themeIcon: string | undefined;
    title: string | undefined;
    site: string | undefined;
    
    // From DataObject
    format: string;
    formatLabel: string;
    specLabel: string;
    temporalResolution: string;
    type: PreviewType | undefined;
    
    // From Row<BasicColNames>
    project: number | string | undefined;
};
```

We then go on to use this `ObjectsTable` construction often, but in reality, the type of `ObjectsTable` is much simpler. For example, one object is:
```ts
ot: ObjectsTable = {
    dataset: "http://meta.icos-cp.eu/resources/cpmeta/etcMeteosenseDataset"
    dobj: "https://meta.icos-cp.eu/objects/-6kxWk4RgNP4USDmiHglG_RG"
    fileName: "ICOSETC_SE-Svb_METEOSENS_NRT.zip"
    format: "http://meta.icos-cp.eu/ontologies/cpmeta/asciiEtcHalfHourlyProductTimeSer"
    hasNextVersion: false
    hasVarInfo: undefined
    level: 1
    project: "http://meta.icos-cp.eu/resources/projects/icos"
    size: 733535
    spec: "http://meta.icos-cp.eu/resources/cpmeta/etcNrtMeteosens"
    submTime: Fri Apr 11 2025 08:10:11 GMT+0200 (Central European Summer Time) {}
    temporalResolution: undefined
    theme: "http://meta.icos-cp.eu/resources/themes/ecosystem"
    timeEnd: Fri Apr 11 2025 01:00:00 GMT+0200 (Central European Summer Time) {}
    timeStart: Tue Dec 31 2024 23:30:00 GMT+0100 (Central European Standard Time) {}
    type: "http://meta.icos-cp.eu/resources/cpmeta/etcNrtMeteosens"
}
```

Thus, we can rename `ObjectsTable` type to `KnownDataObject`. This reflects the actual content (the fetched contents of a data object) and matches existing code conventions, including function names like `fetchKnownDataObjects`; it also avoids conflict with the `metacore` type `DateObject`, ensuring clarity.
