### PR TITLE
[portal] Add file name filter to hash

### DIFF
--- a/src/main/js/portal/main/components/filters/FilterByFileName.tsx
+++ b/src/main/js/portal/main/components/filters/FilterByFileName.tsx
@@ -15,6 +15,9 @@ export default class FilterByFileName extends Component<OurProps> {
 		super(props);
 
 		this.makeQueryDebounced = debounce(this.makeQuery.bind(this));
+		if (this.props.filterFileName) {
+			this.props.updateFileName(this.props.filterFileName);
+		}
 	}
 
 	private makeQuery(ev: ChangeEvent<HTMLInputElement>){

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -459,6 +459,8 @@ const specialCases = (state: Partial<StateSerialized>) => {
 
 	if (state.filterFileName === "") {
 		delete state.filterFileName;
+	} else {
+		delete state.filterPids;
 	}
 
 	return state;

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -30,6 +30,7 @@ export const portalHistoryState = new PortalHistoryState(config.portalHistorySta
 const hashKeys = [
 	'route',
 	'filterCategories',
+	'filterFileName',
 	'filterTemporal',
 	'filterPids',
 	'filterNumbers',
@@ -366,6 +367,7 @@ const simplifyState = (state: State) => {
 type JsonHashState = {
 	route?: Route
 	filterCategories?: CategFilters
+	filterFileName?: string
 	filterTemporal?: SerializedFilterTemporal
 	filterPids?: Sha256Str
 	filterNumbers?: FilterNumberSerialized[]
@@ -455,6 +457,10 @@ const specialCases = (state: Partial<StateSerialized>) => {
 		delete state.route;
 	}
 
+	if (state.filterFileName === "") {
+		delete state.filterFileName;
+	}
+
 	return state;
 };
 
@@ -466,7 +472,6 @@ const hashUpdater = (store: Store) => () => {
 	const state: State = store.getState();
 	let newHash = stateToHash(state);
 	const oldHash = getCurrentHash();
-	
 
 	if (newHash !== oldHash) {
 		newHash = newHash === '' ? '' : "#" + encodeURIComponent(newHash);


### PR DESCRIPTION
In the process of beginning to fix another task, I noticed the URL hash does not perserve the `filterFileName` property from state. This means that the linked search appears very odd when reloaded, because it preserves the identified PIDs but not the fileName search itself.

For example, this search for the filename "BE-Vie_PHEN_20240913_L05_F01.zip" currently becomes:

```
https://data.icos-cp.eu/portal/#%7B%22filterPids%22%3A%5B%22pA3ePIAHzCqiGuIRw0DYhSiU%22%2C%22sE2uouXcEuB1HQj_FnjFiGOy%22%2C%22qWOLC1Ixx_q4-PSYlreRTYnb%22%2C%228OJXwvhVOmHaOpDaQjM2Qj2i%22%2C%22km1qTacTQWTXDA41HV9AMYW0%22%2C%227PSHzICZDw7mXUiMXO8x56jt%22%2C%22Gt2qQcV9ZZrk-svwrEJmyiAq%22%2C%221eSMCLMnv7Uncb0j0Uw2P4wz%22%2C%22S_ItKjQpWwb4IsXWShj_UoS_%22%2C%225_tkclyKf01faXDJ5BRQWOU-%22%2C%22a8TC0iXaOJ-2YnfdMz__Tj17%22%2C%22jdfc9gSpm6GGuPnpEW0YLv_p%22%2C%22_f1F-A3OezPAC3Ewjgq43Jn0%22%2C%22DdygQrn3twQ2W3DwFdswWtiT%22%2C%22BNCNH0YIhM9mI2ywl7cCwwtm%22%2C%22NljbcpGm7TFfiiUtF35xiHGS%22%2C%22_V_Gw2VrUYcrsr3z1TC9QEq0%22%2C%22pKy4oEyVPChXsmHRnQkoQ8q9%22%2C%22FjUeNAa5orR61yykGRleFdQp%22%2C%22eV8jiVF78OGpz9ckT0g3z2a0%22%2C%22nZ3YsbIEmRz687H3doPS3kFm%22%2C%22sGDK1NuZuhpXpOdLxwuegRTT%22%2C%223hQM4iPZXPQZNjcyqniWR-rs%22%2C%220M9NSiVAG5BdJnXxboTn4YrZ%22%2C%22VOjBXRX40l6vO9Shne9nNVrF%22%2C%2241JpPLtcqQsTnC2tEyA36MxJ%22%2C%22jVdrAi2DfmcpHU5-AHM8cOty%22%2C%22_p9uv-KRmAPWpdzYpcB0pBx5%22%2C%22yx5OTsI5pFtFSQaWJcHi7f5E%22%2C%22bI9V-VFClhFNV_cjO8DGTA6Z%22%2C%22fbmwfCw1alS4FFF7CUEObDjn%22%2C%22UkSnMB4rqGHYe0WKoGWjhdI8%22%2C%22axzX63R-L8GAv5_E0otteYXN%22%2C%22TfuBWQGLoeRox2XjdkMdXl4U%22%2C%22fqWnm5zHXVIfnLaZgO58CeuQ%22%2C%22kY2xKS5alH7fQ_sYAACTxDRM%22%2C%22aA0i6aTLtBhlu1EBva-xhJdy%22%2C%22ekMYL5zO32BJ8y7IwWWMnwId%22%2C%22Hvw-k5-1e297B4dMteUFralW%22%2C%22ugcyhPcIJiZZppT2IGChCULd%22%2C%222B9m_icFko8eWMYQfhpVh2qG%22%2C%22VK275RwrNWDhDPkt1dQkiFtx%22%2C%224qBMOzCr2Wfhxww6Y0dapIbe%22%2C%22emSc38VOqeC7wo6kbYiL9yrf%22%2C%22U0qkd6KH3FS_sPcAI9IC7yNc%22%2C%22fXKBgLSYchuANuNTmOGTwE19%22%2C%22nG64Wbv9jSTNePDgKfL0M15B%22%2C%22lRiKN-Yvbr9X57DhPrDg-tFh%22%2C%22cDQG69ONks0OhqevQE5A1J5D%22%2C%22F-rjZnJfry08-RVm_iJCz5aA%22%2C%22ib_lCwaZGtyw_cHS_V7S4eUv%22%2C%22Vchd5vQq2j4R8Q2d8BfCEMdP%22%2C%22RnaOZ0ztj_YswP8ppOiPjaaB%22%2C%229xArEDzSRhyYDfdyWLheaKaD%22%2C%22zjnPpUzvWP7UwYhzmS6a8fkF%22%2C%22JvfNskmbsVdjOOJHdanh_RSF%22%2C%220HmQX758Z2jLA2fXqJWA6dTe%22%2C%22FpqjTDulDrXJ9l9Ytk6P_DEF%22%2C%22PxKWISDdORMepY53VHD_APfO%22%2C%22Ib6WmA3YnHceCccQz4NY_5BQ%22%2C%22A4J6Vc3NaaJ3Fs1kRVF4bbRq%22%2C%22x6CPLK2BN1MYaUUhqNY_0jEm%22%2C%22pz7TWBYZiEi8p4teoNpeJASW%22%2C%22Q1-gkdvTGkwiz-e86rR0yDBC%22%2C%22aLh3e2EBUZUNUUSsVlA1mPxF%22%2C%22Vi68NEwP6-scVn3BsR3zPRC4%22%2C%22zE_Fw2gFPw5CVWJYPWJrgilx%22%2C%22sG2HDdZDYfW5vHYpITZ7uYZ5%22%2C%22kgnIBVrudoP8LpGzxekgyMxh%22%2C%22mClCK3xDTn6r58MI_mOI2Aqm%22%2C%22ma3X-CzgfbCvQXfQBQCelV6l%22%2C%22vjr9AeFrwLWbJa2UXdQpCMOU%22%2C%22tZD8TnKX45533uDsXkOGGd_f%22%2C%22lG99E8nWpOEA6eVyGU-z_Eqj%22%2C%22XUUiENTlUqmRsOPKc4S3I61U%22%2C%22eyXOkvCithrAaEIZzH7mUi9d%22%2C%22oIVjNBG13887-rgtHwETGQXg%22%2C%22POe2waT3kXztqLa4mfEnEwL_%22%2C%22RCFisVTxCVv8aDAL4wyYdTAe%22%2C%22dVG-s6TWNqgpzGJW31ztl8Q_%22%2C%22yhwVOqgH28QuMvj6nBkcaUDg%22%2C%22KdYjOjQFjrHZCg0eUVqpNoRH%22%2C%22waT01Yd8s9gxS0O14wk9H5fR%22%2C%22tAzPky4XfJrwdHTUSoWmMEfk%22%2C%22St88FNfFE8HP0McJaCtsMV8Y%22%2C%22tm7CCrJkd1KrFcJ0r6j3dkuZ%22%2C%22HXE9VZAD8Azd2zmPEebCL79L%22%2C%22zfEWrMdbvhYScN3jmrVaQcIq%22%2C%22w96C6Fnme0n7TAA5qDLsaSPI%22%2C%229nDWLEG--MyO5kTyRPrmvNIF%22%2C%22wasvX8tnIy_dWZoeHM1WVcWJ%22%2C%22b4VpfOcpfKBBGxtoxwgTDtcz%22%2C%225iRC6ljNnJzlH8t5THlffIgd%22%2C%22JMFLoiapBGL16cU_h4rUSJcG%22%2C%22Voo_xcyZgtrizjKFILCuLVpJ%22%2C%224U7kuSD4V_eBzmAEBcuOzNyW%22%2C%22oUERWbbQu8SVfjsKg-Qwsj0q%22%2C%22_gEqpMYlwAQAj_DjrlwN8wUu%22%2C%22sjZZPVyZ5RTvpOerTs8uF2vY%22%2C%22Vqejr0SKIgI9SOIZMZY_NzBx%22%2C%225ss7q7zNO4rCSFSTDdSoOh3v%22%2C%229mMmUjkYMG-zh5fSW--_s09I%22%2C%22xz_OSk9PeYjyIABPnGYSxuXL%22%2C%22Rf7zu4ny5ro3bna1IdOajdAe%22%2C%22ybJaZH456IG48oQzFvmYAvQb%22%2C%22KA4R2QF-4vlFMHaU_KPZFuhg%22%2C%22nfGZ6BlGRXiSbQYiKmMS1iN8%22%2C%224Q56NVVW1v507RC9iW745H9f%22%2C%22UxrYgWbdbhWeRab6XlEEAxWN%22%2C%224aJgMxG9MGnGQqDS6TzJmgFU%22%2C%22M5CVwj3CipI8yuOZgBS6Ctk3%22%2C%22A7H58UNMfgXpEMavDsGdBX9h%22%2C%22DctrMtzDSd_zEmPB68WgFWJ2%22%2C%22ISOyWZ00hAIP7yKvQIebXLGx%22%2C%22D7fhu4103odJh6xKbddOjcqw%22%2C%22tGNtbzqJfuga0kyCEyrfu_DQ%22%2C%22TWWXDW8xyG24vReoVjfPrbPL%22%2C%22mEUnsafm6_CkxII2joGxDx2D%22%2C%22oBV7qiufTBexIK_sHJRjDRAN%22%2C%22tGjag6xjIzDPSPr9mzvWVCHL%22%2C%22-phCfC5bTuvd5KAXSVwfUu50%22%2C%22OGB8LYcvsH_GVPAfU8xthxZN%22%2C%228JwkSL-OuiQEE_dWsxyelogP%22%2C%22jAH9rJ3Qrt_1dW4SLnGMxbKY%22%5D%2C%22tabs%22%3A%7B%22searchTab%22%3A1%7D%2C%22searchOptions%22%3A%7B%22showDeprecated%22%3Atrue%7D%7D
```

With the PR applied, it will become:

```
https://data.icos-cp.eu/portal/#%7B%22filterFileName%22%3A%22BE-Vie_PHEN_20240913_L05_F01.zip%22%2C%22tabs%22%3A%7B%22searchTab%22%3A1%7D%2C%22searchOptions%22%3A%7B%22showDeprecated%22%3Atrue%7D%7D
```