### PR TITLE
Change static resource cache max-age to 1 hour

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/data/routes/StaticRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/data/routes/StaticRouting.scala
@@ -65,7 +65,7 @@ class StaticRouting()(using envriConfigs: EnvriConfigs) {
 				redirect("/" + proj + "/", StatusCodes.Found)
 			} ~
 			rawPathPrefix(maybeDobjVis(proj)){pageFactory =>
-				val caches = Seq(headers.CacheDirectives.public, headers.CacheDirectives.`max-age`(86400))
+				val caches = Seq(headers.CacheDirectives.public, headers.CacheDirectives.`max-age`(3600))
 				respondWithHeader(headers.`Cache-Control`(caches)){
 					pathEndOrSingleSlash{
 						if(pageFactory.isDefinedAt(prEnvri)) complete(pageFactory(prEnvri))


### PR DESCRIPTION
Will now invalidate cache after 1 hour, causing check of eTags and static resource updates sooner.