### PR TITLE
[portal] Ensure undefined parameters are not passed to NetCDF previews

### DIFF
--- a/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
+++ b/src/main/js/portal/main/components/preview/PreviewSelfContained.tsx
@@ -78,10 +78,9 @@ function shouldUpdateHeight(previewType?: PreviewType): boolean {
 }
 
 function settingsToQueryParams(previewSettings: PreviewSettings): string {
-	const remapKey = (key: string) => `${key}=${previewSettings[key as keyof PreviewSettings]}`;
 	return Object.keys(previewSettings)
 		.filter((key) => previewSettings[key as keyof PreviewSettings] !== undefined)
-		.map(remapKey)
+		.map((key: string) => `${key}=${previewSettings[key as keyof PreviewSettings]}`)
 		.join("&");
 }
 


### PR DESCRIPTION
In PR #359 we explicitly set preview settings to `undefined`, but we did not filter them out when using query parameters in NetCDF previews. MapGraph worked fine, because the hash setting with `JSON.stringify` ignores `undefined` values, but when the settings become query parameters, the `undefined` values are implicitly converted into strings, so they need to be explicitly filtered out.