### PR TITLE
[portal] Clear checked items in search when changing filters

### DIFF
--- a/src/main/js/portal/main/reducers/filtersReducer.ts
+++ b/src/main/js/portal/main/reducers/filtersReducer.ts
@@ -24,24 +24,30 @@ export default function(state: State, payload: FiltersPayload): State{
 			filterPids: payload.selectedPids,
 			paging: state.paging
 				.withFiltersEnabled(isInPidFilteringMode(state.tabs, state.filterPids))
-				.withOffset(0)
+				.withOffset(0),
+			checkedObjectsInSearch: []
 		});
 	}
 
 	if (payload instanceof FiltersUpdateFileName) {
 		return stateUtils.update(state, {
-			filterFileName: payload.fileName
+			filterFileName: payload.fileName,
+			checkedObjectsInSearch: []
 		});
 	}
 
 	if (payload instanceof FiltersNumber){
 		return stateUtils.update(state, {
-			filterNumbers: state.filterNumbers.withFilter(payload.numberFilter)
+			filterNumbers: state.filterNumbers.withFilter(payload.numberFilter),
+			checkedObjectsInSearch: []
 		});
 	}
 
 	if (payload instanceof FilterKeywords){
-		return stateUtils.update(state, {filterKeywords: payload.filterKeywords});
+		return stateUtils.update(state, {
+			filterKeywords: payload.filterKeywords,
+			checkedObjectsInSearch: []
+		});
 	}
 
 	return state;

--- a/src/main/js/portal/main/reducers/miscReducer.ts
+++ b/src/main/js/portal/main/reducers/miscReducer.ts
@@ -80,6 +80,7 @@ const handleMiscUpdateSearchOption = (state: State, payload: MiscUpdateSearchOpt
 
 	return {
 		searchOptions,
+		checkedObjectsInSearch: [],
 		...getNewPaging(state.paging, state.page, state.specTable, true),
 	};
 };


### PR DESCRIPTION
Fixes issue: You can end up with checked objects from a "past" search still checked; these behave inconsistently with download, preview, and add to cart buttons.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210326770108241