### PR TITLE
[portal] Rename data cart intelligently

### DIFF
--- a/src/main/js/portal/main/actions/cart.ts
+++ b/src/main/js/portal/main/actions/cart.ts
@@ -3,7 +3,7 @@ import * as Payloads from "../reducers/actionpayloads";
 import {UrlStr} from "../backend/declarations";
 import Cart from "../models/Cart";
 import {fetchKnownDataObjects, fetchLabelLookup, getExtendedDataObjInfo, getIsBatchDownloadOk, getWhoIam, saveCart} from "../backend";
-import {failWithError, fetchCart, getBackendTables} from "./common";
+import {failWithError, fetchCart, getBackendTables, updateCart} from "./common";
 import {saveToRestheart} from "../../../common/main/backend";
 import {WhoAmI} from "../models/State";
 import { getLastSegmentInUrl } from "../utils";
@@ -51,10 +51,10 @@ export function setCartName(newName: string): PortalThunkAction<void> {
 	};
 }
 
-function updateCart(email: string | null, cart: Cart): PortalThunkAction<Promise<any>> {
-	return dispatch => saveCart(email, cart).then(() =>
-		dispatch(new Payloads.BackendUpdateCart(cart))
-	);
+function updatePriorCart(cart: Cart): PortalThunkAction<void> {
+	return dispatch => {
+		dispatch(new Payloads.BackendUpdatePriorCart(cart));
+	};
 }
 
 export function logCartDownloadClick(fileName: string, pids: string[]) {
@@ -78,4 +78,19 @@ export function updateCheckedObjectsInCart(checkedObjectInCart: UrlStr | UrlStr[
 	return (dispatch) => {
 		dispatch(new Payloads.UiUpdateCheckedObjsInCart(checkedObjectInCart));
 	};
+}
+
+export function emptyCart(): PortalThunkAction<void> {
+	return (dispatch, getState) => {
+		const state = getState();
+		dispatch(updatePriorCart(state.cart));
+		dispatch(updateCart(state.user.email, new Cart(undefined, [])));
+	}
+}
+
+export function restorePriorCart(): PortalThunkAction<void> {
+	return (dispatch, getState) => {
+		const state = getState();
+		dispatch(updateCart(state.user.email, state.priorCart ?? state.cart));
+	}
 }

--- a/src/main/js/portal/main/actions/cart.ts
+++ b/src/main/js/portal/main/actions/cart.ts
@@ -2,7 +2,7 @@ import {PortalThunkAction} from "../store";
 import * as Payloads from "../reducers/actionpayloads";
 import {UrlStr} from "../backend/declarations";
 import Cart from "../models/Cart";
-import {fetchKnownDataObjects, fetchLabelLookup, getExtendedDataObjInfo, getIsBatchDownloadOk, getWhoIam, saveCart} from "../backend";
+import {fetchKnownDataObjects, fetchLabelLookup, getExtendedDataObjInfo, getIsBatchDownloadOk, getWhoIam} from "../backend";
 import {failWithError, fetchCart, getBackendTables, updateCart} from "./common";
 import {saveToRestheart} from "../../../common/main/backend";
 import {WhoAmI} from "../models/State";
@@ -80,10 +80,11 @@ export function updateCheckedObjectsInCart(checkedObjectInCart: UrlStr | UrlStr[
 	};
 }
 
-export function emptyCart(): PortalThunkAction<void> {
+export function emptyCart(filename: string): PortalThunkAction<void> {
 	return (dispatch, getState) => {
 		const state = getState();
-		dispatch(updatePriorCart(state.cart));
+		const priorCart = state.cart.name ? state.cart : state.cart.withName(filename);
+		dispatch(updatePriorCart(priorCart));
 		dispatch(updateCart(state.user.email, new Cart(undefined, [])));
 	}
 }

--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -155,7 +155,7 @@ export function fetchCart(user: WhoAmI): PortalThunkAction<Promise<void>> {
 	};
 }
 
-function updateCart(email: string | null, cart: Cart): PortalThunkAction<Promise<any>> {
+export function updateCart(email: string | null, cart: Cart): PortalThunkAction<Promise<any>> {
 	const cartLinks = document.querySelectorAll('.cart-link');
 	cartLinks.forEach(link => {
 		const num = link.querySelector('.items-number')

--- a/src/main/js/portal/main/components/CartPanel.tsx
+++ b/src/main/js/portal/main/components/CartPanel.tsx
@@ -5,12 +5,14 @@ import SearchResultRegularRow from './searchResult/SearchResultRegularRow';
 import CartBtn from './buttons/CartBtn';
 import CheckAllBoxes from './controls/CheckAllBoxes';
 import { DataCartProps } from '../containers/DataCart';
+import { useDownloadInfo } from '../hooks/useDownloadInfo';
 
 type Props = {
 	previewitemId?: string
 	previewItemAction: (urls: string[]) => void
 	updateCheckedObjects: (urls: any) => any
 	handleAllCheckboxesChange: () => void
+	downloadInfo: ReturnType<typeof useDownloadInfo>
 } & DataCartProps
 
 type State = {
@@ -51,6 +53,7 @@ export default class CartPanel extends Component<Props, State> {
 			<div className="card">
 				<EditablePanelHeading
 					editValue={props.cart.name}
+					defaultShownValue={props.downloadInfo.filename}
 					saveValueAction={this.handleSaveCartName.bind(this)}
 					iconEditClass="fas fa-edit"
 					iconEditTooltip="Edit download name"

--- a/src/main/js/portal/main/components/controls/EditablePanelHeading.tsx
+++ b/src/main/js/portal/main/components/controls/EditablePanelHeading.tsx
@@ -2,6 +2,7 @@ import React, { Component, CSSProperties, RefObject } from 'react';
 
 type Props = {
 	editValue: string
+	defaultShownValue?: string
 	saveValueAction: (newName: string) => void
 	iconEditClass: string
 	iconEditTooltip: string
@@ -39,14 +40,15 @@ export default class EditablePanelHeading extends Component<Props, State>{
 
 	render(){
 		const {editMode} = this.state;
-		const { editValue, iconEditClass, iconEditTooltip, iconSaveClass, iconSaveTooltip } = this.props;
+		const { editValue, iconEditClass, iconEditTooltip, iconSaveClass,
+			iconSaveTooltip, defaultShownValue } = this.props;
 		const style: CSSProperties = { position: 'absolute', top: 0, left: -20, margin: '0 20px' };
-
+		const cardTitle = (defaultShownValue && !editValue) ? defaultShownValue + " (default, click to edit)" : editValue;
 		return (
 			<>
 				{ editMode ?
 					<div className="card-header">
-						<span className="card-title">{editValue}</span>
+						<span className="card-title">{cardTitle}</span>
 						<form className="input-group" style={style} onSubmit={this.handleSaveClick.bind(this)}>
 							<input
 								ref={this.editCtrl}
@@ -62,7 +64,7 @@ export default class EditablePanelHeading extends Component<Props, State>{
 					</div>
 					:
 					<div className="card-header" onClick={this.handleIconClick.bind(this)} style={{cursor: 'pointer'}} title={iconEditTooltip}>
-						<span className="card-title">{editValue}</span>
+						<span className="card-title">{cardTitle}</span>
 						<span
 							className={iconEditClass}
 							style={{float: 'left', margin: '3px 5px'}}

--- a/src/main/js/portal/main/components/preview/PreviewTitle.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewTitle.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from "react-redux";
 import { addToCart, removeFromCart } from '../../actions/common';
 import { UrlStr } from '../../backend/declarations';
@@ -8,6 +8,7 @@ import { PortalDispatch } from '../../store';
 import { getUrlWithEnvironmentPrefix, specLabelDisplay } from '../../utils';
 import CartBtn from '../buttons/CartBtn';
 import DownloadButton from '../buttons/DownloadButton';
+import { useDownloadInfo } from '../../hooks/useDownloadInfo';
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
@@ -30,6 +31,10 @@ function PreviewTitle(props: OurProps) {
 	const actionButtonType = areItemsInCart ? 'remove' : 'add';
 	const buttonAction = areItemsInCart ? handleRemoveFromCart : handleAddToCart;
 
+	const localObjectsTable = items.flatMap((x) => x.knownDataObject ? [x.knownDataObject] : [])
+	const { filename } = useDownloadInfo({readyObjectIds: localObjectsTable.map((x) => x.dobj), objectsTable: localObjectsTable,
+			extendedDobjInfo, labelLookup});
+
 	return (
 		<>
 			<h1 className="col-md-8">
@@ -46,7 +51,8 @@ function PreviewTitle(props: OurProps) {
 				/>
 				<DownloadButton
 					style={{}}
-					checkedObjects={items.map((item: CartItem) => item.dobj)}
+					filename={filename}
+					readyObjectIds={items.map((item: CartItem) => item.dobj)}
 					enabled={allowCartAdd}
 				/>
 			</div>

--- a/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
@@ -5,7 +5,7 @@ import {LinkifyText} from '../LinkifyText';
 import config from '../../config';
 import { KnownDataObject, ExtendedDobjInfo, LabelLookup } from "../../models/State";
 import Preview from '../../models/Preview';
-import CartItem, { addingToCartProhibition } from '../../models/CartItem';
+import { addingToCartProhibition } from '../../models/CartItem';
 import { UrlStr } from '../../backend/declarations';
 import CollectionBtn from '../buttons/CollectionBtn';
 

--- a/src/main/js/portal/main/components/ui/Message.tsx
+++ b/src/main/js/portal/main/components/ui/Message.tsx
@@ -2,17 +2,24 @@ import React, { Component, ReactNode } from 'react';
 
 type Props = {
 	title: string
-	onclick: () => void
+	findData: () => void
+	restorePriorCart?: () => void
 }
 
 export default class Message extends Component<Props>{
 	render() {
+		const buttonRestorePriorCart = this.props.restorePriorCart ? 
+			(<button className="btn btn-lg btn-warning d-block mx-auto my-3" onClick={this.props.restorePriorCart}>
+				Restore previous cart
+			</button>) :
+			<></>;
 		return (
 			<div className="text-center" style={{ margin: '5vh 0' }}>
 				<h1 className='pb-3'>{this.props.title}</h1>
-				<button className="btn btn-lg btn-primary" onClick={this.props.onclick}>
+				<button className="btn btn-lg btn-primary" onClick={this.props.findData}>
 					Find data
 				</button>
+				{ buttonRestorePriorCart }
 			</div>
 		)
 	}

--- a/src/main/js/portal/main/containers/DataCart.tsx
+++ b/src/main/js/portal/main/containers/DataCart.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import CartPanel from '../components/CartPanel';
 import {
@@ -15,7 +15,8 @@ import {PortalDispatch} from "../store";
 import {Profile, Route, State} from "../models/State";
 import {removeFromCart, updateRoute} from "../actions/common";
 import Message from '../components/ui/Message';
-
+import DownloadButton from '../components/buttons/DownloadButton';
+import { useDownloadInfo } from '../hooks/useDownloadInfo';
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
@@ -43,22 +44,27 @@ function DataCart(props: DataCartProps) {
 	}
 
 	function handleDownload() {
-		const {name, pids} = props.cart;
-		logCartDownloadClick(name, pids);
-		props.emptyCart();
+		logCartDownloadClick(filename, hashes);
+		props.emptyCart(filename);
 	}
 
 	function handleRestore() {
 		props.restorePriorCart();
 	}
 
-	const {preview, user, cart, priorCart, updateCheckedObjectsInCart} = props;
+	const {preview, user, cart, priorCart, updateCheckedObjectsInCart, extendedDobjInfo, labelLookup} = props;
+	const localObjectsTable = props.cart.items.flatMap((x) => x.knownDataObject ? [x.knownDataObject] : [])
+	const downloadInfo = useDownloadInfo({readyObjectIds: localObjectsTable.map((x) => x.dobj),
+		objectsTable: localObjectsTable, extendedDobjInfo, labelLookup});
+
 	const previewitemId = preview.item ? preview.item.dobj : undefined;
+
 	const downloadTitle = user.email && (user.profile as Profile).icosLicenceOk
 		? 'Download cart content'
 		: 'Accept license and download cart content';
-	const fileName = cart.count == 0 && priorCart ? priorCart.name : cart.name;
-	const hashes = cart.count == 0 && priorCart ? JSON.stringify(priorCart.pids) : JSON.stringify(cart.pids);
+
+	const filename = cart.count == 0 && priorCart ? priorCart.name : (cart.name ? cart.name : downloadInfo.filename);
+	const hashes = cart.count == 0 && priorCart ? priorCart.pids : cart.pids;
 	const showCartPanel = !cart.isInitialized || cart.count > 0;
 
 	return (
@@ -71,6 +77,7 @@ function DataCart(props: DataCartProps) {
 							previewItemAction={handlePreview}
 							updateCheckedObjects={updateCheckedObjectsInCart}
 							handleAllCheckboxesChange={handleAllCheckboxesChange}
+							downloadInfo={downloadInfo}
 							{...props}
 						/>
 					</div>
@@ -80,16 +87,13 @@ function DataCart(props: DataCartProps) {
 								{downloadTitle}
 							</div>
 							<div className="card-body text-center">
-
-								<form action="/objects" method="post" onSubmit={handleDownload} target="_blank">
-									<input type="hidden" name="fileName" value={fileName} />
-									<input type="hidden" name="ids" value={hashes} />
-
-									<button className="btn btn-warning" style={{marginBottom: 15, whiteSpace: 'normal'}}>
-										<span className="fas fa-download" style={{marginRight:9}} />Download
-									</button>
-								</form>
-
+								<DownloadButton
+									style={{}}
+									filename={filename}
+									readyObjectIds={hashes}
+									enabled={true}
+									onSubmitAsForm={handleDownload}
+								/>
 								<div style={{textAlign: 'center', fontSize:'90%'}}>
 									Total size: {formatBytes(cart.size)} (uncompressed)
 								</div>
@@ -102,7 +106,7 @@ function DataCart(props: DataCartProps) {
 				<Message
 					title="Your cart is empty"
 					findData={() => handleRouteClick('search')}
-					restorePriorCart={props.priorCart ? handleRestore : undefined}
+					restorePriorCart={priorCart ? handleRestore : undefined}
 				/>
 			</div>
 		</>
@@ -129,7 +133,7 @@ function dispatchToProps(dispatch: PortalDispatch | Function){
 		fetchIsBatchDownloadOk: () => dispatch(fetchIsBatchDownloadOk),
 		updateCheckedObjectsInCart: (ids: UrlStr[]) => dispatch(updateCheckedObjectsInCart(ids)),
 		removeFromCart: (ids: UrlStr[]) => dispatch(removeFromCart(ids)),
-		emptyCart: () => dispatch(emptyCart()),
+		emptyCart: (filename: string) => dispatch(emptyCart(filename)),
 		restorePriorCart: () => dispatch(restorePriorCart())
 	};
 }

--- a/src/main/js/portal/main/containers/Preview.tsx
+++ b/src/main/js/portal/main/containers/Preview.tsx
@@ -62,7 +62,7 @@ class Preview extends Component<OurProps, OurState> {
 			return(
 				<Message
 					title="No data found"
-					onclick={this.handleSearchRouteClick.bind(this)} />
+					findData={this.handleSearchRouteClick.bind(this)} />
 			)
 		} else {
 			return (

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -114,10 +114,10 @@ function SearchResultRegular(props: OurProps) {
 
 				</div>
 
-					<div>
-						{
-							objectsTable.map((objInfo: KnownDataObject, i) => {
-								const extendedInfo = extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
+				<div>
+					{
+						objectsTable.map((objInfo: KnownDataObject, i) => {
+							const extendedInfo = extendedDobjInfo.find(ext => ext.dobj === objInfo.dobj);
 
 							return extendedInfo && (
 								<SearchResultRegularRow

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
@@ -13,6 +13,7 @@ import HelpButton from "../help/HelpButton";
 import SearchResultRegularRow from "../../components/searchResult/SearchResultRegularRow";
 import { addingToCartProhibition } from '../../models/CartItem';
 import DownloadButton from '../../components/buttons/DownloadButton';
+import { useDownloadInfo } from '../../hooks/useDownloadInfo';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
@@ -39,8 +40,11 @@ function SearchResultRegular(props: OurProps) {
 		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
-	const checkedUriSet = new Set<string>(checkedObjectsInSearch)
-	const checkedObjects = objectsTable.filter(o => checkedUriSet.has(o.dobj))
+	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
+	const checkedObjects = objectsTable.filter(o => checkedUriSet.has(o.dobj));
+
+	const { filename } = useDownloadInfo({readyObjectIds: checkedObjectsInSearch, objectsTable,
+		extendedDobjInfo, labelLookup});
 
 	return (
 		<div className="card">
@@ -106,7 +110,8 @@ function SearchResultRegular(props: OurProps) {
 
 						<DownloadButton
 							style={{}}
-							checkedObjects={checkedObjectsInSearch}
+							filename={filename}
+							readyObjectIds={checkedObjectsInSearch}
 							enabled={checkedObjectsInSearch.length > 0}
 						/>
 

--- a/src/main/js/portal/main/hooks/useDownloadInfo.ts
+++ b/src/main/js/portal/main/hooks/useDownloadInfo.ts
@@ -1,0 +1,93 @@
+import { useMemo, useState, useEffect } from 'react';
+import { KnownDataObject, ExtendedDobjInfo, LabelLookup } from '../models/State';
+
+
+type ReadyInfo = {
+	spec?: string;
+	stationId?: string;
+};
+
+type InfoCache = Record<string, ReadyInfo>;
+
+interface Props {
+	readyObjectIds: string[];
+	objectsTable: KnownDataObject[]
+	extendedDobjInfo: ExtendedDobjInfo[]
+	labelLookup: LabelLookup
+}
+
+export function useDownloadInfo(props: Props) {
+    const { readyObjectIds, objectsTable, extendedDobjInfo, labelLookup } = props;
+	const [infoCache, setInfoCache] = useState<InfoCache>({});
+
+	useEffect(() => {
+		const newCache: InfoCache = {};
+		let updateCache = false;
+
+		for (const readyObjectId of readyObjectIds) {
+			if (!infoCache[readyObjectId]) {
+				const spec = objectsTable.find(
+					(dataObject) => dataObject.dobj === readyObjectId
+				)?.spec;
+
+				const stationId = extendedDobjInfo.find(
+					(edobj) => edobj.dobj === readyObjectId
+				)?.stationId;
+
+				newCache[readyObjectId] = { spec, stationId };
+				updateCache = true;
+			}
+		}
+
+		if (updateCache) {
+			setInfoCache((prev) => ({ ...prev, ...newCache }));
+		}
+	}, [readyObjectIds, objectsTable, extendedDobjInfo]);
+
+	const readyObjectsInfo: InfoCache = useMemo(() => {
+		const readyInfo: InfoCache = {};
+		for (const readyObjectId of readyObjectIds) {
+			if (infoCache[readyObjectId]) {
+				readyInfo[readyObjectId] = infoCache[readyObjectId];
+			}
+		}
+		return readyInfo;
+	}, [infoCache, readyObjectIds]);
+
+	const filename: string = useMemo(() => {
+		const separator = "_";
+		const multiSeparatorRegExp = new RegExp(`[${separator}]+`, "g");
+		const endSeparatorRegExp = new RegExp(`[${separator}]$`);
+
+		const today = new Date();
+		const [year, month, date, hour, minute] = [
+			today.getFullYear(),
+			(today.getMonth() + 1).toString().padStart(2,"0"),
+			today.getDate().toString().padStart(2,"0"),
+			today.getHours().toString().padStart(2,"0"),
+			today.getMinutes().toString().padStart(2,"0")
+		];
+
+		const timestamp = `${year}-${month}-${date}_${hour}${minute}`;
+
+		const stationIdsArr: string[] = Object.values(readyObjectsInfo)
+			.flatMap((info) => info.stationId ? [info.stationId] : [""]);
+		const stationId = (new Set(stationIdsArr)).size === 1 ? stationIdsArr[0] : "";
+
+		const specsArr: string[] = Object.values(readyObjectsInfo)
+			.flatMap((info) => info.spec ? [info.spec] : [""]);
+		const spec = (new Set(specsArr)).size === 1 ? specsArr[0] : "";
+
+		const specLabel = spec ? labelLookup[spec].label : "";
+		const postfix = (specLabel || stationId) ? "" : "downloaded" + separator + "data";
+		const filenameArr = [timestamp, specLabel, stationId, postfix];
+		const filename = filenameArr.join(separator)
+			.replaceAll(/[^0-9a-zA-Z\-._]/g, separator)
+			.replaceAll(multiSeparatorRegExp, separator)
+			.replace(endSeparatorRegExp, "");
+
+		return filename;
+	}, [readyObjectsInfo]);
+
+	return { filename };
+}

--- a/src/main/js/portal/main/hooks/useDownloadInfo.ts
+++ b/src/main/js/portal/main/hooks/useDownloadInfo.ts
@@ -10,7 +10,7 @@ type ReadyInfo = {
 type InfoCache = Record<string, ReadyInfo>;
 
 interface Props {
-	readyObjectIds: string[];
+	readyObjectIds: string[]
 	objectsTable: KnownDataObject[]
 	extendedDobjInfo: ExtendedDobjInfo[]
 	labelLookup: LabelLookup

--- a/src/main/js/portal/main/models/Cart.ts
+++ b/src/main/js/portal/main/models/Cart.ts
@@ -6,7 +6,7 @@ export default class Cart {
 	readonly _ts: string;
 
 	constructor(name: string | undefined = undefined, items: CartItem[] | undefined = undefined){
-		this._name = name || 'My data cart';
+		this._name = name || '';
 		this._items = items || [];
 		this._ts = (items ? Date.now() + '' : '0');
 	}

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -15,7 +15,7 @@ import deepequal from 'deep-equal';
 import { UrlStr, Sha256Str } from "../backend/declarations";
 import {Store} from "redux";
 import { DataObject, References } from "../../../common/main/metacore";
-import SpecTable, {Filter, Row} from "./SpecTable";
+import SpecTable from "./SpecTable";
 import {getLastSegmentInUrl, pick} from "../utils";
 import {FilterNumber, FilterNumbers, FilterNumberSerialized} from "./FilterNumbers";
 import {SupportedSRIDs} from "icos-cp-ol";

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -175,6 +175,7 @@ export interface State {
 	}
 	paging: Paging
 	cart: Cart
+	priorCart: Cart | undefined
 	id: UrlStr | undefined
 	metadata?: MetaData | MetaDataWStats
 	station: {} | undefined
@@ -238,6 +239,7 @@ export const defaultState: State = {
 	},
 	paging: new Paging({objCount: 0}),
 	cart: new Cart(),
+	priorCart: undefined,
 	id: undefined,
 	metadata: undefined,
 	station: undefined,
@@ -288,6 +290,7 @@ const serialize = (state: State) => {
 		baseDobjStats: state.baseDobjStats.serialize,
 		paging: state.paging.serialize,
 		cart: undefined,
+		priorCart: undefined,
 		preview: state.preview.serialize,
 		helpStorage: state.helpStorage.serialize
 	};

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -98,6 +98,10 @@ export class BackendUpdateCart extends BackendPayload{
 	constructor(readonly cart: Cart){super();}
 }
 
+export class BackendUpdatePriorCart extends BackendPayload{
+	constructor(readonly cart: Cart){super();}
+}
+
 export class BackendBatchDownload extends BackendPayload{
 	constructor(readonly isBatchDownloadOk: boolean, readonly user: WhoAmI){super();}
 }

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -12,6 +12,7 @@ import {
 	BackendTsSettings,
 	BackendBatchDownload,
 	BackendUpdateCart,
+	BackendUpdatePriorCart,
 	BackendExportQuery
 } from "./actionpayloads";
 import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
@@ -91,6 +92,13 @@ export default function(state: State, payload: BackendPayload): State {
 		return stateUtils.update(state,{
 			cart: payload.cart,
 			checkedObjectsInCart: state.checkedObjectsInCart.filter(uri => payload.cart.ids.includes(uri))
+		});
+	}
+
+	if (payload instanceof BackendUpdatePriorCart) {
+		return stateUtils.update(state,{
+			priorCart: payload.cart,
+			checkedObjectsInCart: []
 		});
 	}
 


### PR DESCRIPTION
Changes the name of the downloaded file link from "My data" to be based on timestamp, station (if all the same), and spec (if all the same).

Introduces a new directory for `hooks`, custom functions similar to `useState`, `useEffect`, or `useMemo`. This enables reusable hooks to help manage more complex local state and provide the results across multiple components, the first being `useDownloadInfo` which provides information about the objects ready for download (in this case, filename, but could be expanded as necessary). 

It might have been more natural to put this into the `Cart` model itself, but since we do not use the `Cart` when checking objects on the main search page for download, the file name generation needed to be possible in both contexts. The filename generation is more difficult for the search, which is why a hook is used: results are refreshed when the page changes, but the current results (for checked data objects) need to be cached so that the `KnownDataObject` fields are available for the filename generation.

Thus, the broadest use case forms the basis for `useDownloadInfo`, with the narrower use case of the `DataCart` container/interface fitting into it by providing its object info via a `localObjectsTable` instead of a global `objectsTable`. The caching is, of course, unnecessary for the `DataCart`; but the hook and its use of `useMemo` ensures this overhead does not have an impact.

(A few changes were also made to remove unnecessary dependencies that were noticed and missed from PR #365 )