### PR TITLE
Add 30 day bypass of licence acceptance screen

### DIFF
--- a/src/main/js/portal/main/components/buttons/DownloadButton.tsx
+++ b/src/main/js/portal/main/components/buttons/DownloadButton.tsx
@@ -11,26 +11,21 @@ type Props = {
 export default function DownloadButton(props: Props) {
 	const { style, filename, enabled, readyObjectIds, onSubmitHandler } = props;
 
+	const licenceAcceptanceTime = localStorage.getItem("licenceAcceptanceTime");
+	const bypassLicence = Boolean(licenceAcceptanceTime &&
+		Date.now() - parseInt(licenceAcceptanceTime, 10) < 1000*60*60*24*30);
+
 	const dobjIds = readyObjectIds.map(dobj => dobj.split('/').pop());
 
-	const downloadLink = useMemo(() => {
-		if (dobjIds.length == 1) {
-			return `/objects/${dobjIds[0]}`;
-		} else {
-			const ids = encodeURIComponent(JSON.stringify(dobjIds));
-			return `/objects?ids=${ids}&fileName=${encodeURIComponent(filename)}`;
-		}
-	}, [dobjIds, filename]);
-
-	const link = enabled ? downloadLink : undefined;
 	const btnType = enabled ? 'btn-warning' : 'btn-outline-secondary';
 	const className = `btn ${btnType}${enabled ? "" : " disabled"}`;
-	const btnStyle: CSSProperties = enabled ? {} : { pointerEvents: 'auto', cursor: 'not-allowed' };
+	const btnStyle: CSSProperties = enabled ? {...style} : {...style, pointerEvents: 'auto', cursor: 'not-allowed'};
 
 	return (
 		<form action="/objects" method="post" onSubmit={onSubmitHandler} target="_blank">
 			<input type="hidden" name="fileName" value={encodeURIComponent(filename)} />
 			<input type="hidden" name="ids" value={JSON.stringify(dobjIds)} />
+			{ bypassLicence ? <input type="hidden" name="licenceOk" value="true" /> : <></>}
 
 			<button className={className} style={btnStyle}>
 				<span className="fas fa-download" style={{marginRight:9}} />Download

--- a/src/main/twirl/views/LicencePage.scala.html
+++ b/src/main/twirl/views/LicencePage.scala.html
@@ -101,6 +101,12 @@
 					conditions.
 				</label>
 			</div>
+			<div class="form-check">
+				<input id="saveLicenceChkBx" class="form-check-input" type="checkbox">
+				<label class="form-check-label" for="saveLicenceChkBx">
+					Save my acceptance locally for 30 days, bypassing this page.
+				</label>
+			</div>
 			</div>
 		</div>
 	</div>
@@ -132,6 +138,15 @@
 				}
 			}
 
+			function saveLicenceAcceptance() {
+				if (document.getElementById("saveLicenceChkBx").checked &&
+					document.getElementById("agreementChkBx").checked) {
+					localStorage.setItem("licenceAcceptanceTime", String(Date.now()));
+				} else if(!document.getElementById("agreementChkBx").checked) {
+					localStorage.removeItem("licenceAcceptanceTime");
+				}
+			}
+
 			window.addEventListener("load", () => {
 				downloadBtn.innerHTML = "Download";
 
@@ -142,6 +157,12 @@
 				agreementChkBx.classList.remove('d-none');
 				agreementChkBx.addEventListener("click", function(){
 					toggleBtn(!this.checked);
+					saveLicenceAcceptance();
+				});
+
+				const saveLicenceChkBx = document.getElementById("saveLicenceChkBx");
+				saveLicenceChkBx.addEventListener("click", function() {
+					saveLicenceAcceptance();
 				});
 
 				toggleBtn(!agreementChkBx.checked);


### PR DESCRIPTION
Adds a checkbox for saving licence acceptance for 30 days and checks licence acceptance time when generating the form for the `DownloadButton` component, allowing users to bypass the licence acceptance page temporarily.