### PR TITLE
Use .zip downloads for single data objects

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/data/routes/DownloadRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/data/routes/DownloadRouting.scala
@@ -80,7 +80,7 @@ class DownloadRouting(
 							case None =>
 								batchDownload(Seq(hashsum), fileName)
 							case Some(licUri) =>
-								redirect(new UriLicenceProfile(Seq(hashsum), Some(fileName), false).licenceUri, StatusCodes.Found)
+								redirect(new UriLicenceProfile(Seq(hashsum), None, false).licenceUri, StatusCodes.Found)
 						}
 
 					case Success(doc: DocObject) =>

--- a/src/main/scala/se/lu/nateko/cp/data/routes/DownloadRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/data/routes/DownloadRouting.scala
@@ -69,17 +69,18 @@ class DownloadRouting(
 			userOpt{uidOpt =>
 				onComplete(uploadService.meta.lookupObject(hashsum)){
 					case Success(dobj: DataObject) =>
+						val fileName = dobj.fileName.replaceAll("\\.[^.]*$", "")
 						licenceCookieHashsums{ hashes =>
 							deleteCookie(LicenceCookieName){
-								if(hashes.contains(dobj.hash)) batchDownload(Seq(hashsum), dobj.fileName.replaceAll("\\.[^.]*$", ""))
+								if(hashes.contains(dobj.hash)) batchDownload(Seq(hashsum), fileName)
 								else reject
 							}
 						} ~
 						onSuccess(downloadService.licenceToAccept(dobj, uidOpt)){
 							case None =>
-								batchDownload(Seq(hashsum), dobj.fileName.replaceAll("\\.[^.]*$", ""))
+								batchDownload(Seq(hashsum), fileName)
 							case Some(licUri) =>
-								redirect(new UriLicenceProfile(Seq(hashsum), None, false).licenceUri, StatusCodes.Found)
+								redirect(new UriLicenceProfile(Seq(hashsum), Some(fileName), false).licenceUri, StatusCodes.Found)
 						}
 
 					case Success(doc: DocObject) =>


### PR DESCRIPTION
Remove `singleObjRoute`, which downloads single data objects directly, and use `batchDownload` instead.

File names are stripped of the final extension, as `.zip` is added to the provided file name.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209841412600862