### PR TITLE
[dashboard] Allow different numbers of datasets, not only 2

### DIFF
--- a/src/main/js/dashboard/main/models/Stats.js
+++ b/src/main/js/dashboard/main/models/Stats.js
@@ -76,12 +76,12 @@ export default class Stats {
 	get calculatedStats(){
 		// binTable contains three columns on each row; TIMESTAMP (ms), data value and quality flag
 		const startStop = this.startStop;
-		if (startStop === undefined || this.datasets.length < 2) {
+		if (startStop === undefined || this.datasets.length === 0) {
 			return {min: 0, max: 0, mean: 0};
 		}
 
 		const getRows = dataset => {
-			if (dataset.binTable === undefined) return [];
+			if (dataset === undefined || dataset.binTable === undefined) return [];
 
 			const columnIndices = Array.from({length: dataset.binTable.nCols}, (_, i) => i);
 			return dataset.binTable
@@ -136,11 +136,11 @@ export default class Stats {
 	}
 
 	get isComplete(){
-		return this.metadata.dobjs.length > 0 && this.startStop !== undefined && this.datasets.length === 2;
+		return this.metadata.dobjs.length > 0 && this.startStop !== undefined && this.datasets.length > 0;
 	}
 
 	get error(){
-		if (this.datasets.length === 2 && this.metadata.dobjs.length === 0) {
+		if (this.datasets.length > 0 && this.metadata.dobjs.length === 0) {
 			return 'No data could be found. Check URL.';
 		}
 	}


### PR DESCRIPTION
This will allow the dashboard to be displayed with various numbers of datasets:

- 2 datasets provided, one level 1 and level 2 (previously assumed case)
- More than 2 datasets provided, at least one level 1 and at least one level 2 (may work inconsistently as it currently just uses the FIRST of each level for comparisons)
- 1 dataset provided, either level 1 or level 2 (should work consistently but may fail for yearly statistics if data is not present; do not have a great test case for this right now)
- 2 or more datasets provided of the same level (may work inconsistently, as it would use the FIRST dataset provided and ignore the others)

We can change the way the stats are calculated to use an arbitrary number of datasets, if desired. We can change the loop in `calculatedStats` to use an array of indices, timestamps, and rows (from `getRows`), one for each dataset, instead of `idx1` and `idx2`. It would be difficult to "prefer" specific datasets, especially if, e.g., multiple level 2 datasets were provided.

This would be fix the issue with potential inconsistencies based on dataset ordering for multiple datasets, but would be more computationally intensive, potentially even for the "default case" of one dataset for level 1 and one for level 2.