### PR TITLE
[dygraph-light] Use correct envri to determine spinner type

### DIFF
--- a/src/main/js/dygraph-light/main/App.ts
+++ b/src/main/js/dygraph-light/main/App.ts
@@ -79,7 +79,7 @@ export default class App {
 		this.lastDateFormat = undefined;
 		this.labelMaker = new LabelMaker(params);
 
-		const isSites = config.envri === "SITES";
+		const isSites = envri === "SITES";
 		this.spinner = new Spinner(isSites);
 
 		if (window.frameElement) {


### PR DESCRIPTION
Fixes bug associated with transition of `envri` from being defined within the exported `config` object to its own export.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211181721487500