### PR TITLE
[portal] Fix total obj count when filtering by PIDs

### DIFF
--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -126,10 +126,13 @@ const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
 		return {...ot, ...spec};
 	});
 
+	const filtersEnabled = isInPidFilteringMode(state.tabs, state.filterPids);
+	const objCount = filtersEnabled && state.filterPids ? state.filterPids.length : getObjCount(state.specTable);
+
 	const paging = state.paging.withObjCount({
-		objCount: getObjCount(state.specTable),
+		objCount,
 		pageCount: payload.objectsTable.length,
-		filtersEnabled: isInPidFilteringMode(state.tabs, state.filterPids),
+		filtersEnabled,
 		isDataEndReached: payload.isDataEndReached
 	});
 


### PR DESCRIPTION
When filtering by PIDs, limit set total object count equal to total number of provided PIDs.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209676606688004