### PR TITLE
[portal] Add SamplingStart as possible default preview x-axis

### DIFF
--- a/src/main/js/portal/main/config.ts
+++ b/src/main/js/portal/main/config.ts
@@ -181,7 +181,7 @@ export default {
 	metaResourceGraph,
 	envriFilteringFromGraphs,
 	additionalStationsGraphs,
-	previewXaxisCols: ['TIME', 'Date', 'UTC_TIMESTAMP', 'TIMESTAMP', 'time'],
+	previewXaxisCols: ['TIME', 'Date', 'UTC_TIMESTAMP', 'TIMESTAMP', 'time', 'SamplingStart'],
 	historyStateMaxAge: (1000 * 3600 * 24),
 	exportCSVLimit: 20_000,
 	searchResultsCSVName,


### PR DESCRIPTION
Enables automatically setting the x-axis for ATC/CAL flask time series data in previews.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210532785903264