### PR TITLE
[Do not merge] Dual pane view

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val data = (project in file("."))
 		).value,
 		cpDeployPlaybook := "core.yml",
 		cpDeployPermittedInventories := Some(Seq("staging", "cities", "production", "test-fs4")),
-		cpDeployInfraBranch := "master",
+		cpDeployInfraBranch := "valter/test/virtuoso",
 
 //		initialCommands in console := """
 //			import se.lu.nateko.cp.data.api.B2Playground._

--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val data = (project in file("."))
 			cpFrontendPublish
 		).value,
 		cpDeployPlaybook := "core.yml",
-		cpDeployPermittedInventories := Some(Seq("staging", "cities", "production")),
+		cpDeployPermittedInventories := Some(Seq("staging", "cities", "production", "test-fs4")),
 		cpDeployInfraBranch := "master",
 
 //		initialCommands in console := """

--- a/src/main/js/common/main/backend.js
+++ b/src/main/js/common/main/backend.js
@@ -2,6 +2,9 @@ import config from "./config";
 
 
 export const saveToRestheart = dataToSave => {
+	// Logging to the portaluse endpoint can be disabled via config.
+	if (config.portalUseLogDisabled) return Promise.resolve();
+
 	return fetch(config.portalUseLogUrl, {
 		method: 'POST',
 		mode: 'cors',

--- a/src/main/js/common/main/config.js
+++ b/src/main/js/common/main/config.js
@@ -16,13 +16,15 @@ const restheartDbUrls = {
 	ICOSCities: '//cityrestheart.icos-cp.eu/pauldb/'
 };
 
-// Optional second SPARQL endpoint for the dual-view comparison feature.
-// Set window.envriConfig.secondaryMetaHost to enable; left null otherwise.
+// Second SPARQL endpoint for the dual-view comparison feature. Enabled when
+// secondaryMetaHost is configured (cpdata.secondaryMetaHosts.<ENVRI> in
+// application.conf, injected into window.envriConfig); null disables the feature.
 const secondaryMetaHost = window.envriConfig.secondaryMetaHost;
+const secondarySparqlEndpoint = secondaryMetaHost ? `https://${secondaryMetaHost}/sparql` : null;
 
 export default {
 	sparqlEndpoint: metaBaseUri + '/sparql',
-	secondarySparqlEndpoint: secondaryMetaHost ? `https://${secondaryMetaHost}/sparql` : null,
+	secondarySparqlEndpoint,
 	restheartDbUrl: restheartDbUrls[envri],
 	restheartProfileBaseUrl: `${authBaseUri}/db/users`,
 	portalUseLogUrl: `${authBaseUri}/logs/portaluse`,

--- a/src/main/js/common/main/config.js
+++ b/src/main/js/common/main/config.js
@@ -28,6 +28,8 @@ export default {
 	restheartDbUrl: restheartDbUrls[envri],
 	restheartProfileBaseUrl: `${authBaseUri}/db/users`,
 	portalUseLogUrl: `${authBaseUri}/logs/portaluse`,
+	// When true, no requests are sent to the portaluse logging endpoint. Currently disabled.
+	portalUseLogDisabled: true,
 	cpmetaOntoUri: 'http://meta.icos-cp.eu/ontologies/cpmeta/',
 	cpmetaResUri: 'http://meta.icos-cp.eu/resources/cpmeta/',
 	metaBaseUri,

--- a/src/main/js/common/main/config.js
+++ b/src/main/js/common/main/config.js
@@ -16,8 +16,13 @@ const restheartDbUrls = {
 	ICOSCities: '//cityrestheart.icos-cp.eu/pauldb/'
 };
 
+// Optional second SPARQL endpoint for the dual-view comparison feature.
+// Set window.envriConfig.secondaryMetaHost to enable; left null otherwise.
+const secondaryMetaHost = window.envriConfig.secondaryMetaHost;
+
 export default {
 	sparqlEndpoint: metaBaseUri + '/sparql',
+	secondarySparqlEndpoint: secondaryMetaHost ? `https://${secondaryMetaHost}/sparql` : null,
 	restheartDbUrl: restheartDbUrls[envri],
 	restheartProfileBaseUrl: `${authBaseUri}/db/users`,
 	portalUseLogUrl: `${authBaseUri}/logs/portaluse`,

--- a/src/main/js/portal/main/CachedDataObjectsFetcher.ts
+++ b/src/main/js/portal/main/CachedDataObjectsFetcher.ts
@@ -18,7 +18,7 @@ export class CachedDataObjectsFetcher{
 	private cacheId?: {};
 	private linearCache? : LinearCache;
 
-	constructor(public readonly fetchLimit: number){
+	constructor(public readonly fetchLimit: number, private readonly endpoint?: string){
 		this.fetchLimit = fetchLimit;
 		this.cacheId = undefined;
 		this.linearCache = undefined;
@@ -34,7 +34,7 @@ export class CachedDataObjectsFetcher{
 				(offset: number, limit: number) => {
 					const opts = Object.assign({}, options, {paging:{offset, limit}});
 
-					return fetchFilteredDataObjects(opts).then((res: FetchFilteredDataObjects) => res.rows);
+					return fetchFilteredDataObjects(opts, this.endpoint).then((res: FetchFilteredDataObjects) => res.rows);
 				},
 				this.fetchLimit,
 				offset
@@ -50,8 +50,10 @@ export class CachedDataObjectsFetcher{
 }
 
 export class DataObjectsFetcher{
+	constructor(private readonly endpoint?: string){}
+
 	fetch(options: QueryParameters): FetchedDataObjs {
-		return fetchFilteredDataObjects(options).then(({rows}) => {
+		return fetchFilteredDataObjects(options, this.endpoint).then(({rows}) => {
 			return {
 				rows,
 				cacheSize: 0,

--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -181,7 +181,7 @@ export function removeFromCart(ids: UrlStr[]): PortalThunkAction<void> {
 export function getKnownDataObjInfo(dobjs: string[], cb?: Function): PortalThunkAction<void> {
 	return (dispatch) => {
 		fetchKnownDataObjects(dobjs).then(result => {
-				dispatch(new Payloads.BackendObjectsFetched(result.rows, true));
+				dispatch(new Payloads.BackendObjectsFetched(result.rows, true, result.rows.length));
 
 				if (cb) dispatch(cb);
 			},

--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -181,7 +181,7 @@ export function removeFromCart(ids: UrlStr[]): PortalThunkAction<void> {
 export function getKnownDataObjInfo(dobjs: string[], cb?: Function): PortalThunkAction<void> {
 	return (dispatch) => {
 		fetchKnownDataObjects(dobjs).then(result => {
-				dispatch(new Payloads.BackendObjectsFetched(result.rows, true, result.rows.length));
+				dispatch(new Payloads.BackendObjectsFetched(result.rows, true));
 
 				if (cb) dispatch(cb);
 			},

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -30,7 +30,8 @@ import {
 } from "./common";
 import {FilterNumber} from "../models/FilterNumbers";
 import Paging from "../models/Paging";
-import { listFilteredDataObjects } from '../sparqlQueries';
+// The export/SPARQL-client query targets the primary endpoint, which runs on Virtuoso.
+import { listFilteredDataObjects } from '../sparqlQueriesVirtuoso';
 import { sparqlFetchBlob } from "../backend";
 import {PersistedMapPropsExtended} from "../models/InitMap";
 import scopedKeywords from "../backend/scopedKeywords";

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -151,6 +151,7 @@ const getOptions = (state: State, customPaging?: Paging): QueryParameters => {
 		stations: null,
 		sites: null,
 		submitters: null,
+		filterCategories: {},
 		sorting,
 		paging: customPaging ?? paging,
 		filters
@@ -177,7 +178,8 @@ const getOptions = (state: State, customPaging?: Paging): QueryParameters => {
 			]),
 			stations: originsStationFilter,
 			sites: sitesFilters.some(f => specTable.origins.filteredColumns.includes(f)) ? specTable.getColumnValuesFilter('site') : null,
-			submitters: specTable.getFilter('submitter')
+			submitters: specTable.getFilter('submitter'),
+			filterCategories: state.filterCategories
 		};
 };
 

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -129,18 +129,20 @@ export const getFilteredDataObjects: PortalThunkAction<void>  = (dispatch, getSt
 	)
 
 	dataObjectsFetcher.fetch(options).then(
-		({rows, isDataEndReached, cacheSize}) => {
+		({rows, isDataEndReached}) => {
 			dispatch(fetchExtendedDataObjInfo(rows.map((d) => d.dobj)));
-			dispatch(new Payloads.BackendObjectsFetched(rows, isDataEndReached, cacheSize));
+			dispatch(new Payloads.BackendObjectsFetched(rows, isDataEndReached));
+			dispatch(ensureFullDataObjectCount(false));
 		},
 		failWithError(dispatch)
 	);
 
 	if (secondaryDataObjectsFetcher) {
 		secondaryDataObjectsFetcher.fetch(options).then(
-			({rows, isDataEndReached, cacheSize}) => {
+			({rows, isDataEndReached}) => {
 				dispatch(fetchSecondaryExtendedDobjInfo(rows.map((d) => d.dobj)));
-				dispatch(new Payloads.BackendSecondaryObjectsFetched(rows, isDataEndReached, cacheSize));
+				dispatch(new Payloads.BackendSecondaryObjectsFetched(rows, isDataEndReached));
+				dispatch(ensureFullDataObjectCount(true));
 			},
 			failWithError(dispatch)
 		);
@@ -221,19 +223,23 @@ export function getAllFilteredDataObjects(): PortalThunkAction<void>{
 }
 
 
-// Fetch the full result set for a pane and store its actual size, so the count-query
-// number can be compared against the number of data objects actually returned by that
-// endpoint. Capped at config.exportCSVLimit.
-export function fetchFullDataObjectCount(isSecondary: boolean): PortalThunkAction<void> {
+// After a pane's results load, fetch the full result set once and store its actual size,
+// so the count-query number can be compared against the number of data objects actually
+// returned by that endpoint. The count depends only on the filters, so it is fetched once
+// per filter set (skipped while already known or in flight). Capped at config.exportCSVLimit.
+function ensureFullDataObjectCount(isSecondary: boolean): PortalThunkAction<void> {
 	return (dispatch, getState) => {
 		const endpoint = isSecondary ? config.secondarySparqlEndpoint ?? undefined : undefined;
 		if (isSecondary && !endpoint) return;
+
+		const state = getState();
+		const paging = isSecondary ? state.secondaryPaging : state.paging;
+		if (paging.receivedCount !== undefined || paging.receivedCountFetching) return;
 
 		dispatch(new Payloads.BackendFullCountLoading(isSecondary));
 
 		// Sort order is irrelevant when we only need the total, and dropping the
 		// `order by` clause makes the count query considerably cheaper.
-		const state = getState();
 		const options = getOptions(
 			{ ...state, sorting: { varName: '', ascending: state.sorting.ascending } },
 			new Paging({ objCount: 0, offset: 0, limit: config.exportCSVLimit })

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -35,7 +35,7 @@ import { listFilteredDataObjects } from '../sparqlQueriesVirtuoso';
 // The secondary (dual-view comparison) pane runs against the original meta backend,
 // so its exported query is built with the original (non-Virtuoso) query module.
 import { listFilteredDataObjects as listFilteredDataObjectsSecondary } from '../sparqlQueries';
-import { sparqlFetchBlob } from "../backend";
+import { sparqlFetchBlob, fetchFilteredDataObjects } from "../backend";
 import {PersistedMapPropsExtended} from "../models/InitMap";
 import scopedKeywords from "../backend/scopedKeywords";
 
@@ -129,18 +129,18 @@ export const getFilteredDataObjects: PortalThunkAction<void>  = (dispatch, getSt
 	)
 
 	dataObjectsFetcher.fetch(options).then(
-		({rows, isDataEndReached}) => {
+		({rows, isDataEndReached, cacheSize}) => {
 			dispatch(fetchExtendedDataObjInfo(rows.map((d) => d.dobj)));
-			dispatch(new Payloads.BackendObjectsFetched(rows, isDataEndReached));
+			dispatch(new Payloads.BackendObjectsFetched(rows, isDataEndReached, cacheSize));
 		},
 		failWithError(dispatch)
 	);
 
 	if (secondaryDataObjectsFetcher) {
 		secondaryDataObjectsFetcher.fetch(options).then(
-			({rows, isDataEndReached}) => {
+			({rows, isDataEndReached, cacheSize}) => {
 				dispatch(fetchSecondaryExtendedDobjInfo(rows.map((d) => d.dobj)));
-				dispatch(new Payloads.BackendSecondaryObjectsFetched(rows, isDataEndReached));
+				dispatch(new Payloads.BackendSecondaryObjectsFetched(rows, isDataEndReached, cacheSize));
 			},
 			failWithError(dispatch)
 		);
@@ -220,6 +220,33 @@ export function getAllFilteredDataObjects(): PortalThunkAction<void>{
 	};
 }
 
+
+// Fetch the full result set for a pane and store its actual size, so the count-query
+// number can be compared against the number of data objects actually returned by that
+// endpoint. Capped at config.exportCSVLimit.
+export function fetchFullDataObjectCount(isSecondary: boolean): PortalThunkAction<void> {
+	return (dispatch, getState) => {
+		const endpoint = isSecondary ? config.secondarySparqlEndpoint ?? undefined : undefined;
+		if (isSecondary && !endpoint) return;
+
+		dispatch(new Payloads.BackendFullCountLoading(isSecondary));
+
+		// Sort order is irrelevant when we only need the total, and dropping the
+		// `order by` clause makes the count query considerably cheaper.
+		const state = getState();
+		const options = getOptions(
+			{ ...state, sorting: { varName: '', ascending: state.sorting.ascending } },
+			new Paging({ objCount: 0, offset: 0, limit: config.exportCSVLimit })
+		);
+
+		fetchFilteredDataObjects(options, endpoint).then(
+			({ rows }) => {
+				dispatch(new Payloads.BackendFullCount(rows.length, isSecondary));
+			},
+			failWithError(dispatch)
+		);
+	};
+}
 
 function fetchExtendedDataObjInfo(dobjs: UrlStr[]): PortalThunkAction<void> {
 	return (dispatch) => {

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -84,6 +84,9 @@ const getSecondaryOriginsAndCounts: PortalThunkAction<void> = (dispatch, getStat
 
 function getDobjOriginsAndCounts(fetchObjListWhenDone: boolean): PortalThunkAction<void> {
 	return (dispatch, getState) => {
+		// Filters changed: clear both panes and reset counts so it's clear new results are loading
+		dispatch(new Payloads.BackendResultsLoading());
+
 		const filters = getFilters(getState());
 
 		fetchDobjOriginsAndCounts(filters).then(
@@ -329,6 +332,8 @@ export function updateAdvanced(filterText: string, filterType: AdvancedFilter): 
 export function updateSelectedPids(selectedPids: Sha256Str[] | null): PortalThunkAction<void> {
 	return (dispatch) => {
 		dispatch(new FiltersUpdatePids(selectedPids));
+		// Filters changed: clear both panes and reset counts so it's clear new results are loading
+		dispatch(new Payloads.BackendResultsLoading());
 		dispatch(getFilteredDataObjects);
 	};
 }

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -35,7 +35,7 @@ import { listFilteredDataObjects } from '../sparqlQueriesVirtuoso';
 // The secondary (dual-view comparison) pane runs against the original meta backend,
 // so its exported query is built with the original (non-Virtuoso) query module.
 import { listFilteredDataObjects as listFilteredDataObjectsSecondary } from '../sparqlQueries';
-import { sparqlFetchBlob, fetchFilteredDataObjects } from "../backend";
+import { sparqlFetchBlob, fetchFilteredDataObjectsCount } from "../backend";
 import {PersistedMapPropsExtended} from "../models/InitMap";
 import scopedKeywords from "../backend/scopedKeywords";
 
@@ -132,7 +132,7 @@ export const getFilteredDataObjects: PortalThunkAction<void>  = (dispatch, getSt
 		({rows, isDataEndReached}) => {
 			dispatch(fetchExtendedDataObjInfo(rows.map((d) => d.dobj)));
 			dispatch(new Payloads.BackendObjectsFetched(rows, isDataEndReached));
-			dispatch(ensureFullDataObjectCount(false));
+			dispatch(ensureFullDataObjectCount(false, options));
 		},
 		failWithError(dispatch)
 	);
@@ -142,7 +142,7 @@ export const getFilteredDataObjects: PortalThunkAction<void>  = (dispatch, getSt
 			({rows, isDataEndReached}) => {
 				dispatch(fetchSecondaryExtendedDobjInfo(rows.map((d) => d.dobj)));
 				dispatch(new Payloads.BackendSecondaryObjectsFetched(rows, isDataEndReached));
-				dispatch(ensureFullDataObjectCount(true));
+				dispatch(ensureFullDataObjectCount(true, options));
 			},
 			failWithError(dispatch)
 		);
@@ -223,31 +223,25 @@ export function getAllFilteredDataObjects(): PortalThunkAction<void>{
 }
 
 
-// After a pane's results load, fetch the full result set once and store its actual size,
-// so the count-query number can be compared against the number of data objects actually
-// returned by that endpoint. The count depends only on the filters, so it is fetched once
-// per filter set (skipped while already known or in flight). Capped at config.exportCSVLimit.
-function ensureFullDataObjectCount(isSecondary: boolean): PortalThunkAction<void> {
+// After a pane's results load, run a count query (the exact same query used to fetch the
+// data objects, but projecting only the count and without order by/limit) and store the
+// actual total, so the count-query number can be compared against the number of data objects
+// actually matched by that endpoint. The count depends only on the filters, so it is fetched
+// once per filter set (skipped while already known or in flight). The `options` passed in are
+// the very same ones used for the data-object fetch, guaranteeing an identical query.
+function ensureFullDataObjectCount(isSecondary: boolean, options: QueryParameters): PortalThunkAction<void> {
 	return (dispatch, getState) => {
 		const endpoint = isSecondary ? config.secondarySparqlEndpoint ?? undefined : undefined;
 		if (isSecondary && !endpoint) return;
 
-		const state = getState();
-		const paging = isSecondary ? state.secondaryPaging : state.paging;
+		const paging = isSecondary ? getState().secondaryPaging : getState().paging;
 		if (paging.receivedCount !== undefined || paging.receivedCountFetching) return;
 
 		dispatch(new Payloads.BackendFullCountLoading(isSecondary));
 
-		// Sort order is irrelevant when we only need the total, and dropping the
-		// `order by` clause makes the count query considerably cheaper.
-		const options = getOptions(
-			{ ...state, sorting: { varName: '', ascending: state.sorting.ascending } },
-			new Paging({ objCount: 0, offset: 0, limit: config.exportCSVLimit })
-		);
-
-		fetchFilteredDataObjects(options, endpoint).then(
-			({ rows }) => {
-				dispatch(new Payloads.BackendFullCount(rows.length, isSecondary));
+		fetchFilteredDataObjectsCount(options, endpoint).then(
+			count => {
+				dispatch(new Payloads.BackendFullCount(count, isSecondary));
 			},
 			failWithError(dispatch)
 		);

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -32,6 +32,9 @@ import {FilterNumber} from "../models/FilterNumbers";
 import Paging from "../models/Paging";
 // The export/SPARQL-client query targets the primary endpoint, which runs on Virtuoso.
 import { listFilteredDataObjects } from '../sparqlQueriesVirtuoso';
+// The secondary (dual-view comparison) pane runs against the original meta backend,
+// so its exported query is built with the original (non-Virtuoso) query module.
+import { listFilteredDataObjects as listFilteredDataObjectsSecondary } from '../sparqlQueries';
 import { sparqlFetchBlob } from "../backend";
 import {PersistedMapPropsExtended} from "../models/InitMap";
 import scopedKeywords from "../backend/scopedKeywords";
@@ -112,6 +115,11 @@ export const getFilteredDataObjects: PortalThunkAction<void>  = (dispatch, getSt
 	const sparqClientQuery = makeQuerySubmittable(sparqQuery.text);
 
 	dispatch(new Payloads.BackendExportQuery(false, sparqClientQuery));
+
+	if (config.dualView) {
+		const secondaryQuery = makeQuerySubmittable(listFilteredDataObjectsSecondary(options).text);
+		dispatch(new Payloads.BackendExportQuery(false, secondaryQuery, true));
+	}
 
 	scopedKeywords.fetch(options).then(
 		(scopedKeywords) => {

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -41,6 +41,7 @@ export default function bootstrapSearch(user: WhoAmI,tabs: TabsState): PortalThu
 		const filters = getFilters(getState());
 		dispatch(getBackendTables(filters)).then(_ => {
 			dispatch(getFilteredDataObjects);
+			dispatch(getSecondaryOriginsAndCounts);
 		});
 
 		dispatch(new Payloads.BootstrapRouteSearch());
@@ -55,7 +56,30 @@ const dataObjectsFetcher = config.useDataObjectsCache
 	? new CachedDataObjectsFetcher(config.dobjCacheFetchLimit)
 	: new DataObjectsFetcher();
 
+// Dual-view: a separate fetcher bound to the secondary endpoint, used to mirror
+// the result list with the same (shared) filters. Undefined when the feature is off.
+const secondaryDataObjectsFetcher = (config.dualView && config.secondarySparqlEndpoint)
+	? (config.useDataObjectsCache
+		? new CachedDataObjectsFetcher(config.dobjCacheFetchLimit, config.secondarySparqlEndpoint)
+		: new DataObjectsFetcher(config.secondarySparqlEndpoint))
+	: undefined;
+
 export const getOriginsThenDobjList: PortalThunkAction<void> = getDobjOriginsAndCounts(true);
+
+// Dual-view: fetch origins/counts from the secondary endpoint with the shared filters.
+// No-op when the feature is disabled.
+const getSecondaryOriginsAndCounts: PortalThunkAction<void> = (dispatch, getState) => {
+	if (!(config.dualView && config.secondarySparqlEndpoint)) return;
+
+	const filters = getFilters(getState());
+	fetchDobjOriginsAndCounts(filters, config.secondarySparqlEndpoint).then(
+		dobjOriginsAndCounts => {
+			const tbl = new SpecTable<OriginsColNames>(dobjOriginsAndCounts.colNames, dobjOriginsAndCounts.rows, {});
+			dispatch(new Payloads.BackendSecondaryOriginsTable(tbl));
+		},
+		failWithError(dispatch)
+	);
+};
 
 function getDobjOriginsAndCounts(fetchObjListWhenDone: boolean): PortalThunkAction<void> {
 	return (dispatch, getState) => {
@@ -70,6 +94,8 @@ function getDobjOriginsAndCounts(fetchObjListWhenDone: boolean): PortalThunkActi
 			},
 			failWithError(dispatch)
 		);
+
+		dispatch(getSecondaryOriginsAndCounts);
 
 	};
 }
@@ -97,6 +123,16 @@ export const getFilteredDataObjects: PortalThunkAction<void>  = (dispatch, getSt
 		},
 		failWithError(dispatch)
 	);
+
+	if (secondaryDataObjectsFetcher) {
+		secondaryDataObjectsFetcher.fetch(options).then(
+			({rows, isDataEndReached}) => {
+				dispatch(fetchSecondaryExtendedDobjInfo(rows.map((d) => d.dobj)));
+				dispatch(new Payloads.BackendSecondaryObjectsFetched(rows, isDataEndReached));
+			},
+			failWithError(dispatch)
+		);
+	}
 
 	logPortalUsage(state);
 };
@@ -175,6 +211,16 @@ function fetchExtendedDataObjInfo(dobjs: UrlStr[]): PortalThunkAction<void> {
 	return (dispatch) => {
 		getExtendedDataObjInfo(dobjs).then(extendedDobjInfo => {
 				dispatch(new Payloads.BackendExtendedDataObjInfo(extendedDobjInfo));
+			},
+			failWithError(dispatch)
+		);
+	};
+}
+
+function fetchSecondaryExtendedDobjInfo(dobjs: UrlStr[]): PortalThunkAction<void> {
+	return (dispatch) => {
+		getExtendedDataObjInfo(dobjs, config.secondarySparqlEndpoint ?? undefined).then(extendedDobjInfo => {
+				dispatch(new Payloads.BackendSecondaryExtendedDataObjInfo(extendedDobjInfo));
 			},
 			failWithError(dispatch)
 		);

--- a/src/main/js/portal/main/actions/types.ts
+++ b/src/main/js/portal/main/actions/types.ts
@@ -1,5 +1,5 @@
 import {Filter} from "../models/SpecTable";
-import {SearchOptions, State} from "../models/State";
+import {CategFilters, SearchOptions, State} from "../models/State";
 import Paging from "../models/Paging";
 import {FilterRequest} from "../models/FilterRequest";
 
@@ -9,6 +9,9 @@ export interface QueryParameters {
 	stations: Filter
 	sites: Filter
 	submitters: Filter
+	// Raw per-column UI selections, consumed by the Virtuoso (primary) query builder to produce a
+	// self-contained relational query. The original sparqlQueries.ts still uses the fields above.
+	filterCategories: CategFilters
 	sorting: State['sorting']
 	paging: Paging
 	filters: FilterRequest[]

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -52,10 +52,10 @@ const fetchSpecColumnMeta = () => {
 	}));
 };
 
-export const fetchDobjOriginsAndCounts = (filters: FilterRequest[]) => {
+export const fetchDobjOriginsAndCounts = (filters: FilterRequest[], endpoint: UrlStr = config.sparqlEndpoint) => {
 	const query = queries.dobjOriginsAndCounts(filters);
 
-	return sparqlFetchAndParse(query, config.sparqlEndpoint, b => ({
+	return sparqlFetchAndParse(query, endpoint, b => ({
 		spec: b.spec.value,
 		countryCode: b.countryCode?.value,
 		submitter: b.submitter.value,
@@ -171,17 +171,17 @@ export const fetchKnownDataObjects = (dobjs: string[]) => {
 		: Promise.resolve({colNames: [], rows: []});
 };
 
-export function fetchFilteredDataObjects(options: QueryParameters){
+export function fetchFilteredDataObjects(options: QueryParameters, endpoint: UrlStr = config.sparqlEndpoint){
 	return Filter.allowsNothing(options.specs) || Filter.allowsNothing(options.submitters) || Filter.allowsNothing(options.stations)
 		? Promise.resolve({
 			colNames: [],
 			rows: []
 		})
-		: fetchAndParseDataObjects(queries.listFilteredDataObjects(options));
+		: fetchAndParseDataObjects(queries.listFilteredDataObjects(options), endpoint);
 }
 
-const fetchAndParseDataObjects = (query: ObjInfoQuery) => {
-	return sparqlFetchAndParse(query, config.sparqlEndpoint, b => ({
+const fetchAndParseDataObjects = (query: ObjInfoQuery, endpoint: UrlStr = config.sparqlEndpoint) => {
+	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
 		hasNextVersion: false,
 		spec: sparqlParsers.fromUrl(b.spec),
@@ -291,12 +291,12 @@ export const getProfile = (email: string | null): Promise<User['profile']> => {
 		: Promise.resolve({});
 };
 
-export const getExtendedDataObjInfo = (dobjs: UrlStr[]): Promise<ExtendedDobjInfo[]> => {
+export const getExtendedDataObjInfo = (dobjs: UrlStr[], endpoint: UrlStr = config.sparqlEndpoint): Promise<ExtendedDobjInfo[]> => {
 	if (dobjs.length == 0) return Promise.resolve([]);
 
 	const query = queries.extendedDataObjectInfo(dobjs);
 
-	return sparqlFetchAndParse(query, config.sparqlEndpoint, b => ({
+	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
 		station: sparqlParsers.fromString(b.station),
 		stationId: sparqlParsers.fromString(b.stationId),

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -24,6 +24,12 @@ const config = Object.assign(commonConfig, localConfig);
 const tsSettingsStorageName = 'tsSettings';
 const tsSettingsStorage = new Storage();
 
+// The primary SPARQL endpoint currently runs on Virtuoso, which needs a few
+// query/parsing work-arounds (FROM clauses, distinct_keywords, boolean bindings).
+// The secondary endpoint (dual-view comparison pane) runs the original backend and
+// must use the original implementation. This predicate selects which to apply.
+const isVirtuosoEndpoint = (endpoint: UrlStr) => endpoint === config.sparqlEndpoint;
+
 const fetchSpecBasics = () => {
 	const query = queries.specBasics();
 
@@ -53,7 +59,7 @@ const fetchSpecColumnMeta = () => {
 };
 
 export const fetchDobjOriginsAndCounts = (filters: FilterRequest[], endpoint: UrlStr = config.sparqlEndpoint) => {
-	const query = queries.dobjOriginsAndCounts(filters);
+	const query = queries.dobjOriginsAndCounts(filters, isVirtuosoEndpoint(endpoint));
 
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		spec: b.spec.value,
@@ -177,20 +183,23 @@ export function fetchFilteredDataObjects(options: QueryParameters, endpoint: Url
 			colNames: [],
 			rows: []
 		})
-		: fetchAndParseDataObjects(queries.listFilteredDataObjects(options), endpoint);
+		: fetchAndParseDataObjects(queries.listFilteredDataObjects(options, isVirtuosoEndpoint(endpoint)), endpoint);
 }
 
 const fetchAndParseDataObjects = (query: ObjInfoQuery, endpoint: UrlStr = config.sparqlEndpoint) => {
+	// Virtuoso work-around: these EXISTS-based boolean bindings misbehave on the primary
+	// endpoint, so force them to false there; the original backend parses them normally.
+	const virtuoso = isVirtuosoEndpoint(endpoint);
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
-		hasNextVersion: false,
+		hasNextVersion: virtuoso ? false : sparqlParsers.fromBoolean(b.hasNextVersion),
 		spec: sparqlParsers.fromUrl(b.spec),
 		fileName: sparqlParsers.fromString(b.fileName),
 		size: sparqlParsers.fromLong(b.size),
 		submTime: sparqlParsers.fromDateTime(b.submTime),
 		timeStart: sparqlParsers.fromDateTime(b.timeStart),
 		timeEnd: sparqlParsers.fromDateTime(b.timeEnd),
-		hasVarInfo: false
+		hasVarInfo: virtuoso ? false : sparqlParsers.fromBoolean(b.hasVarInfo)
 	}));
 };
 
@@ -296,6 +305,8 @@ export const getExtendedDataObjInfo = (dobjs: UrlStr[], endpoint: UrlStr = confi
 
 	const query = queries.extendedDataObjectInfo(dobjs);
 
+	// Virtuoso work-around: see fetchAndParseDataObjects; hasVarInfo is forced false on the primary endpoint.
+	const virtuoso = isVirtuosoEndpoint(endpoint);
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
 		station: sparqlParsers.fromString(b.station),
@@ -309,7 +320,7 @@ export const getExtendedDataObjInfo = (dobjs: UrlStr[], endpoint: UrlStr = confi
 		specComments: sparqlParsers.fromString(b.specComments),
 		columnNames: b.columnNames ? JSON.parse(b.columnNames.value) as string[] : undefined,
 		site: b.site?.value,
-		hasVarInfo: false,
+		hasVarInfo: virtuoso ? false : sparqlParsers.fromBoolean(b.hasVarInfo),
 		dois: b.dois && b.dois.value !== "" ? b.dois.value.split('|') : undefined,
 		biblioInfo: sparqlParsers.fromString(b.biblioInfo)
 	})).then(res => res.rows.map(

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -190,6 +190,21 @@ export function fetchFilteredDataObjects(options: QueryParameters, endpoint: Url
 		: fetchAndParseDataObjects(queriesFor(endpoint).listFilteredDataObjects(options), endpoint);
 }
 
+// Counts the filtered data objects using the exact same query as fetchFilteredDataObjects,
+// but projecting only the count and without `order by`/`offset`/`limit`.
+export function fetchFilteredDataObjectsCount(options: QueryParameters, endpoint: UrlStr = config.sparqlEndpoint): Promise<number> {
+	if (Filter.allowsNothing(options.specs) || Filter.allowsNothing(options.submitters) || Filter.allowsNothing(options.stations))
+		return Promise.resolve(0);
+
+	const query = queriesFor(endpoint).countFilteredDataObjects(options);
+	console.log(`Full count query (endpoint: ${endpoint}):\n${query.text}`);
+
+	return sparql(query, endpoint, true).then(res => {
+		const binding = res.results.bindings[0];
+		return binding ? parseInt(binding.count.value) : 0;
+	});
+}
+
 const fetchAndParseDataObjects = (query: ObjInfoQuery, endpoint: UrlStr = config.sparqlEndpoint) => {
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -183,14 +183,14 @@ export function fetchFilteredDataObjects(options: QueryParameters){
 const fetchAndParseDataObjects = (query: ObjInfoQuery) => {
 	return sparqlFetchAndParse(query, config.sparqlEndpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
-		hasNextVersion: sparqlParsers.fromBoolean(b.hasNextVersion),
+		hasNextVersion: false,
 		spec: sparqlParsers.fromUrl(b.spec),
 		fileName: sparqlParsers.fromString(b.fileName),
 		size: sparqlParsers.fromLong(b.size),
 		submTime: sparqlParsers.fromDateTime(b.submTime),
 		timeStart: sparqlParsers.fromDateTime(b.timeStart),
 		timeEnd: sparqlParsers.fromDateTime(b.timeEnd),
-		hasVarInfo: sparqlParsers.fromBoolean(b.hasVarInfo)
+		hasVarInfo: false
 	}));
 };
 
@@ -309,7 +309,7 @@ export const getExtendedDataObjInfo = (dobjs: UrlStr[]): Promise<ExtendedDobjInf
 		specComments: sparqlParsers.fromString(b.specComments),
 		columnNames: b.columnNames ? JSON.parse(b.columnNames.value) as string[] : undefined,
 		site: b.site?.value,
-		hasVarInfo: sparqlParsers.fromBoolean(b.hasVarInfo),
+		hasVarInfo: false,
 		dois: b.dois && b.dois.value !== "" ? b.dois.value.split('|') : undefined,
 		biblioInfo: sparqlParsers.fromString(b.biblioInfo)
 	})).then(res => res.rows.map(

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -1,5 +1,6 @@
 import { sparqlFetch, sparqlFetchAndParse } from './backend/SparqlFetch';
 import * as queries from './sparqlQueries';
+import * as virtuosoQueries from './sparqlQueriesVirtuoso';
 import commonConfig from '../../common/main/config';
 import localConfig from './config';
 import Cart, {JsonCart} from './models/Cart';
@@ -27,8 +28,11 @@ const tsSettingsStorage = new Storage();
 // The primary SPARQL endpoint currently runs on Virtuoso, which needs a few
 // query/parsing work-arounds (FROM clauses, distinct_keywords, boolean bindings).
 // The secondary endpoint (dual-view comparison pane) runs the original backend and
-// must use the original implementation. This predicate selects which to apply.
+// must use the original implementation. These selectors pick which to apply: the
+// virtuoso query module (sparqlQueriesVirtuoso) for the primary endpoint, the original
+// query module (sparqlQueries) for the secondary one.
 const isVirtuosoEndpoint = (endpoint: UrlStr) => endpoint === config.sparqlEndpoint;
+const queriesFor = (endpoint: UrlStr) => isVirtuosoEndpoint(endpoint) ? virtuosoQueries : queries;
 
 const fetchSpecBasics = () => {
 	const query = queries.specBasics();
@@ -59,7 +63,7 @@ const fetchSpecColumnMeta = () => {
 };
 
 export const fetchDobjOriginsAndCounts = (filters: FilterRequest[], endpoint: UrlStr = config.sparqlEndpoint) => {
-	const query = queries.dobjOriginsAndCounts(filters, isVirtuosoEndpoint(endpoint));
+	const query = queriesFor(endpoint).dobjOriginsAndCounts(filters);
 
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		spec: b.spec.value,
@@ -183,7 +187,7 @@ export function fetchFilteredDataObjects(options: QueryParameters, endpoint: Url
 			colNames: [],
 			rows: []
 		})
-		: fetchAndParseDataObjects(queries.listFilteredDataObjects(options, isVirtuosoEndpoint(endpoint)), endpoint);
+		: fetchAndParseDataObjects(queriesFor(endpoint).listFilteredDataObjects(options), endpoint);
 }
 
 const fetchAndParseDataObjects = (query: ObjInfoQuery, endpoint: UrlStr = config.sparqlEndpoint) => {

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -26,7 +26,7 @@ const tsSettingsStorageName = 'tsSettings';
 const tsSettingsStorage = new Storage();
 
 // The primary SPARQL endpoint currently runs on Virtuoso, which needs a few
-// query/parsing work-arounds (FROM clauses, distinct_keywords, boolean bindings).
+// query work-arounds (FROM clauses, distinct_keywords).
 // The secondary endpoint (dual-view comparison pane) runs the original backend and
 // must use the original implementation. These selectors pick which to apply: the
 // virtuoso query module (sparqlQueriesVirtuoso) for the primary endpoint, the original
@@ -191,19 +191,16 @@ export function fetchFilteredDataObjects(options: QueryParameters, endpoint: Url
 }
 
 const fetchAndParseDataObjects = (query: ObjInfoQuery, endpoint: UrlStr = config.sparqlEndpoint) => {
-	// Virtuoso work-around: these EXISTS-based boolean bindings misbehave on the primary
-	// endpoint, so force them to false there; the original backend parses them normally.
-	const virtuoso = isVirtuosoEndpoint(endpoint);
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
-		hasNextVersion: virtuoso ? false : sparqlParsers.fromBoolean(b.hasNextVersion),
+		hasNextVersion: sparqlParsers.fromBoolean(b.hasNextVersion),
 		spec: sparqlParsers.fromUrl(b.spec),
 		fileName: sparqlParsers.fromString(b.fileName),
 		size: sparqlParsers.fromLong(b.size),
 		submTime: sparqlParsers.fromDateTime(b.submTime),
 		timeStart: sparqlParsers.fromDateTime(b.timeStart),
 		timeEnd: sparqlParsers.fromDateTime(b.timeEnd),
-		hasVarInfo: virtuoso ? false : sparqlParsers.fromBoolean(b.hasVarInfo)
+		hasVarInfo: sparqlParsers.fromBoolean(b.hasVarInfo)
 	}));
 };
 
@@ -309,8 +306,6 @@ export const getExtendedDataObjInfo = (dobjs: UrlStr[], endpoint: UrlStr = confi
 
 	const query = queries.extendedDataObjectInfo(dobjs);
 
-	// Virtuoso work-around: see fetchAndParseDataObjects; hasVarInfo is forced false on the primary endpoint.
-	const virtuoso = isVirtuosoEndpoint(endpoint);
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		dobj: sparqlParsers.fromUrl(b.dobj),
 		station: sparqlParsers.fromString(b.station),
@@ -324,7 +319,7 @@ export const getExtendedDataObjInfo = (dobjs: UrlStr[], endpoint: UrlStr = confi
 		specComments: sparqlParsers.fromString(b.specComments),
 		columnNames: b.columnNames ? JSON.parse(b.columnNames.value) as string[] : undefined,
 		site: b.site?.value,
-		hasVarInfo: virtuoso ? false : sparqlParsers.fromBoolean(b.hasVarInfo),
+		hasVarInfo: sparqlParsers.fromBoolean(b.hasVarInfo),
 		dois: b.dois && b.dois.value !== "" ? b.dois.value.split('|') : undefined,
 		biblioInfo: sparqlParsers.fromString(b.biblioInfo)
 	})).then(res => res.rows.map(

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -64,6 +64,7 @@ const fetchSpecColumnMeta = () => {
 
 export const fetchDobjOriginsAndCounts = (filters: FilterRequest[], endpoint: UrlStr = config.sparqlEndpoint) => {
 	const query = queriesFor(endpoint).dobjOriginsAndCounts(filters);
+	console.log(`Initial origins/counts query (endpoint: ${endpoint}):\n${query.text}`);
 
 	return sparqlFetchAndParse(query, endpoint, b => ({
 		spec: b.spec.value,

--- a/src/main/js/portal/main/backend/scopedKeywords.ts
+++ b/src/main/js/portal/main/backend/scopedKeywords.ts
@@ -48,18 +48,10 @@ function getUniqueKeywords(query: QueryParameters): Promise<string[]>{
 }
 
 function filteredKeywordsQuery(params: QueryParameters): Query<'keywords', never>{
-	const prefixes: string = `
-prefix cpmeta: <${config.cpmetaOntoUri}>
-prefix prov: <http://www.w3.org/ns/prov#>
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
-prefix geo: <http://www.opengis.net/ont/geosparql#>`
-
-	return {text: `# filteredKeywordsQuery
-${prefixes}
-select (cpmeta:distinct_keywords() as ?keywords)
-${envriFilteringFromClauses}
-where {
-	${objectFilterClauses(params)}
-}`
+	return {text: `
+		prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
+		select distinct ?keywords where{
+			?dobj cpmeta:hasKeywords ?keywords .
+		}`
 	};
 }

--- a/src/main/js/portal/main/backend/scopedKeywords.ts
+++ b/src/main/js/portal/main/backend/scopedKeywords.ts
@@ -6,6 +6,7 @@ import { sparqlParsers } from "./sparql";
 import { UrlStr } from "./declarations";
 import {distinct} from '../utils';
 import { envriFilteringFromClauses, objectFilterClauses } from "../sparqlQueries";
+import { objectFilterClauses as objectFilterClausesVirtuoso } from "../sparqlQueriesVirtuoso";
 import { QueryParameters } from "../actions/types";
 
 export type SpecLookupByKeyword = {[keyword: string]: UrlStr[] | undefined}
@@ -60,7 +61,7 @@ function filteredKeywordsQuery(params: QueryParameters, virtuoso: boolean = true
 			${prefixes}
 			select distinct ?keyword
 			where {
-				${objectFilterClauses(params)} .
+				${objectFilterClausesVirtuoso(params)} .
 				?dobj cpmeta:hasKeyword ?keyword
 			}`
 		};

--- a/src/main/js/portal/main/backend/scopedKeywords.ts
+++ b/src/main/js/portal/main/backend/scopedKeywords.ts
@@ -42,35 +42,37 @@ function getUniqueKeywords(query: QueryParameters, endpoint: UrlStr = commonConf
 		filteredKeywordsQuery(query, endpoint === commonConfig.sparqlEndpoint),
 		endpoint,
 		b => ({
-			keywords: sparqlParsers.fromCommaSepListString(b.keywords)
+			keyword: sparqlParsers.fromCommaSepListString(b.keyword)
 		})
-	).then(res => distinct(res.rows.flatMap(r => r.keywords)));
+	).then(res => distinct(res.rows.flatMap(r => r.keyword)));
 }
 
-function filteredKeywordsQuery(params: QueryParameters, virtuoso: boolean = true): Query<'keywords', never>{
-	// Virtuoso work-around: the cpmeta:distinct_keywords() magic function isn't available on the
-	// primary endpoint, so query the keywords directly there; the original backend uses the magic.
+function filteredKeywordsQuery(params: QueryParameters, virtuoso: boolean = true): Query<'keyword', never>{
+	const prefixes: string = `
+		prefix cpmeta: <${config.cpmetaOntoUri}>
+		prefix prov: <http://www.w3.org/ns/prov#>
+		prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+		prefix geo: <http://www.opengis.net/ont/geosparql#>`
+
 	if (virtuoso) {
-		return {text: `
-		prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
-		select distinct ?keywords where{
-			?dobj cpmeta:hasKeywords ?keywords .
-		}`
+		return {text:
+			`# filteredKeywordsQuery
+			${prefixes}
+			select distinct ?keyword
+			where {
+				${objectFilterClauses(params)} .
+				?dobj cpmeta:hasKeyword ?keyword
+			}`
+		};
+	} else {
+		return {text:
+			`# filteredKeywordsQuery
+			${prefixes}
+			select (cpmeta:distinct_keywords() as ?keyword)
+			${envriFilteringFromClauses}
+			where {
+				${objectFilterClauses(params)}
+			}`
 		};
 	}
-
-	const prefixes: string = `
-prefix cpmeta: <${config.cpmetaOntoUri}>
-prefix prov: <http://www.w3.org/ns/prov#>
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
-prefix geo: <http://www.opengis.net/ont/geosparql#>`
-
-	return {text: `# filteredKeywordsQuery
-${prefixes}
-select (cpmeta:distinct_keywords() as ?keywords)
-${envriFilteringFromClauses}
-where {
-	${objectFilterClauses(params)}
-}`
-	};
 }

--- a/src/main/js/portal/main/backend/scopedKeywords.ts
+++ b/src/main/js/portal/main/backend/scopedKeywords.ts
@@ -12,8 +12,8 @@ export type SpecLookupByKeyword = {[keyword: string]: UrlStr[] | undefined}
 
 
 export default{
-	fetch: function(query: QueryParameters): Promise<string[]>{
-		return getUniqueKeywords(query);
+	fetch: function(query: QueryParameters, endpoint: UrlStr = commonConfig.sparqlEndpoint): Promise<string[]>{
+		return getUniqueKeywords(query, endpoint);
 	}
 }
 const config = Object.assign(commonConfig, localConfig);
@@ -37,21 +37,40 @@ where{
 	return {text};
 }
 
-function getUniqueKeywords(query: QueryParameters): Promise<string[]>{
+function getUniqueKeywords(query: QueryParameters, endpoint: UrlStr = commonConfig.sparqlEndpoint): Promise<string[]>{
 	return sparqlFetchAndParse(
-		filteredKeywordsQuery(query),
-		commonConfig.sparqlEndpoint,
+		filteredKeywordsQuery(query, endpoint === commonConfig.sparqlEndpoint),
+		endpoint,
 		b => ({
 			keywords: sparqlParsers.fromCommaSepListString(b.keywords)
 		})
 	).then(res => distinct(res.rows.flatMap(r => r.keywords)));
 }
 
-function filteredKeywordsQuery(params: QueryParameters): Query<'keywords', never>{
-	return {text: `
+function filteredKeywordsQuery(params: QueryParameters, virtuoso: boolean = true): Query<'keywords', never>{
+	// Virtuoso work-around: the cpmeta:distinct_keywords() magic function isn't available on the
+	// primary endpoint, so query the keywords directly there; the original backend uses the magic.
+	if (virtuoso) {
+		return {text: `
 		prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
 		select distinct ?keywords where{
 			?dobj cpmeta:hasKeywords ?keywords .
 		}`
+		};
+	}
+
+	const prefixes: string = `
+prefix cpmeta: <${config.cpmetaOntoUri}>
+prefix prov: <http://www.w3.org/ns/prov#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix geo: <http://www.opengis.net/ont/geosparql#>`
+
+	return {text: `# filteredKeywordsQuery
+${prefixes}
+select (cpmeta:distinct_keywords() as ?keywords)
+${envriFilteringFromClauses}
+where {
+	${objectFilterClauses(params)}
+}`
 	};
 }

--- a/src/main/js/portal/main/backend/sparql.ts
+++ b/src/main/js/portal/main/backend/sparql.ts
@@ -28,6 +28,7 @@ export const sparqlParsers = {
 	fromFloat: makeParser("http://www.w3.org/2001/XMLSchema#float", parseFloat),
 	fromDouble: makeParser("http://www.w3.org/2001/XMLSchema#double", parseFloat),
 	fromDateTime: makeParser("http://www.w3.org/2001/XMLSchema#dateTime", s => new Date(s)),
+	fromBoolean: makeParser("http://www.w3.org/2001/XMLSchema#boolean", s => (s.toLowerCase() === "true")),
 	fromString: makeParser(undefined, s => s),
 	fromCommaSepListString: makeParser(undefined, s => s.split(',').map(s => s.trim())),
 	fromUrl: liftToOptional(fromUrl)

--- a/src/main/js/portal/main/backend/sparql.ts
+++ b/src/main/js/portal/main/backend/sparql.ts
@@ -28,7 +28,6 @@ export const sparqlParsers = {
 	fromFloat: makeParser("http://www.w3.org/2001/XMLSchema#float", parseFloat),
 	fromDouble: makeParser("http://www.w3.org/2001/XMLSchema#double", parseFloat),
 	fromDateTime: makeParser("http://www.w3.org/2001/XMLSchema#dateTime", s => new Date(s)),
-	fromBoolean: makeParser("http://www.w3.org/2001/XMLSchema#boolean", s => (s.toLowerCase() === "true")),
 	fromString: makeParser(undefined, s => s),
 	fromCommaSepListString: makeParser(undefined, s => s.split(',').map(s => s.trim())),
 	fromUrl: liftToOptional(fromUrl)

--- a/src/main/js/portal/main/backend/sparql.ts
+++ b/src/main/js/portal/main/backend/sparql.ts
@@ -22,13 +22,29 @@ function fromUrl(v: SparqlResultValue): UrlStr {
 	return v.value
 }
 
+function fromBoolean(v: SparqlResultValue): boolean {
+	if(!resultIsLiteralValue(v)) throw new Error(`SPARQL result parsing error, ${v} was not literal`)
+	// The standard backend serializes xsd:boolean results as "true"/"false", whereas Virtuoso
+	// serializes boolean-valued expressions (e.g. EXISTS bindings) as xsd:integer "1"/"0". Accept both.
+	switch(v.value.toLowerCase()){
+		case "true":
+		case "1":
+			return true
+		case "false":
+		case "0":
+			return false
+		default:
+			throw new Error(`SPARQL result parsing error, expected ${v.value} to be a boolean`)
+	}
+}
+
 export const sparqlParsers = {
 	fromInt: makeParser("http://www.w3.org/2001/XMLSchema#integer", parseInt),
 	fromLong: makeParser("http://www.w3.org/2001/XMLSchema#long", parseInt),
 	fromFloat: makeParser("http://www.w3.org/2001/XMLSchema#float", parseFloat),
 	fromDouble: makeParser("http://www.w3.org/2001/XMLSchema#double", parseFloat),
 	fromDateTime: makeParser("http://www.w3.org/2001/XMLSchema#dateTime", s => new Date(s)),
-	fromBoolean: makeParser("http://www.w3.org/2001/XMLSchema#boolean", s => (s.toLowerCase() === "true")),
+	fromBoolean: liftToOptional(fromBoolean),
 	fromString: makeParser(undefined, s => s),
 	fromCommaSepListString: makeParser(undefined, s => s.split(',').map(s => s.trim())),
 	fromUrl: liftToOptional(fromUrl)

--- a/src/main/js/portal/main/components/ToSparqlClient.tsx
+++ b/src/main/js/portal/main/components/ToSparqlClient.tsx
@@ -4,6 +4,12 @@ import commonConfig from '../../../common/main/config';
 
 export const sparqlUrl = `${commonConfig.metaBaseUri}/sparqlclient/`;
 
+// The secondary (dual-view) meta backend's SPARQL client, derived from its /sparql endpoint.
+// null when the dual-view feature is disabled.
+export const secondarySparqlUrl = commonConfig.secondarySparqlEndpoint
+	? commonConfig.secondarySparqlEndpoint.replace(/\/sparql\/?$/, '/sparqlclient/')
+	: null;
+
 interface Props extends PublicQueryDeclaration {
 	queryName: QueryName
 	getPublicQuery: (queryName: QueryName) => string

--- a/src/main/js/portal/main/components/buttons/FileDownload.tsx
+++ b/src/main/js/portal/main/components/buttons/FileDownload.tsx
@@ -1,12 +1,14 @@
 import React, { CSSProperties } from 'react';
 import config from '../../config';
 import { ExportQuery } from '../../models/State';
-import { sparqlUrl } from '../ToSparqlClient';
+import { sparqlUrl, secondarySparqlUrl } from '../ToSparqlClient';
+import type { PaneSource } from '../../containers/search/SearchResultRegular';
 
 interface Props {
 	getAllFilteredDataObjects: () => void
 	exportQuery: ExportQuery
 	searchResultsCount: number
+	paneSource?: PaneSource
 }
 
 const iconStyle: CSSProperties = {
@@ -14,13 +16,19 @@ const iconStyle: CSSProperties = {
 	cursor: 'pointer'
 };
 
-export const FileDownload = ({ getAllFilteredDataObjects, exportQuery, searchResultsCount }: Props) => {
+export const FileDownload = ({ getAllFilteredDataObjects, exportQuery, searchResultsCount, paneSource }: Props) => {
 	const { isFetchingCVS, sparqClientQuery } = exportQuery;
 	const downloadCount = searchResultsCount > config.exportCSVLimit ? `first ${config.exportCSVLimit.toLocaleString()}` : searchResultsCount.toLocaleString();
 	const saveTitle = `Export ${downloadCount} records to CSV`;
 
+	// Each pane posts its own query to its own meta backend; unique form ids keep the two panes'
+	// hidden forms from colliding (getElementById would otherwise always return the first pane's form).
+	const isSecondary = paneSource === 'secondary';
+	const formId = isSecondary ? "sparqlClientForm_secondary" : "sparqlClientForm";
+	const actionUrl = isSecondary ? (secondarySparqlUrl ?? sparqlUrl) : sparqlUrl;
+
 	const openSparqlQuery = () => {
-		const form = document.getElementById("sparqlClientForm") as HTMLFormElement;
+		const form = document.getElementById(formId) as HTMLFormElement;
 		form.submit();
 	};
 
@@ -38,7 +46,7 @@ export const FileDownload = ({ getAllFilteredDataObjects, exportQuery, searchRes
 				<span style={iconStyle} onClick={getAllFilteredDataObjects} className="fas fa-download" title={saveTitle} />
 				<span style={iconStyle} onClick={openSparqlQuery} className="fas fa-share-square" title="Open SPARQL query for basic search result. See Advanced tab for more queries." />
 
-				<form id="sparqlClientForm" method="POST" action={sparqlUrl} target="_blank" style={{display: 'none'}}>
+				<form id={formId} method="POST" action={actionUrl} target="_blank" style={{display: 'none'}}>
 					<input type="hidden" name="query" value={sparqClientQuery} />
 				</form>
 			</span>

--- a/src/main/js/portal/main/components/buttons/Paging.tsx
+++ b/src/main/js/portal/main/components/buttons/Paging.tsx
@@ -14,11 +14,10 @@ interface Paging {
 	getAllFilteredDataObjects: () => void
 	exportQuery: ExportQuery
 	paneSource?: PaneSource
-	getFullCount?: () => void
 }
 
 export const Paging = (props: Paging) => {
-	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery, paneSource, getFullCount } = props;
+	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery, paneSource } = props;
 
 	const {offset, objCount, pageCount, receivedCount, receivedCountFetching} = paging;
 	const minObjs = Math.min(offset + pageCount, objCount);
@@ -39,8 +38,6 @@ export const Paging = (props: Paging) => {
 					<FullCountControl
 						receivedCount={receivedCount}
 						isFetching={receivedCountFetching}
-						objCount={objCount}
-						getFullCount={getFullCount}
 					/>
 
 					<FileDownload exportQuery={exportQuery} getAllFilteredDataObjects={getAllFilteredDataObjects} searchResultsCount={count} paneSource={paneSource} />
@@ -68,36 +65,18 @@ export const Paging = (props: Paging) => {
 interface FullCountControl {
 	receivedCount?: number
 	isFetching: boolean
-	objCount: number
-	getFullCount?: () => void
 }
 
-// Renders next to the count-query number: a button to fetch the full result set, a
-// spinner while it loads, or nothing once the actual received count is known (that
-// count is then shown in parentheses by CountHeader).
-const FullCountControl = ({receivedCount, isFetching, objCount, getFullCount}: FullCountControl) => {
-	if (receivedCount !== undefined) return null;
-
-	if (isFetching) {
-		return (
-			<span className="ms-2 text-muted small align-middle">
-				<span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
-				counting…
-			</span>
-		);
-	}
-
-	if (!getFullCount || objCount === 0) return null;
+// Shows a spinner next to the count-query number while the actual received count is being
+// fetched automatically. Once known, the count is shown in parentheses by CountHeader.
+const FullCountControl = ({receivedCount, isFetching}: FullCountControl) => {
+	if (receivedCount !== undefined || !isFetching) return null;
 
 	return (
-		<button
-			type="button"
-			className="btn btn-link btn-sm p-0 ms-2 align-middle"
-			onClick={getFullCount}
-			title="Fetch the full result set and show the actual number of received results"
-		>
-			count received
-		</button>
+		<span className="ms-2 text-muted small align-middle">
+			<span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+			counting…
+		</span>
 	);
 };
 
@@ -115,12 +94,22 @@ const CountHeader = ({objCount, to, offset, showDeprecated, receivedCount}: Coun
 	const deprecatedTxt = showDeprecated
 		? ' (including deprecated objects)'
 		: '';
-	const receivedTxt = receivedCount === undefined
-		? ''
-		: ` (${receivedCount.toLocaleString()})`;
-	const countTxt = !isNaN(to) && !isNaN(objCount)
-		? `Data objects ${objCount === 0 ? 0 : offset + 1} to ${to} of ${objCount.toLocaleString()}${receivedTxt}${deprecatedTxt}`
-		: <span>&nbsp;</span>;
 
-	return <span>{countTxt}</span>;
+	if (isNaN(to) || isNaN(objCount)) return <span>&nbsp;</span>;
+
+	// Colour the actual received count softly green when it matches the count-query
+	// number, softly red when it doesn't, so a discrepancy is easy to spot.
+	const received = receivedCount === undefined
+		? null
+		: <span style={{ color: receivedCount === objCount ? '#5a9e6a' : '#cf7b7b' }}>
+			{` (${receivedCount.toLocaleString()})`}
+		</span>;
+
+	return (
+		<span>
+			{`Data objects ${objCount === 0 ? 0 : offset + 1} to ${to} of ${objCount.toLocaleString()}`}
+			{received}
+			{deprecatedTxt}
+		</span>
+	);
 };

--- a/src/main/js/portal/main/components/buttons/Paging.tsx
+++ b/src/main/js/portal/main/components/buttons/Paging.tsx
@@ -14,12 +14,13 @@ interface Paging {
 	getAllFilteredDataObjects: () => void
 	exportQuery: ExportQuery
 	paneSource?: PaneSource
+	getFullCount?: () => void
 }
 
 export const Paging = (props: Paging) => {
-	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery, paneSource } = props;
+	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery, paneSource, getFullCount } = props;
 
-	const {offset, objCount, pageCount} = paging;
+	const {offset, objCount, pageCount, receivedCount, receivedCountFetching} = paging;
 	const minObjs = Math.min(offset + pageCount, objCount);
 	const to = minObjs < pageCount
 		? pageCount
@@ -32,7 +33,15 @@ export const Paging = (props: Paging) => {
 		return (
 			<div className="card-header bg-transparent">
 				<span className="align-middle">
-					<CountHeader objCount={count} to={to} offset={offset} showDeprecated={showDeprecated} />
+					<CountHeader objCount={count} to={to} offset={offset} showDeprecated={showDeprecated}
+						receivedCount={receivedCount} />
+
+					<FullCountControl
+						receivedCount={receivedCount}
+						isFetching={receivedCountFetching}
+						objCount={objCount}
+						getFullCount={getFullCount}
+					/>
 
 					<FileDownload exportQuery={exportQuery} getAllFilteredDataObjects={getAllFilteredDataObjects} searchResultsCount={count} paneSource={paneSource} />
 				</span>
@@ -56,19 +65,61 @@ export const Paging = (props: Paging) => {
 	}
 };
 
+interface FullCountControl {
+	receivedCount?: number
+	isFetching: boolean
+	objCount: number
+	getFullCount?: () => void
+}
+
+// Renders next to the count-query number: a button to fetch the full result set, a
+// spinner while it loads, or nothing once the actual received count is known (that
+// count is then shown in parentheses by CountHeader).
+const FullCountControl = ({receivedCount, isFetching, objCount, getFullCount}: FullCountControl) => {
+	if (receivedCount !== undefined) return null;
+
+	if (isFetching) {
+		return (
+			<span className="ms-2 text-muted small align-middle">
+				<span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+				counting…
+			</span>
+		);
+	}
+
+	if (!getFullCount || objCount === 0) return null;
+
+	return (
+		<button
+			type="button"
+			className="btn btn-link btn-sm p-0 ms-2 align-middle"
+			onClick={getFullCount}
+			title="Fetch the full result set and show the actual number of received results"
+		>
+			count received
+		</button>
+	);
+};
+
 interface CountHeader {
 	objCount: number
 	to: number
 	offset: number
 	showDeprecated: boolean
+	// Actual number of results received once all are loaded; shown in parentheses
+	// next to the count-query number to reveal any discrepancy. Undefined while loading.
+	receivedCount?: number
 }
 
-const CountHeader = ({objCount, to, offset, showDeprecated}: CountHeader) => {
+const CountHeader = ({objCount, to, offset, showDeprecated, receivedCount}: CountHeader) => {
 	const deprecatedTxt = showDeprecated
 		? ' (including deprecated objects)'
 		: '';
+	const receivedTxt = receivedCount === undefined
+		? ''
+		: ` (${receivedCount.toLocaleString()})`;
 	const countTxt = !isNaN(to) && !isNaN(objCount)
-		? `Data objects ${objCount === 0 ? 0 : offset + 1} to ${to} of ${objCount.toLocaleString()}${deprecatedTxt}`
+		? `Data objects ${objCount === 0 ? 0 : offset + 1} to ${to} of ${objCount.toLocaleString()}${receivedTxt}${deprecatedTxt}`
 		: <span>&nbsp;</span>;
 
 	return <span>{countTxt}</span>;

--- a/src/main/js/portal/main/components/buttons/Paging.tsx
+++ b/src/main/js/portal/main/components/buttons/Paging.tsx
@@ -4,6 +4,7 @@ import P from "../../models/Paging";
 import config from "../../config";
 import {ExportQuery, SearchOptions} from "../../models/State";
 import { FileDownload } from './FileDownload';
+import type { PaneSource } from '../../containers/search/SearchResultRegular';
 
 interface Paging {
 	type: 'header' | 'footer'
@@ -12,10 +13,11 @@ interface Paging {
 	searchOptions: SearchOptions | undefined
 	getAllFilteredDataObjects: () => void
 	exportQuery: ExportQuery
+	paneSource?: PaneSource
 }
 
 export const Paging = (props: Paging) => {
-	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery } = props;
+	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery, paneSource } = props;
 
 	const {offset, objCount, pageCount} = paging;
 	const minObjs = Math.min(offset + pageCount, objCount);
@@ -32,7 +34,7 @@ export const Paging = (props: Paging) => {
 				<span className="align-middle">
 					<CountHeader objCount={count} to={to} offset={offset} showDeprecated={showDeprecated} />
 
-					<FileDownload exportQuery={exportQuery} getAllFilteredDataObjects={getAllFilteredDataObjects} searchResultsCount={count} />
+					<FileDownload exportQuery={exportQuery} getAllFilteredDataObjects={getAllFilteredDataObjects} searchResultsCount={count} paneSource={paneSource} />
 				</span>
 				<div className="float-end lh-sm">
 					<StepButton direction="step-backward" enabled={offset > 0} onStep={() => requestStep(-1)}/>

--- a/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
+++ b/src/main/js/portal/main/components/searchResult/SearchResultRegularRow.tsx
@@ -8,6 +8,7 @@ import Preview from '../../models/Preview';
 import { addingToCartProhibition } from '../../models/CartItem';
 import { UrlStr } from '../../backend/declarations';
 import CollectionBtn from '../buttons/CollectionBtn';
+import type { PaneSource } from '../../containers/search/SearchResultRegular';
 
 
 const truncateStyle: CSSProperties = {
@@ -37,6 +38,7 @@ interface OurProps {
 	checkedObjects?: KnownDataObject[]
 	labelLookup: LabelLookup
 	isCartView: Boolean
+	paneSource?: PaneSource
 }
 
 export default class SearchResultRegularRow extends Component<OurProps> {
@@ -55,6 +57,10 @@ export default class SearchResultRegularRow extends Component<OurProps> {
 		const {allowCartAdd, uiMessage} = addingToCartProhibition(objInfo);
 		const checkBtnTitle = uiMessage ?? `Select to preview or download`;
 		const level = `Level ${objInfo.level}`
+		// Each pane links to its own meta backend; the secondary pane uses the secondary base URI.
+		const metaBaseUri = props.paneSource === 'secondary'
+			? (config.secondaryMetaBaseUri ?? undefined)
+			: undefined;
 
 		return(
 			<div className='d-flex border-top py-4'>
@@ -70,7 +76,7 @@ export default class SearchResultRegularRow extends Component<OurProps> {
 				</div>
 				<div>
 					<h4 className="fs-5">
-						<a title="View metadata" href={getUrlWithEnvironmentPrefix(objInfo.dobj)}>{title}</a>
+						<a title="View metadata" href={getUrlWithEnvironmentPrefix(objInfo.dobj, metaBaseUri)}>{title}</a>
 					</h4>
 					<Description extendedInfo={extendedInfo} truncateStyle={truncateStyle} />
 					<div className="extended-info" style={{ marginTop: 4 }}>

--- a/src/main/js/portal/main/config.ts
+++ b/src/main/js/portal/main/config.ts
@@ -176,6 +176,11 @@ export default {
 	restheartDbUrl: commonConfig.restheartDbUrl,
 	sparqlEndpoint: commonConfig.sparqlEndpoint,
 	secondarySparqlEndpoint: commonConfig.secondarySparqlEndpoint as string | null,
+	// Base URI of the secondary meta backend (for landing-page links from the comparison pane),
+	// derived from its /sparql endpoint. null when the dual-view feature is disabled.
+	secondaryMetaBaseUri: commonConfig.secondarySparqlEndpoint
+		? (commonConfig.secondarySparqlEndpoint as string).replace(/\/sparql\/?$/, '')
+		: null,
 	// Dual-view comparison pane is enabled when a second SPARQL endpoint is configured
 	dualView: !!commonConfig.secondarySparqlEndpoint,
 	stepsize: 20,

--- a/src/main/js/portal/main/config.ts
+++ b/src/main/js/portal/main/config.ts
@@ -174,6 +174,10 @@ export default {
 		PHENOCAM: '/imagezipview/'
 	},
 	restheartDbUrl: commonConfig.restheartDbUrl,
+	sparqlEndpoint: commonConfig.sparqlEndpoint,
+	secondarySparqlEndpoint: commonConfig.secondarySparqlEndpoint as string | null,
+	// Dual-view comparison pane is enabled when a second SPARQL endpoint is configured
+	dualView: !!commonConfig.secondarySparqlEndpoint,
 	stepsize: 20,
 	useDataObjectsCache: true,
 	dobjCacheFetchLimit: 60,

--- a/src/main/js/portal/main/containers/search/Advanced.tsx
+++ b/src/main/js/portal/main/containers/search/Advanced.tsx
@@ -11,7 +11,8 @@ import CheckBtn from "../../components/buttons/CheckBtn";
 import {FilterPanel} from "../../components/filters/FilterPanel";
 import { ToSparqlClient } from '../../components/ToSparqlClient';
 import { publicQueries, QueryName } from '../../config';
-import * as queries from '../../sparqlQueries';
+// The advanced tab shows the queries that run against the primary (Virtuoso) endpoint.
+import * as queries from '../../sparqlQueriesVirtuoso';
 import { getFilters } from '../../actions/common';
 import { specKeywordsQuery } from '../../backend/scopedKeywords';
 

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -25,6 +25,8 @@ type OurProps = StateProps & DispatchProps & { HelpSection: ReactNode };
 type OurState = {
 	expandedFilters: boolean
 	srid?: SupportedSRIDs
+	// dual-view only: restrict each pane to data objects (by hash) absent from the other pane
+	showUniqueOnly: boolean
 };
 
 class Search extends Component<OurProps, OurState> {
@@ -52,7 +54,8 @@ class Search extends Component<OurProps, OurState> {
 
 		this.state = {
 			expandedFilters: !isSmallDevice(),
-			srid: this.persistedMapProps.srid
+			srid: this.persistedMapProps.srid,
+			showUniqueOnly: false
 		};
 	}
 
@@ -102,6 +105,10 @@ class Search extends Component<OurProps, OurState> {
 		this.setState({expandedFilters: !this.state.expandedFilters});
 	}
 
+	toggleShowUniqueOnly() {
+		this.setState({showUniqueOnly: !this.state.showUniqueOnly});
+	}
+
 	componentWillUnmount(){
 		this.events.clear();
 	}
@@ -135,26 +142,41 @@ class Search extends Component<OurProps, OurState> {
 
 				<div className="col-sm-8 col-md-9">
 					{config.dualView ? (
-						<div className="row">
-							<div className="col-lg-6 mb-3">
-								<EndpointLabel url={config.sparqlEndpoint} />
-								<SearchResultRegular
-									tabHeader="Search results"
-									paneSource="primary"
-									handlePreview={this.handlePreview.bind(this)}
-									handleAddToCart={this.handleAddToCart.bind(this)}
-									handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
-								/>
+						<div>
+							<div className="d-flex justify-content-end mb-2">
+								<button
+									type="button"
+									className={"btn btn-sm " + (this.state.showUniqueOnly ? "btn-secondary" : "btn-outline-secondary")}
+									onClick={this.toggleShowUniqueOnly.bind(this)}
+									title="Show only the data objects (compared by hash) that are present in one source but not in the other"
+								>
+									<i className="fas fa-not-equal" style={{ marginRight: 6 }} aria-hidden="true" />
+									Unique entries only
+								</button>
 							</div>
-							<div className="col-lg-6 mb-3">
-								<EndpointLabel url={config.secondarySparqlEndpoint ?? ''} />
-								<SearchResultRegular
-									tabHeader="Search results"
-									paneSource="secondary"
-									handlePreview={this.handlePreview.bind(this)}
-									handleAddToCart={this.handleAddToCart.bind(this)}
-									handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
-								/>
+							<div className="row">
+								<div className="col-lg-6 mb-3">
+									<EndpointLabel url={config.sparqlEndpoint} />
+									<SearchResultRegular
+										tabHeader="Search results"
+										paneSource="primary"
+										showUniqueOnly={this.state.showUniqueOnly}
+										handlePreview={this.handlePreview.bind(this)}
+										handleAddToCart={this.handleAddToCart.bind(this)}
+										handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+									/>
+								</div>
+								<div className="col-lg-6 mb-3">
+									<EndpointLabel url={config.secondarySparqlEndpoint ?? ''} />
+									<SearchResultRegular
+										tabHeader="Search results"
+										paneSource="secondary"
+										showUniqueOnly={this.state.showUniqueOnly}
+										handlePreview={this.handlePreview.bind(this)}
+										handleAddToCart={this.handleAddToCart.bind(this)}
+										handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+									/>
+								</div>
 							</div>
 						</div>
 					) : (

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -134,30 +134,62 @@ class Search extends Component<OurProps, OurState> {
 				</div>
 
 				<div className="col-sm-8 col-md-9">
-					<Tabs tabName="resultTab" selectedTabId={tabs.resultTab} switchTab={switchTab}>
-						<SearchResultRegular
-							tabHeader="Search results"
-							handlePreview={this.handlePreview.bind(this)}
-							handleAddToCart={this.handleAddToCart.bind(this)}
-							handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
-						/>
-						<SearchResultCompact
-							tabHeader="Compact view"
-							handlePreview={this.handlePreview.bind(this)}
-						/>
-						<SearchResultMap
-							key={srid}
-							tabHeader="Stations map"
-							persistedMapProps={this.persistedMapProps}
-							updatePersistedMapProps={this.updatePersistedMapProps.bind(this)}
-							updateMapSelectedSRID={this.updateMapSelectedSRID.bind(this)}
-						/>
-					</Tabs>
+					{config.dualView ? (
+						<div className="row">
+							<div className="col-lg-6 mb-3">
+								<EndpointLabel url={config.sparqlEndpoint} />
+								<SearchResultRegular
+									tabHeader="Search results"
+									paneSource="primary"
+									handlePreview={this.handlePreview.bind(this)}
+									handleAddToCart={this.handleAddToCart.bind(this)}
+									handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+								/>
+							</div>
+							<div className="col-lg-6 mb-3">
+								<EndpointLabel url={config.secondarySparqlEndpoint ?? ''} />
+								<SearchResultRegular
+									tabHeader="Search results"
+									paneSource="secondary"
+									handlePreview={this.handlePreview.bind(this)}
+									handleAddToCart={this.handleAddToCart.bind(this)}
+									handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+								/>
+							</div>
+						</div>
+					) : (
+						<Tabs tabName="resultTab" selectedTabId={tabs.resultTab} switchTab={switchTab}>
+							<SearchResultRegular
+								tabHeader="Search results"
+								handlePreview={this.handlePreview.bind(this)}
+								handleAddToCart={this.handleAddToCart.bind(this)}
+								handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+							/>
+							<SearchResultCompact
+								tabHeader="Compact view"
+								handlePreview={this.handlePreview.bind(this)}
+							/>
+							<SearchResultMap
+								key={srid}
+								tabHeader="Stations map"
+								persistedMapProps={this.persistedMapProps}
+								updatePersistedMapProps={this.updatePersistedMapProps.bind(this)}
+								updateMapSelectedSRID={this.updateMapSelectedSRID.bind(this)}
+							/>
+						</Tabs>
+					)}
 				</div>
 			</div>
 		);
 	}
 }
+
+const EndpointLabel = ({ url }: { url: string }) => (
+	<div className="text-secondary small text-truncate mb-1" title={url} style={{ fontWeight: 600 }}>
+		<i className="fas fa-database" style={{ marginRight: 6 }} aria-hidden="true" />
+		{url}
+	</div>
+);
 
 function stateToProps(state: State){
 	return {

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -149,6 +149,7 @@ function SearchResultRegular(props: OurProps) {
 									isChecked={checkedObjectsInSearch.includes(objInfo.dobj)}
 									checkedObjects={checkedObjects}
 									isCartView={false}
+									paneSource={paneSource}
 								/>
 							);
 						})

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
-import {getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
+import {fetchFullDataObjectCount, getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
 import {Paging} from "../../components/buttons/Paging";
 import CheckAllBoxes from "../../components/controls/CheckAllBoxes";
@@ -42,7 +42,8 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly, paneSource } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly, paneSource,
+		fetchFullCount } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -61,6 +62,7 @@ function SearchResultRegular(props: OurProps) {
 				getAllFilteredDataObjects={getAllFilteredDataObjects}
 				exportQuery={exportQuery}
 				paneSource={paneSource}
+				getFullCount={() => fetchFullCount(paneSource === 'secondary')}
 			/>
 
 			<div className="card-body pb-0">
@@ -204,6 +206,7 @@ function dispatchToProps(dispatch: PortalDispatch){
 		toggleSort: (varName: string) => dispatch(toggleSort(varName)),
 		requestStep: (direction: -1 | 1) => dispatch(requestStep(direction)),
 		getAllFilteredDataObjects: () => dispatch(getAllFilteredDataObjects()),
+		fetchFullCount: (isSecondary: boolean) => dispatch(fetchFullDataObjectCount(isSecondary)),
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
-import {fetchFullDataObjectCount, getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
+import {getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
 import {Paging} from "../../components/buttons/Paging";
 import CheckAllBoxes from "../../components/controls/CheckAllBoxes";
@@ -42,8 +42,7 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly, paneSource,
-		fetchFullCount } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly, paneSource } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -62,7 +61,6 @@ function SearchResultRegular(props: OurProps) {
 				getAllFilteredDataObjects={getAllFilteredDataObjects}
 				exportQuery={exportQuery}
 				paneSource={paneSource}
-				getFullCount={() => fetchFullCount(paneSource === 'secondary')}
 			/>
 
 			<div className="card-body pb-0">
@@ -206,7 +204,6 @@ function dispatchToProps(dispatch: PortalDispatch){
 		toggleSort: (varName: string) => dispatch(toggleSort(varName)),
 		requestStep: (direction: -1 | 1) => dispatch(requestStep(direction)),
 		getAllFilteredDataObjects: () => dispatch(getAllFilteredDataObjects()),
-		fetchFullCount: (isSecondary: boolean) => dispatch(fetchFullDataObjectCount(isSecondary)),
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -42,7 +42,7 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly, paneSource } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -60,6 +60,7 @@ function SearchResultRegular(props: OurProps) {
 				requestStep={requestStep}
 				getAllFilteredDataObjects={getAllFilteredDataObjects}
 				exportQuery={exportQuery}
+				paneSource={paneSource}
 			/>
 
 			<div className="card-body pb-0">
@@ -191,7 +192,7 @@ function stateToProps(state: State, ownProps: IncomingProps){
 		sorting: state.sorting,
 		searchOptions: state.searchOptions,
 		extendedDobjInfo: isSecondary ? state.secondaryExtendedDobjInfo : state.extendedDobjInfo,
-		exportQuery: state.exportQuery,
+		exportQuery: isSecondary ? state.secondaryExportQuery : state.exportQuery,
 		user: state.user
 	};
 }

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -23,7 +23,10 @@ type IncomingActions = {
 	handleAddToCart: (objInfo: UrlStr[]) => void
 	handleAllCheckboxesChange: () => void
 }
-type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
+// 'secondary' makes the pane read its rows/counts from the secondary (dual-view) state slice
+export type PaneSource = 'primary' | 'secondary';
+type IncomingProps = IncomingActions & {tabHeader: string, paneSource?: PaneSource};
+type OurProps = StateProps & DispatchProps & IncomingProps;
 
 const dropdownLookup = {
 	fileName: 'File name',
@@ -153,18 +156,19 @@ function SearchResultRegular(props: OurProps) {
 	);
 }
 
-function stateToProps(state: State){
+function stateToProps(state: State, ownProps: IncomingProps){
+	const isSecondary = ownProps.paneSource === 'secondary';
 	return {
 		previewLookup: state.previewLookup,
 		labelLookup: state.labelLookup,
 		checkedObjectsInSearch: state.checkedObjectsInSearch,
-		objectsTable: state.objectsTable,
+		objectsTable: isSecondary ? state.secondaryObjectsTable : state.objectsTable,
 		preview: state.preview,
 		cart: state.cart,
-		paging: state.paging,
+		paging: isSecondary ? state.secondaryPaging : state.paging,
 		sorting: state.sorting,
 		searchOptions: state.searchOptions,
-		extendedDobjInfo: state.extendedDobjInfo,
+		extendedDobjInfo: isSecondary ? state.secondaryExtendedDobjInfo : state.extendedDobjInfo,
 		exportQuery: state.exportQuery,
 		user: state.user
 	};

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -14,6 +14,7 @@ import SearchResultRegularRow from "../../components/searchResult/SearchResultRe
 import { addingToCartProhibition } from '../../models/CartItem';
 import DownloadButton from '../../components/buttons/DownloadButton';
 import { useDownloadInfo } from '../../hooks/useDownloadInfo';
+import { getLastSegmentInUrl } from '../../utils';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
@@ -25,7 +26,8 @@ type IncomingActions = {
 }
 // 'secondary' makes the pane read its rows/counts from the secondary (dual-view) state slice
 export type PaneSource = 'primary' | 'secondary';
-type IncomingProps = IncomingActions & {tabHeader: string, paneSource?: PaneSource};
+// showUniqueOnly filters the pane down to data objects (compared by hash) absent from the other pane
+type IncomingProps = IncomingActions & {tabHeader: string, paneSource?: PaneSource, showUniqueOnly?: boolean};
 type OurProps = StateProps & DispatchProps & IncomingProps;
 
 const dropdownLookup = {
@@ -40,7 +42,7 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, showUniqueOnly } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -122,6 +124,14 @@ function SearchResultRegular(props: OurProps) {
 
 				</div>
 
+				{showUniqueOnly &&
+					<div className="text-secondary small mb-2">
+						{objectsTable.length === 1
+							? "1 entry on the current page is unique to this source"
+							: `${objectsTable.length} entries on the current page are unique to this source`}
+					</div>
+				}
+
 				<div>
 					{
 						objectsTable.map((objInfo: KnownDataObject, i) => {
@@ -156,13 +166,25 @@ function SearchResultRegular(props: OurProps) {
 	);
 }
 
+// The two endpoints serve dobj URLs with different hosts, so compare by the
+// data object hash (last URL segment) rather than by the full URL
+function filterUniqueByHash(own: KnownDataObject[], other: KnownDataObject[]): KnownDataObject[] {
+	const otherHashes = new Set(other.map(o => getLastSegmentInUrl(o.dobj)));
+	return own.filter(o => !otherHashes.has(getLastSegmentInUrl(o.dobj)));
+}
+
 function stateToProps(state: State, ownProps: IncomingProps){
 	const isSecondary = ownProps.paneSource === 'secondary';
+	const ownObjectsTable = isSecondary ? state.secondaryObjectsTable : state.objectsTable;
+	const otherObjectsTable = isSecondary ? state.objectsTable : state.secondaryObjectsTable;
+	const objectsTable = ownProps.showUniqueOnly
+		? filterUniqueByHash(ownObjectsTable, otherObjectsTable)
+		: ownObjectsTable;
 	return {
 		previewLookup: state.previewLookup,
 		labelLookup: state.labelLookup,
 		checkedObjectsInSearch: state.checkedObjectsInSearch,
-		objectsTable: isSecondary ? state.secondaryObjectsTable : state.objectsTable,
+		objectsTable,
 		preview: state.preview,
 		cart: state.cart,
 		paging: isSecondary ? state.secondaryPaging : state.paging,

--- a/src/main/js/portal/main/models/Paging.ts
+++ b/src/main/js/portal/main/models/Paging.ts
@@ -8,10 +8,12 @@ interface Props {
 	filtersEnabled?: boolean
 	cacheOffset?: number
 	isDataEndReached?: boolean
+	receivedCount?: number
+	receivedCountFetching?: boolean
 }
 type Offset = number;
 type FiltersEnabled = Required<Pick<Props, 'filtersEnabled'>>['filtersEnabled'];
-type WithProps = Pick<Props, 'objCount' | 'pageCount' | 'filtersEnabled' | 'isDataEndReached'>;
+type WithProps = Pick<Props, 'objCount' | 'pageCount' | 'filtersEnabled' | 'isDataEndReached' | 'receivedCount'>;
 
 export default class Paging{
 	private _objCount: number;
@@ -21,8 +23,13 @@ export default class Paging{
 	private _filtersEnabled: boolean;
 	private _cacheOffset: number;
 	private _isDataEndReached: boolean;
+	// Actual number of data objects received for the full result set (known once the
+	// data end is reached or the user requests a full-count fetch). Undefined until known.
+	private _receivedCount?: number;
+	// True while a full-count fetch is in progress (button-triggered).
+	private _receivedCountFetching: boolean;
 
-	constructor({objCount, offset, limit, pageCount, filtersEnabled, cacheOffset, isDataEndReached}: Props){
+	constructor({objCount, offset, limit, pageCount, filtersEnabled, cacheOffset, isDataEndReached, receivedCount, receivedCountFetching}: Props){
 		this._objCount = objCount;
 		this._offset = offset || 0;
 		this._pageCount = pageCount ?? config.stepsize;
@@ -30,6 +37,8 @@ export default class Paging{
 		this._filtersEnabled = filtersEnabled || false;
 		this._cacheOffset = cacheOffset ?? this._offset;
 		this._isDataEndReached = isDataEndReached || false;
+		this._receivedCount = receivedCount;
+		this._receivedCountFetching = receivedCountFetching || false;
 	}
 
 	get serialize(){
@@ -39,7 +48,9 @@ export default class Paging{
 			pageCount: this._pageCount,
 			filtersEnabled: this._filtersEnabled,
 			cacheOffset: this._cacheOffset,
-			isDataEndReached: this._isDataEndReached
+			isDataEndReached: this._isDataEndReached,
+			receivedCount: this._receivedCount,
+			receivedCountFetching: this._receivedCountFetching
 		};
 	}
 
@@ -67,13 +78,36 @@ export default class Paging{
 		return this._limit;
 	}
 
+	get isDataEndReached(){
+		return this._isDataEndReached;
+	}
+
+	get receivedCount(){
+		return this._receivedCount;
+	}
+
+	get receivedCountFetching(){
+		return this._receivedCountFetching;
+	}
+
+	// Explicitly set the full received-count (e.g. from a button-triggered full fetch),
+	// clearing the fetching flag.
+	withReceivedCount(receivedCount: number){
+		return new Paging({...this.serialize, receivedCount, receivedCountFetching: false});
+	}
+
+	withReceivedCountFetching(receivedCountFetching: boolean){
+		return new Paging({...this.serialize, receivedCountFetching});
+	}
+
 	withOffset(offset: Offset){
 		return new Paging({
 			objCount: this._objCount,
 			offset: offset,
 			pageCount: this._pageCount,
 			filtersEnabled: this._filtersEnabled,
-			isDataEndReached: this._isDataEndReached
+			isDataEndReached: this._isDataEndReached,
+			receivedCount: this._receivedCount
 		});
 	}
 
@@ -85,7 +119,8 @@ export default class Paging{
 				objCount: this._objCount,
 				offset,
 				cacheOffset: Math.min(offset, this._cacheOffset),
-				isDataEndReached: this._isDataEndReached
+				isDataEndReached: this._isDataEndReached,
+				receivedCount: this._receivedCount
 			});
 
 		} else if (direction > 0){
@@ -95,20 +130,22 @@ export default class Paging{
 				objCount: this._objCount,
 				offset,
 				cacheOffset: this._cacheOffset,
-				isDataEndReached: this._isDataEndReached
+				isDataEndReached: this._isDataEndReached,
+				receivedCount: this._receivedCount
 			});
 
 		} else return this;
 	}
 
-	withObjCount({objCount, pageCount, filtersEnabled, isDataEndReached}: WithProps){
+	withObjCount({objCount, pageCount, filtersEnabled, isDataEndReached, receivedCount}: WithProps){
 		return new Paging({
 			objCount,
 			offset: this._offset,
 			pageCount,
 			filtersEnabled,
 			cacheOffset: this._cacheOffset,
-			isDataEndReached: isDataEndReached
+			isDataEndReached: isDataEndReached,
+			receivedCount: receivedCount
 		});
 	}
 
@@ -118,7 +155,8 @@ export default class Paging{
 			offset: this._offset,
 			pageCount: this._pageCount,
 			filtersEnabled,
-			isDataEndReached: this._isDataEndReached
+			isDataEndReached: this._isDataEndReached,
+			receivedCount: this._receivedCount
 		});
 	}
 }

--- a/src/main/js/portal/main/models/Paging.ts
+++ b/src/main/js/portal/main/models/Paging.ts
@@ -13,7 +13,7 @@ interface Props {
 }
 type Offset = number;
 type FiltersEnabled = Required<Pick<Props, 'filtersEnabled'>>['filtersEnabled'];
-type WithProps = Pick<Props, 'objCount' | 'pageCount' | 'filtersEnabled' | 'isDataEndReached' | 'receivedCount'>;
+type WithProps = Pick<Props, 'objCount' | 'pageCount' | 'filtersEnabled' | 'isDataEndReached'>;
 
 export default class Paging{
 	private _objCount: number;
@@ -23,8 +23,9 @@ export default class Paging{
 	private _filtersEnabled: boolean;
 	private _cacheOffset: number;
 	private _isDataEndReached: boolean;
-	// Actual number of data objects received for the full result set (known once the
-	// data end is reached or the user requests a full-count fetch). Undefined until known.
+	// Actual number of data objects received for the full result set (populated by an
+	// automatic full-count fetch once results load). Depends only on the filters, so it
+	// persists across paging/sorting and is reset (to undefined) only when filters change.
 	private _receivedCount?: number;
 	// True while a full-count fetch is in progress (button-triggered).
 	private _receivedCountFetching: boolean;
@@ -107,7 +108,8 @@ export default class Paging{
 			pageCount: this._pageCount,
 			filtersEnabled: this._filtersEnabled,
 			isDataEndReached: this._isDataEndReached,
-			receivedCount: this._receivedCount
+			receivedCount: this._receivedCount,
+			receivedCountFetching: this._receivedCountFetching
 		});
 	}
 
@@ -120,7 +122,8 @@ export default class Paging{
 				offset,
 				cacheOffset: Math.min(offset, this._cacheOffset),
 				isDataEndReached: this._isDataEndReached,
-				receivedCount: this._receivedCount
+				receivedCount: this._receivedCount,
+				receivedCountFetching: this._receivedCountFetching
 			});
 
 		} else if (direction > 0){
@@ -131,13 +134,16 @@ export default class Paging{
 				offset,
 				cacheOffset: this._cacheOffset,
 				isDataEndReached: this._isDataEndReached,
-				receivedCount: this._receivedCount
+				receivedCount: this._receivedCount,
+				receivedCountFetching: this._receivedCountFetching
 			});
 
 		} else return this;
 	}
 
-	withObjCount({objCount, pageCount, filtersEnabled, isDataEndReached, receivedCount}: WithProps){
+	// A fresh page of results: the received count depends only on the filters, so it (and
+	// any in-flight full-count fetch) is preserved across paging/sorting.
+	withObjCount({objCount, pageCount, filtersEnabled, isDataEndReached}: WithProps){
 		return new Paging({
 			objCount,
 			offset: this._offset,
@@ -145,7 +151,8 @@ export default class Paging{
 			filtersEnabled,
 			cacheOffset: this._cacheOffset,
 			isDataEndReached: isDataEndReached,
-			receivedCount: receivedCount
+			receivedCount: this._receivedCount,
+			receivedCountFetching: this._receivedCountFetching
 		});
 	}
 
@@ -156,7 +163,8 @@ export default class Paging{
 			pageCount: this._pageCount,
 			filtersEnabled,
 			isDataEndReached: this._isDataEndReached,
-			receivedCount: this._receivedCount
+			receivedCount: this._receivedCount,
+			receivedCountFetching: this._receivedCountFetching
 		});
 	}
 }

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -204,6 +204,7 @@ export interface State {
 	exportQuery: ExportQuery
 	// Dual-view comparison pane: results mirrored from the secondary SPARQL endpoint
 	// using the same (shared) filters. Empty/unused when config.dualView is false.
+	secondaryExportQuery: ExportQuery
 	secondarySpecTable: CompositeSpecTable
 	secondaryObjectsTable: KnownDataObject[]
 	secondaryExtendedDobjInfo: ExtendedDobjInfo[]
@@ -276,6 +277,10 @@ export const defaultState: State = {
 		isFetchingCVS: false,
 		sparqClientQuery: ''
 	},
+	secondaryExportQuery: {
+		isFetchingCVS: false,
+		sparqClientQuery: ''
+	},
 	secondarySpecTable: emptyCompositeSpecTable,
 	secondaryObjectsTable: [],
 	secondaryExtendedDobjInfo: [],
@@ -340,7 +345,8 @@ const deserialize = (jsonObj: StateSerialized, cart: Cart) => {
 		preview: preview,
 		previewSettings: preview.previewSettings,
 		helpStorage: HelpStorage.deserialize(jsonObj.helpStorage),
-		exportQuery: {isFetchingCVS: false, sparqClientQuery: jsonObj.exportQuery.sparqClientQuery}
+		exportQuery: {isFetchingCVS: false, sparqClientQuery: jsonObj.exportQuery.sparqClientQuery},
+		secondaryExportQuery: {isFetchingCVS: false, sparqClientQuery: jsonObj.secondaryExportQuery?.sparqClientQuery ?? ''}
 	};
 
 	return props;

--- a/src/main/js/portal/main/models/State.ts
+++ b/src/main/js/portal/main/models/State.ts
@@ -202,6 +202,12 @@ export interface State {
 	scopedKeywords: string[]
 	filterKeywords: string[]
 	exportQuery: ExportQuery
+	// Dual-view comparison pane: results mirrored from the secondary SPARQL endpoint
+	// using the same (shared) filters. Empty/unused when config.dualView is false.
+	secondarySpecTable: CompositeSpecTable
+	secondaryObjectsTable: KnownDataObject[]
+	secondaryExtendedDobjInfo: ExtendedDobjInfo[]
+	secondaryPaging: Paging
 }
 
 export const emptyCompositeSpecTable = new CompositeSpecTable(
@@ -269,7 +275,11 @@ export const defaultState: State = {
 	exportQuery: {
 		isFetchingCVS: false,
 		sparqClientQuery: ''
-	}
+	},
+	secondarySpecTable: emptyCompositeSpecTable,
+	secondaryObjectsTable: [],
+	secondaryExtendedDobjInfo: [],
+	secondaryPaging: new Paging({objCount: 0})
 };
 
 const update = (state: State, updates: Partial<State>): State => {
@@ -296,6 +306,8 @@ const serialize = (state: State) => {
 		specTable: state.specTable.serialize,
 		baseDobjStats: state.baseDobjStats.serialize,
 		paging: state.paging.serialize,
+		secondarySpecTable: state.secondarySpecTable.serialize,
+		secondaryPaging: state.secondaryPaging.serialize,
 		cart: undefined,
 		priorCart: undefined,
 		preview: state.preview.serialize,
@@ -322,6 +334,8 @@ const deserialize = (jsonObj: StateSerialized, cart: Cart) => {
 		specTable,
 		baseDobjStats,
 		paging: Paging.deserialize(jsonObj.paging),
+		secondarySpecTable: CompositeSpecTable.deserialize(jsonObj.secondarySpecTable),
+		secondaryPaging: Paging.deserialize(jsonObj.secondaryPaging),
 		cart,
 		preview: preview,
 		previewSettings: preview.previewSettings,

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -129,6 +129,12 @@ export class BackendSecondaryExtendedDataObjInfo extends BackendPayload{
 	constructor(readonly extendedDobjInfo: AsyncResult<typeof getExtendedDataObjInfo>){super();}
 }
 
+// Emptied when filters change and a fresh fetch begins, so both panes visibly
+// clear their result lists and counts while the new results are loading.
+export class BackendResultsLoading extends BackendPayload{
+	constructor(){super();}
+}
+
 export class BackendExportQuery extends BackendPayload {
 	constructor(readonly isFetchingCVS: boolean, readonly sparqClientQuery: string) { super(); }
 }

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -136,7 +136,7 @@ export class BackendResultsLoading extends BackendPayload{
 }
 
 export class BackendExportQuery extends BackendPayload {
-	constructor(readonly isFetchingCVS: boolean, readonly sparqClientQuery: string) { super(); }
+	constructor(readonly isFetchingCVS: boolean, readonly sparqClientQuery: string, readonly isSecondary: boolean = false) { super(); }
 }
 
 export class MiscError extends MiscPayload{

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -116,6 +116,19 @@ export class BackendKeywordsFetched extends BackendPayload {
 	constructor(readonly scopedKeywords: string[]){super();}
 }
 
+// Dual-view: payloads carrying results from the secondary SPARQL endpoint
+export class BackendSecondaryOriginsTable extends BackendPayload{
+	constructor(readonly table: SpecTable<OriginsColNames>){super();}
+}
+
+export class BackendSecondaryObjectsFetched extends BackendPayload{
+	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
+}
+
+export class BackendSecondaryExtendedDataObjInfo extends BackendPayload{
+	constructor(readonly extendedDobjInfo: AsyncResult<typeof getExtendedDataObjInfo>){super();}
+}
+
 export class BackendExportQuery extends BackendPayload {
 	constructor(readonly isFetchingCVS: boolean, readonly sparqClientQuery: string) { super(); }
 }

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -109,7 +109,7 @@ export class BackendBatchDownload extends BackendPayload{
 
 export type ObjectsTableLike = AsyncResult<typeof fetchKnownDataObjects>['rows'] | KnownDataObject[];
 export class BackendObjectsFetched extends BackendPayload{
-	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean, readonly receivedCount: number){super();}
+	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
 }
 
 export class BackendKeywordsFetched extends BackendPayload {
@@ -122,7 +122,7 @@ export class BackendSecondaryOriginsTable extends BackendPayload{
 }
 
 export class BackendSecondaryObjectsFetched extends BackendPayload{
-	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean, readonly receivedCount: number){super();}
+	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
 }
 
 export class BackendSecondaryExtendedDataObjInfo extends BackendPayload{

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -109,7 +109,7 @@ export class BackendBatchDownload extends BackendPayload{
 
 export type ObjectsTableLike = AsyncResult<typeof fetchKnownDataObjects>['rows'] | KnownDataObject[];
 export class BackendObjectsFetched extends BackendPayload{
-	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
+	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean, readonly receivedCount: number){super();}
 }
 
 export class BackendKeywordsFetched extends BackendPayload {
@@ -122,7 +122,7 @@ export class BackendSecondaryOriginsTable extends BackendPayload{
 }
 
 export class BackendSecondaryObjectsFetched extends BackendPayload{
-	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean){super();}
+	constructor(readonly objectsTable: ObjectsTableLike, readonly isDataEndReached: boolean, readonly receivedCount: number){super();}
 }
 
 export class BackendSecondaryExtendedDataObjInfo extends BackendPayload{
@@ -133,6 +133,16 @@ export class BackendSecondaryExtendedDataObjInfo extends BackendPayload{
 // clear their result lists and counts while the new results are loading.
 export class BackendResultsLoading extends BackendPayload{
 	constructor(){super();}
+}
+
+// Full-count fetch (button-triggered): a marker that the fetch has started (so the
+// pane can show a spinner) and the payload carrying the resulting total.
+export class BackendFullCountLoading extends BackendPayload{
+	constructor(readonly isSecondary: boolean){super();}
+}
+
+export class BackendFullCount extends BackendPayload{
+	constructor(readonly receivedCount: number, readonly isSecondary: boolean){super();}
 }
 
 export class BackendExportQuery extends BackendPayload {

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -13,7 +13,10 @@ import {
 	BackendBatchDownload,
 	BackendUpdateCart,
 	BackendUpdatePriorCart,
-	BackendExportQuery
+	BackendExportQuery,
+	BackendSecondaryOriginsTable,
+	BackendSecondaryObjectsFetched,
+	BackendSecondaryExtendedDataObjInfo
 } from "./actionpayloads";
 import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
 import config, {CategoryType} from "../config";
@@ -64,6 +67,20 @@ export default function(state: State, payload: BackendPayload): State {
 	if (payload instanceof BackendKeywordsFetched){
 		return stateUtils.update(state, {
 			scopedKeywords: payload.scopedKeywords
+		});
+	}
+
+	if (payload instanceof BackendSecondaryOriginsTable){
+		return stateUtils.update(state, handleSecondaryOriginsTable(state, payload));
+	}
+
+	if (payload instanceof BackendSecondaryObjectsFetched){
+		return stateUtils.update(state, handleSecondaryObjectsFetched(state, payload));
+	}
+
+	if (payload instanceof BackendSecondaryExtendedDataObjInfo){
+		return stateUtils.update(state, {
+			secondaryExtendedDobjInfo: payload.extendedDobjInfo
 		});
 	}
 
@@ -139,6 +156,39 @@ const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
 	return {
 		objectsTable: extendedObjectsTable,
 		paging
+	};
+};
+
+// Dual-view: secondary endpoint mirrors the result list/counts using the shared
+// (primary) filters. We graft the secondary origins onto the primary basics/columnMeta
+// so the same count/availability helpers apply; primary state is never touched here.
+const handleSecondaryOriginsTable = (state: State, payload: BackendSecondaryOriginsTable): Pick<State, 'secondarySpecTable' | 'secondaryPaging'> => {
+	const secondarySpecTable = state.specTable.withOriginsTable(payload.table);
+	return {
+		secondarySpecTable,
+		secondaryPaging: new Paging({ objCount: getObjCount(secondarySpecTable) })
+	};
+};
+
+const handleSecondaryObjectsFetched = (state: State, payload: BackendSecondaryObjectsFetched): Pick<State, 'secondaryObjectsTable' | 'secondaryPaging'> => {
+	const objectsTable = payload.objectsTable as KnownDataObject[];
+	const extendedObjectsTable = objectsTable.map(ot => {
+		const spec = state.specTable.getTableRows('basics').find(r => r.spec === ot.spec);
+		return {...ot, ...spec};
+	});
+
+	const objCount = getObjCount(state.secondarySpecTable);
+	// Paging is shared with the primary pane, so mirror its offset for the window display.
+	const secondaryPaging = state.secondaryPaging.withObjCount({
+		objCount,
+		pageCount: payload.objectsTable.length,
+		filtersEnabled: false,
+		isDataEndReached: payload.isDataEndReached
+	}).withOffset(state.paging.offset);
+
+	return {
+		secondaryObjectsTable: extendedObjectsTable,
+		secondaryPaging
 	};
 };
 

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -90,9 +90,10 @@ export default function(state: State, payload: BackendPayload): State {
 	}
 
 	if (payload instanceof BackendExportQuery) {
-		return stateUtils.update(state, {
-			exportQuery: payload
-		});
+		return stateUtils.update(state, payload.isSecondary
+			? { secondaryExportQuery: payload }
+			: { exportQuery: payload }
+		);
 	}
 
 	if (payload instanceof BackendExtendedDataObjInfo) {

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -16,7 +16,8 @@ import {
 	BackendExportQuery,
 	BackendSecondaryOriginsTable,
 	BackendSecondaryObjectsFetched,
-	BackendSecondaryExtendedDataObjInfo
+	BackendSecondaryExtendedDataObjInfo,
+	BackendResultsLoading
 } from "./actionpayloads";
 import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
 import config, {CategoryType} from "../config";
@@ -82,6 +83,10 @@ export default function(state: State, payload: BackendPayload): State {
 		return stateUtils.update(state, {
 			secondaryExtendedDobjInfo: payload.extendedDobjInfo
 		});
+	}
+
+	if (payload instanceof BackendResultsLoading){
+		return stateUtils.update(state, handleResultsLoading());
 	}
 
 	if (payload instanceof BackendExportQuery) {
@@ -189,6 +194,20 @@ const handleSecondaryObjectsFetched = (state: State, payload: BackendSecondaryOb
 	return {
 		secondaryObjectsTable: extendedObjectsTable,
 		secondaryPaging
+	};
+};
+
+// Clear both panes' result lists and reset their counts to signal that a new
+// fetch (triggered by a filter change) is in progress. The fresh counts/results
+// arrive later via BackendOriginsTable/BackendObjectsFetched and their secondary
+// counterparts.
+const handleResultsLoading = (): Pick<State, 'objectsTable' | 'paging' | 'page' | 'secondaryObjectsTable' | 'secondaryPaging'> => {
+	return {
+		objectsTable: [],
+		paging: new Paging({ objCount: 0 }),
+		page: 0,
+		secondaryObjectsTable: [],
+		secondaryPaging: new Paging({ objCount: 0 })
 	};
 };
 

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -195,12 +195,21 @@ const handleSecondaryObjectsFetched = (state: State, payload: BackendSecondaryOb
 const handleSpecFilterUpdate = (state: State, payload: BackendUpdateSpecFilter) => {
 	const specTable = state.specTable.withFilter(payload.varName as ColNames, payload.filter);
 
+	// Categorical filters update counts client-side (no server refetch), so the
+	// dual-view secondary table must apply the same filter to keep its count in sync.
+	const secondarySpecTable = config.dualView
+		? state.secondarySpecTable.withFilter(payload.varName as ColNames, payload.filter)
+		: state.secondarySpecTable;
+
 	return stateUtils.update(state,{
 		specTable,
 		objectsTable: [],
 		...getNewPaging(state.paging, state.page, specTable, true),
 		filterCategories: Object.assign(state.filterCategories, {[payload.varName]: payload.filter}),
-		checkedObjectsInSearch: []
+		checkedObjectsInSearch: [],
+		secondarySpecTable,
+		secondaryObjectsTable: [],
+		secondaryPaging: new Paging({ objCount: getObjCount(secondarySpecTable) })
 	});
 };
 

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -17,7 +17,9 @@ import {
 	BackendSecondaryOriginsTable,
 	BackendSecondaryObjectsFetched,
 	BackendSecondaryExtendedDataObjInfo,
-	BackendResultsLoading
+	BackendResultsLoading,
+	BackendFullCountLoading,
+	BackendFullCount
 } from "./actionpayloads";
 import stateUtils, {CategFilters, KnownDataObject, State} from "../models/State";
 import config, {CategoryType} from "../config";
@@ -89,6 +91,20 @@ export default function(state: State, payload: BackendPayload): State {
 		return stateUtils.update(state, handleResultsLoading());
 	}
 
+	if (payload instanceof BackendFullCountLoading){
+		return stateUtils.update(state, payload.isSecondary
+			? { secondaryPaging: state.secondaryPaging.withReceivedCountFetching(true) }
+			: { paging: state.paging.withReceivedCountFetching(true) }
+		);
+	}
+
+	if (payload instanceof BackendFullCount){
+		return stateUtils.update(state, payload.isSecondary
+			? { secondaryPaging: state.secondaryPaging.withReceivedCount(payload.receivedCount) }
+			: { paging: state.paging.withReceivedCount(payload.receivedCount) }
+		);
+	}
+
 	if (payload instanceof BackendExportQuery) {
 		return stateUtils.update(state, payload.isSecondary
 			? { secondaryExportQuery: payload }
@@ -156,7 +172,10 @@ const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
 		objCount,
 		pageCount: payload.objectsTable.length,
 		filtersEnabled,
-		isDataEndReached: payload.isDataEndReached
+		isDataEndReached: payload.isDataEndReached,
+		// The received count is the true full total only once the data end is reached;
+		// otherwise it's just a partial page, so leave it unknown until a full fetch.
+		receivedCount: payload.isDataEndReached ? payload.receivedCount : undefined
 	});
 
 	return {
@@ -189,7 +208,8 @@ const handleSecondaryObjectsFetched = (state: State, payload: BackendSecondaryOb
 		objCount,
 		pageCount: payload.objectsTable.length,
 		filtersEnabled: false,
-		isDataEndReached: payload.isDataEndReached
+		isDataEndReached: payload.isDataEndReached,
+		receivedCount: payload.isDataEndReached ? payload.receivedCount : undefined
 	}).withOffset(state.paging.offset);
 
 	return {

--- a/src/main/js/portal/main/reducers/backendReducer.ts
+++ b/src/main/js/portal/main/reducers/backendReducer.ts
@@ -172,10 +172,7 @@ const handleObjectsFetched = (state: State, payload: BackendObjectsFetched) => {
 		objCount,
 		pageCount: payload.objectsTable.length,
 		filtersEnabled,
-		isDataEndReached: payload.isDataEndReached,
-		// The received count is the true full total only once the data end is reached;
-		// otherwise it's just a partial page, so leave it unknown until a full fetch.
-		receivedCount: payload.isDataEndReached ? payload.receivedCount : undefined
+		isDataEndReached: payload.isDataEndReached
 	});
 
 	return {
@@ -208,8 +205,7 @@ const handleSecondaryObjectsFetched = (state: State, payload: BackendSecondaryOb
 		objCount,
 		pageCount: payload.objectsTable.length,
 		filtersEnabled: false,
-		isDataEndReached: payload.isDataEndReached,
-		receivedCount: payload.isDataEndReached ? payload.receivedCount : undefined
+		isDataEndReached: payload.isDataEndReached
 	}).withOffset(state.paging.offset);
 
 	return {

--- a/src/main/js/portal/main/reducers/miscReducer.ts
+++ b/src/main/js/portal/main/reducers/miscReducer.ts
@@ -88,6 +88,11 @@ const handleMiscUpdateSearchOption = (state: State, payload: MiscUpdateSearchOpt
 const resetFilters = (state: State): Partial<State> => {
 	const specTable = state.specTable.withResetFilters();
 
+	// Keep the dual-view secondary table's count in sync when filters are cleared.
+	const secondarySpecTable = config.dualView
+		? state.secondarySpecTable.withResetFilters()
+		: state.secondarySpecTable;
+
 	return {
 		specTable,
 		mapProps: defaultState.mapProps,
@@ -97,7 +102,10 @@ const resetFilters = (state: State): Partial<State> => {
 		checkedObjectsInSearch: [],
 		filterTemporal: new FilterTemporal(),
 		filterNumbers: new FilterNumbers(numberFilterKeys.map(cat => new FilterNumber(cat))),
-		filterKeywords: []
+		filterKeywords: [],
+		secondarySpecTable,
+		secondaryObjectsTable: [],
+		secondaryPaging: new Paging({ objCount: getObjCount(secondarySpecTable) })
 	};
 };
 

--- a/src/main/js/portal/main/sparqlQueries.ts
+++ b/src/main/js/portal/main/sparqlQueries.ts
@@ -76,9 +76,9 @@ where{
 
 export type DobjOriginsAndCountsQuery = Query<"spec" | "submitter" | "count", "station" | "countryCode" | "ecosystem" | "location" | "site" | "stationclass" | "stationNetwork">
 
-export const envriFilteringFromClauses = ""
+export const envriFilteringFromClauses = config.envriFilteringFromGraphs.map(g => `from <${g}>`).join("\n")
 
-export function dobjOriginsAndCounts(filters: FilterRequest[]): DobjOriginsAndCountsQuery {
+export function dobjOriginsAndCounts(filters: FilterRequest[], virtuoso: boolean = true): DobjOriginsAndCountsQuery {
 	let siteQueries: string
 	switch(config.envri){
 		case "SITES":
@@ -105,13 +105,16 @@ export function dobjOriginsAndCounts(filters: FilterRequest[]): DobjOriginsAndCo
 
 	}
 
+	// Virtuoso work-around: the primary endpoint must omit the ENVRI-filtering FROM clauses.
+	const fromClauses = virtuoso ? "" : envriFilteringFromClauses
+
 	const text = `# dobjOriginsAndCounts
 prefix cpmeta: <${config.cpmetaOntoUri}>
 prefix prov: <http://www.w3.org/ns/prov#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix geo: <http://www.opengis.net/ont/geosparql#>
 select ?spec ?countryCode ?submitter ?count ?station ?ecosystem ?location ?site ?stationclass ?stationNetwork
-${envriFilteringFromClauses}
+${fromClauses}
 where{
 	{
 		select ?station ?site ?submitter ?spec (count(?dobj) as ?count) where{
@@ -289,7 +292,7 @@ export function objectFilterClauses(query: QueryParameters): String {
 	${getFilterClauses(filters, false)}`;
 }
 
-export function filteredObjectsQuery(params: QueryParameters, selections: string): string {
+export function filteredObjectsQuery(params: QueryParameters, selections: string, virtuoso: boolean = true): string {
 
 	const { sorting, paging } = params;
 	const orderBy = (sorting && sorting.varName)
@@ -304,7 +307,8 @@ export function filteredObjectsQuery(params: QueryParameters, selections: string
 	// because the FROM clauses do not include the RDF graph that the object's own triples belong to;
 	// in contrast, the magic part of query execution uses the FROM clauses solely to determine the ENVRI
 	const hasKnownObjects = params.filters.filter(isPidFilter).flatMap(f => f.pids || []).length > 0
-	const fromClauses = ""
+	// Virtuoso work-around: the primary endpoint must omit the FROM clauses entirely.
+	const fromClauses = virtuoso ? "" : (hasKnownObjects ? '' : (envriFilteringFromClauses + '\n'))
 
 	return `
 prefix cpmeta: <${config.cpmetaOntoUri}>
@@ -319,10 +323,10 @@ ${orderBy}
 offset ${paging.offset || 0} limit ${paging.limit || 20}`;
 }
 
-export function listFilteredDataObjects(params: QueryParameters): ObjInfoQuery {
+export function listFilteredDataObjects(params: QueryParameters, virtuoso: boolean = true): ObjInfoQuery {
 	const selections = `?dobj ?hasNextVersion ?${SPECCOL} ?fileName ?size ?submTime ?timeStart ?timeEnd`;
 	return {
-		text: `# listFilteredDataObjects${filteredObjectsQuery(params, selections)}`
+		text: `# listFilteredDataObjects${filteredObjectsQuery(params, selections, virtuoso)}`
 	};
 };
 

--- a/src/main/js/portal/main/sparqlQueries.ts
+++ b/src/main/js/portal/main/sparqlQueries.ts
@@ -289,7 +289,9 @@ export function objectFilterClauses(query: QueryParameters): String {
 	${getFilterClauses(filters, false)}`;
 }
 
-export function filteredObjectsQuery(params: QueryParameters, selections: string): string {
+// When asCount is true, the query is identical to the data-objects query except that the
+// only projection is the result count and the `order by`/`offset`/`limit` clauses are dropped.
+export function filteredObjectsQuery(params: QueryParameters, selections: string, asCount: boolean = false): string {
 
 	const { sorting, paging } = params;
 	const orderBy = (sorting && sorting.varName)
@@ -311,18 +313,26 @@ prefix cpmeta: <${config.cpmetaOntoUri}>
 prefix prov: <http://www.w3.org/ns/prov#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix geo: <http://www.opengis.net/ont/geosparql#>
-select ${selections}
+select ${asCount ? '(count(?dobj) as ?count)' : selections}
 ${fromClauses}where {
 ${objectFilterClauses(params)}
-}
+}${asCount ? '' : `
 ${orderBy}
-offset ${paging.offset || 0} limit ${paging.limit || 20}`;
+offset ${paging.offset || 0} limit ${paging.limit || 20}`}`;
 }
 
 export function listFilteredDataObjects(params: QueryParameters): ObjInfoQuery {
 	const selections = `?dobj ?hasNextVersion ?${SPECCOL} ?fileName ?size ?submTime ?timeStart ?timeEnd`;
 	return {
 		text: `# listFilteredDataObjects${filteredObjectsQuery(params, selections)}`
+	};
+};
+
+export type CountQuery = Query<'count', never>
+
+export function countFilteredDataObjects(params: QueryParameters): CountQuery {
+	return {
+		text: `# countFilteredDataObjects${filteredObjectsQuery(params, '', true)}`
 	};
 };
 

--- a/src/main/js/portal/main/sparqlQueries.ts
+++ b/src/main/js/portal/main/sparqlQueries.ts
@@ -76,7 +76,7 @@ where{
 
 export type DobjOriginsAndCountsQuery = Query<"spec" | "submitter" | "count", "station" | "countryCode" | "ecosystem" | "location" | "site" | "stationclass" | "stationNetwork">
 
-export const envriFilteringFromClauses = config.envriFilteringFromGraphs.map(g => `from <${g}>`).join("\n")
+export const envriFilteringFromClauses = ""
 
 export function dobjOriginsAndCounts(filters: FilterRequest[]): DobjOriginsAndCountsQuery {
 	let siteQueries: string
@@ -304,7 +304,7 @@ export function filteredObjectsQuery(params: QueryParameters, selections: string
 	// because the FROM clauses do not include the RDF graph that the object's own triples belong to;
 	// in contrast, the magic part of query execution uses the FROM clauses solely to determine the ENVRI
 	const hasKnownObjects = params.filters.filter(isPidFilter).flatMap(f => f.pids || []).length > 0
-	const fromClauses = hasKnownObjects ? '' : (envriFilteringFromClauses + '\n')
+	const fromClauses = ""
 
 	return `
 prefix cpmeta: <${config.cpmetaOntoUri}>

--- a/src/main/js/portal/main/sparqlQueriesVirtuoso.ts
+++ b/src/main/js/portal/main/sparqlQueriesVirtuoso.ts
@@ -1,3 +1,7 @@
+// Virtuoso variant of sparqlQueries.ts, used for the primary endpoint (main pane).
+// Identical to sparqlQueries.ts except for the Virtuoso work-arounds: the ENVRI-filtering
+// FROM clauses are removed (see envriFilteringFromClauses and filteredObjectsQuery below).
+// The original sparqlQueries.ts is used for the secondary (dual-view comparison) endpoint.
 import commonConfig from '../../common/main/config';
 import localConfig from './config';
 import { Query } from 'icos-cp-backend';
@@ -76,7 +80,7 @@ where{
 
 export type DobjOriginsAndCountsQuery = Query<"spec" | "submitter" | "count", "station" | "countryCode" | "ecosystem" | "location" | "site" | "stationclass" | "stationNetwork">
 
-export const envriFilteringFromClauses = config.envriFilteringFromGraphs.map(g => `from <${g}>`).join("\n")
+export const envriFilteringFromClauses = ""
 
 export function dobjOriginsAndCounts(filters: FilterRequest[]): DobjOriginsAndCountsQuery {
 	let siteQueries: string
@@ -304,7 +308,7 @@ export function filteredObjectsQuery(params: QueryParameters, selections: string
 	// because the FROM clauses do not include the RDF graph that the object's own triples belong to;
 	// in contrast, the magic part of query execution uses the FROM clauses solely to determine the ENVRI
 	const hasKnownObjects = params.filters.filter(isPidFilter).flatMap(f => f.pids || []).length > 0
-	const fromClauses = hasKnownObjects ? '' : (envriFilteringFromClauses + '\n')
+	const fromClauses = ""
 
 	return `
 prefix cpmeta: <${config.cpmetaOntoUri}>

--- a/src/main/js/portal/main/sparqlQueriesVirtuoso.ts
+++ b/src/main/js/portal/main/sparqlQueriesVirtuoso.ts
@@ -16,8 +16,8 @@ import {
 	isNumberFilter, NumberFilterRequest,
 	VariableFilterRequest, isVariableFilter, isKeywordsFilter, isGeoFilter
 } from './models/FilterRequest';
-import { Value } from "./models/SpecTable";
 import { Sha256Str, UrlStr } from './backend/declarations';
+import type { CategFilters } from './models/State';
 
 
 const config = Object.assign(commonConfig, localConfig);
@@ -257,40 +257,158 @@ const getPidListFilter = (pidsList: (string | null)[]) => {
 	return `VALUES ?dobj { ${pidsList.map(fr => `<${config.cpmetaObjectUri}${fr}>`).join(" ")} }\n`;
 };
 
+const uriValues = (vals: string[]): string => vals.map(v => `<${v}>`).join(' ');
+const strValues = (vals: string[]): string =>
+	vals.map(v => `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(' ');
+
+const activeValues = (cats: CategFilters, cat: keyof CategFilters): string[] | null => {
+	const vals = cats[cat];
+	return (vals != null && vals.length > 0) ? vals : null;
+};
+
+// Reproduces the computed ?stationclass BIND/IF from dobjOriginsAndCounts as a filter on the
+// acquisition station's cpmeta:hasStationClass (ICOS only). Selected values are the derived
+// strings "ICOS" / "Associated" / "Other".
+function stationClassClause(classes: string[]): string {
+	const conds = classes.map(cls => {
+		if (cls === "Associated")
+			return `EXISTS {?stationClassStation cpmeta:hasStationClass ?stationClass FILTER(strstarts(?stationClass, "Ass"))}`;
+		if (cls === "Other")
+			return `NOT EXISTS {?stationClassStation cpmeta:hasStationClass []}`;
+		// "ICOS" (any concrete station class not starting with "Ass")
+		return `EXISTS {?stationClassStation cpmeta:hasStationClass ?stationClass FILTER(!strstarts(?stationClass, "Ass"))}`;
+	});
+	const distinctConds = conds.filter((c, i) => conds.indexOf(c) === i);
+	return `?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith ?stationClassStation .
+	FILTER( ${distinctConds.join(' || ')} )`;
+}
+
+// Mirrors specColumnMeta's variable pattern: ?v is the column/variable node, ?vt its value type,
+// ${titleVar} its title. Applies whichever column-meta facets are active.
+function columnMetaPattern(titleVar: string, cats: CategFilters): string {
+	const variable = activeValues(cats, 'variable');
+	const valType = activeValues(cats, 'valType');
+	const quantityKind = activeValues(cats, 'quantityKind');
+	const quantityUnit = activeValues(cats, 'quantityUnit');
+
+	const lines: string[] = [
+		`?${SPECCOL} cpmeta:containsDataset ?ds .`,
+		`{ ?ds cpmeta:hasColumn ?v . ?v cpmeta:hasColumnTitle ${titleVar} } UNION { ?ds cpmeta:hasVariable ?v . ?v cpmeta:hasVariableTitle ${titleVar} }`,
+		`FILTER NOT EXISTS { ?v cpmeta:isQualityFlagFor [] }`,
+		`?v cpmeta:hasValueType ?vt .`
+	];
+	if (variable) lines.push(`VALUES ?v {${uriValues(variable)}}`);
+	if (valType) lines.push(`VALUES ?vt {${uriValues(valType)}}`);
+	if (quantityKind) lines.push(`?vt cpmeta:hasQuantityKind ?qk . VALUES ?qk {${uriValues(quantityKind)}}`);
+	if (quantityUnit) {
+		const naLabel = "(not applicable)";
+		const unitVals = quantityUnit.filter(u => u !== naLabel);
+		const hasNa = unitVals.length !== quantityUnit.length;
+		const alts: string[] = [];
+		if (unitVals.length) alts.push(`{ ?vt cpmeta:hasUnit ?unit . VALUES ?unit {${strValues(unitVals)}} }`);
+		if (hasNa) alts.push(`{ FILTER NOT EXISTS { ?vt cpmeta:hasUnit [] } }`);
+		if (alts.length) lines.push(alts.length > 1 ? `{ ${alts.join(' UNION ')} }` : alts[0]);
+	}
+	return lines.join('\n\t\t');
+}
+
+// Value-type / variable / quantity-kind / quantity-unit facets, reproducing exactly the original
+// two mechanisms: (1) the object's spec must contain a matching non-quality-flag variable, and
+// (2) when variable or valType is selected, the object's *actual* variables (cpmeta:hasVariableName)
+// must match too, with a UNION escape for objects lacking variable metadata (cf. getVarFilter).
+function columnMetaClause(cats: CategFilters): string {
+	const anyActive = (['variable', 'valType', 'quantityKind', 'quantityUnit'] as const)
+		.some(c => activeValues(cats, c));
+	if (!anyActive) return '';
+
+	const mech1 = `FILTER EXISTS {
+		${columnMetaPattern('?vTitle', cats)}
+	}`;
+
+	const coupled = activeValues(cats, 'variable') || activeValues(cats, 'valType');
+	if (!coupled) return mech1;
+
+	const mech2 = `{
+		{ FILTER NOT EXISTS { ?dobj cpmeta:hasVariableName [] } }
+		UNION
+		{
+			?dobj cpmeta:hasVariableName ?matchedVar .
+			FILTER EXISTS {
+		${columnMetaPattern('?matchedVar', cats)}
+			}
+		}
+	}`;
+	return `${mech1}\n\t${mech2}`;
+}
+
+// Builds all facet constraints directly from the raw UI selections, so the (primary/Virtuoso)
+// query is a pure function of the selected filter values, independent of the client-side SpecTable.
+function categoryClauses(cats: CategFilters): string {
+	const clauses: string[] = [];
+
+	const type = activeValues(cats, 'type');
+	if (type) clauses.push(`VALUES ?${SPECCOL} {${uriValues(type)}}`);
+
+	const level = activeValues(cats, 'level');
+	if (level) clauses.push(`?${SPECCOL} cpmeta:hasDataLevel ?level . VALUES ?level {${level.map(l => `"${l}"^^xsd:integer`).join(' ')}}`);
+
+	const format = activeValues(cats, 'format');
+	if (format) clauses.push(`?${SPECCOL} cpmeta:hasFormat ?format . VALUES ?format {${uriValues(format)}}`);
+
+	const theme = activeValues(cats, 'theme');
+	if (theme) clauses.push(`?${SPECCOL} cpmeta:hasDataTheme ?theme . VALUES ?theme {${uriValues(theme)}}`);
+
+	const project = activeValues(cats, 'project');
+	if (project) clauses.push(`FILTER EXISTS {?${SPECCOL} cpmeta:hasAssociatedProject ?project . VALUES ?project {${uriValues(project)}}}`);
+
+	const station = activeValues(cats, 'station');
+	if (station) clauses.push(`?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith ?station . VALUES ?station {${uriValues(station)}}`);
+
+	const submitter = activeValues(cats, 'submitter');
+	if (submitter) clauses.push(`?dobj cpmeta:wasSubmittedBy/prov:wasAssociatedWith ?submitter . VALUES ?submitter {${uriValues(submitter)}}`);
+
+	const countryCode = activeValues(cats, 'countryCode');
+	if (countryCode) clauses.push(`FILTER EXISTS {?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith/cpmeta:countryCode ?countryCode . VALUES ?countryCode {${strValues(countryCode)}}}`);
+
+	const stationNetwork = activeValues(cats, 'stationNetwork');
+	if (stationNetwork) clauses.push(`FILTER EXISTS {?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith/cpmeta:belongsToNetwork ?stationNetwork . VALUES ?stationNetwork {${uriValues(stationNetwork)}}}`);
+
+	const ecosystem = activeValues(cats, 'ecosystem');
+	if (ecosystem) {
+		const ecoArm = config.envri === "SITES" ? "cpmeta:wasPerformedAt" : "prov:wasAssociatedWith";
+		clauses.push(`FILTER EXISTS {?dobj cpmeta:wasAcquiredBy/${ecoArm}/cpmeta:hasEcosystemType ?ecosystem . VALUES ?ecosystem {${uriValues(ecosystem)}}}`);
+	}
+
+	const location = activeValues(cats, 'location');
+	if (location) clauses.push(`FILTER EXISTS {?dobj cpmeta:wasAcquiredBy/cpmeta:wasPerformedAt/cpmeta:hasSpatialCoverage ?location . VALUES ?location {${uriValues(location)}}}`);
+
+	const stationclass = activeValues(cats, 'stationclass');
+	if (stationclass) clauses.push(stationClassClause(stationclass));
+
+	const colMeta = columnMetaClause(cats);
+	if (colMeta) clauses.push(colMeta);
+
+	return clauses.join('\n\t');
+}
+
 export function objectFilterClauses(query: QueryParameters): String {
-	const { specs, stations, submitters, sites, filters } = query;
+	const { filters, filterCategories } = query;
 	const pidsList = filters.filter(isPidFilter).flatMap(filter => filter.pids);
 
 	const pidListFilter = getPidListFilter(pidsList);
 
-	const specsValues = specs == null
-		? `?${SPECCOL} cpmeta:hasDataLevel [] .
-	FILTER NOT EXISTS {?${SPECCOL} cpmeta:hasAssociatedProject/cpmeta:hasHideFromSearchPolicy "true"^^xsd:boolean}`
-		: `VALUES ?${SPECCOL} {<${specs.join('> <')}>}`;
-
-	const submitterSearch = submitters == null ? ''
-		: `VALUES ?submitter {<${submitters.join('> <')}>}
-	?dobj cpmeta:wasSubmittedBy/prov:wasAssociatedWith ?submitter .`;
-
-	const stationSearch = stations == null || stations.filter(Value.isDefined).length === 0
-		? ''
-		: `VALUES ?station {<${stations.filter(Value.isDefined).join('> <')}>}
-	?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith ?station .`;
-
-	const siteSearch = sites == null || sites.filter(Value.isDefined).length === 0
-		? ''
-		: `VALUES ?site {<${sites.filter(Value.isDefined).join('> <')}>}
-	?dobj cpmeta:wasAcquiredBy/cpmeta:wasPerformedAt ?site .`;
+	// value-type/variable coupling is reproduced relationally from filterCategories (columnMetaClause),
+	// so drop the reflection-derived variableNames filter here to avoid double-filtering
+	const nonVarFilters = filters.filter(f => !isVariableFilter(f));
 
 	return `
-	${pidListFilter}${specsValues}
-	?dobj cpmeta:hasObjectSpec ?${SPECCOL} .
+	${pidListFilter}?dobj cpmeta:hasObjectSpec ?${SPECCOL} .
+	?${SPECCOL} cpmeta:hasDataLevel [] .
+	FILTER NOT EXISTS {?${SPECCOL} cpmeta:hasAssociatedProject/cpmeta:hasHideFromSearchPolicy "true"^^xsd:boolean}
 	BIND(EXISTS{[] cpmeta:isNextVersionOf ?dobj} AS ?hasNextVersion)
-	${stationSearch}
-	${siteSearch}
-	${submitterSearch}
+	${categoryClauses(filterCategories)}
 	${standardDobjPropsDef}
-	${getFilterClauses(filters, false)}`;
+	${getFilterClauses(nonVarFilters, false)}`;
 }
 
 export function filteredObjectsQuery(params: QueryParameters, selections: string): string {

--- a/src/main/js/portal/main/sparqlQueriesVirtuoso.ts
+++ b/src/main/js/portal/main/sparqlQueriesVirtuoso.ts
@@ -411,7 +411,9 @@ export function objectFilterClauses(query: QueryParameters): String {
 	${getFilterClauses(nonVarFilters, false)}`;
 }
 
-export function filteredObjectsQuery(params: QueryParameters, selections: string): string {
+// When asCount is true, the query is identical to the data-objects query except that the
+// only projection is the result count and the `order by`/`offset`/`limit` clauses are dropped.
+export function filteredObjectsQuery(params: QueryParameters, selections: string, asCount: boolean = false): string {
 
 	const { sorting, paging } = params;
 	const orderBy = (sorting && sorting.varName)
@@ -433,18 +435,26 @@ prefix cpmeta: <${config.cpmetaOntoUri}>
 prefix prov: <http://www.w3.org/ns/prov#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix geo: <http://www.opengis.net/ont/geosparql#>
-select ${selections}
+select ${asCount ? '(count(?dobj) as ?count)' : selections}
 ${fromClauses}where {
 ${objectFilterClauses(params)}
-}
+}${asCount ? '' : `
 ${orderBy}
-offset ${paging.offset || 0} limit ${paging.limit || 20}`;
+offset ${paging.offset || 0} limit ${paging.limit || 20}`}`;
 }
 
 export function listFilteredDataObjects(params: QueryParameters): ObjInfoQuery {
 	const selections = `?dobj ?hasNextVersion ?${SPECCOL} ?fileName ?size ?submTime ?timeStart ?timeEnd`;
 	return {
 		text: `# listFilteredDataObjects${filteredObjectsQuery(params, selections)}`
+	};
+};
+
+export type CountQuery = Query<'count', never>
+
+export function countFilteredDataObjects(params: QueryParameters): CountQuery {
+	return {
+		text: `# countFilteredDataObjects${filteredObjectsQuery(params, '', true)}`
 	};
 };
 

--- a/src/main/js/portal/main/utils.ts
+++ b/src/main/js/portal/main/utils.ts
@@ -108,8 +108,8 @@ export function getUrlsFromPids(pids: Sha256Str[]): UrlStr[] {
 
 export const pidRegexp = /^(?:https?\:\/\/(?:hdl\.handle\.net|doi\.org)\/)?(?:[\d\.]+\d\/)?([a-zA-Z0-9\-_]{24})$/
 
-export function getUrlWithEnvironmentPrefix(dobj: UrlStr) {
-	return commonConfig.metaBaseUri + '/objects/' + dobj.split('/').pop()
+export function getUrlWithEnvironmentPrefix(dobj: UrlStr, metaBaseUri: string = commonConfig.metaBaseUri) {
+	return metaBaseUri + '/objects/' + dobj.split('/').pop()
 }
 
 export type OptFunction<I, O> = <IOPT extends I | undefined>(io: IOPT) => (IOPT extends undefined ? undefined : O)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,6 +14,10 @@ akka{
 cpdata{
 	interface = "127.0.0.1"
 	port = 9011
+	# Per-ENVRI host of an optional second metadata backend for the portal's
+	# dual-view comparison pane. Empty by default; override per ENVRI, e.g.
+	# secondaryMetaHosts.ICOS = "meta.icos-cp.eu"
+	secondaryMetaHosts = {}
 	auth {
 		pub: ${authPub} #substituted from cpauth core config
 		userSecretSalt = "dummy to be replaced in production with a long random string"

--- a/src/main/scala/se/lu/nateko/cp/data/CpdataConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/data/CpdataConfig.scala
@@ -111,7 +111,10 @@ case class CpdataConfig(
 	postgis: PostgisConfig,
 	etcFacade: EtcFacadeConfig,
 	sentry: SentryConfig,
-	mailing: EmailConfig
+	mailing: EmailConfig,
+	// Optional per-ENVRI host of a second metadata backend, used by the portal's
+	// dual-view comparison pane. Injected into window.envriConfig.secondaryMetaHost.
+	secondaryMetaHosts: Map[Envri, String]
 )
 
 object ConfigReader extends CommonJsonSupport{
@@ -149,7 +152,7 @@ object ConfigReader extends CommonJsonSupport{
 	import se.lu.nateko.cp.cpauth.core.JsonSupport.{given RootJsonFormat[EmailConfig]}
 	given RootJsonFormat[RestHeartConfig] = jsonFormat3(RestHeartConfig.apply)
 	given RootJsonFormat[SentryConfig] = jsonFormat2(SentryConfig.apply)
-	given RootJsonFormat[CpdataConfig] = jsonFormat11(CpdataConfig.apply)
+	given RootJsonFormat[CpdataConfig] = jsonFormat12(CpdataConfig.apply)
 
 	val appConfig: Config = {
 		val confFile = new java.io.File("application.conf").getAbsoluteFile

--- a/src/main/scala/se/lu/nateko/cp/data/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/data/Main.scala
@@ -79,7 +79,7 @@ object Main extends App:
 	val integrityRoute = new IntegrityRouting(authRouting, config.upload, extractEnvri).route(integrityService)
 
 	val licenceRoute = new LicenceRouting(authRouting.userOpt, ConfigReader.metaCore.handleProxies).route
-	val staticRoute = new StaticRouting(config.sentry.portalDsn).route
+	val staticRoute = new StaticRouting(config.sentry.portalDsn, config.secondaryMetaHosts).route
 	val etcUploadRoute = new EtcUploadRouting(authRouting, config.etcFacade, uploadService).route
 
 	val statsRoute = new StatsRouting(postgisLogAnalyzer, ConfigReader.metaCore)

--- a/src/main/scala/se/lu/nateko/cp/data/routes/StaticRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/data/routes/StaticRouting.scala
@@ -19,7 +19,7 @@ import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import scala.concurrent.Future
 import eu.icoscp.envri.Envri
 
-class StaticRouting(sentryPortalDsn: String)(using envriConfigs: EnvriConfigs) {
+class StaticRouting(sentryPortalDsn: String, secondaryMetaHosts: Map[Envri, String])(using envriConfigs: EnvriConfigs) {
 	import StaticRouting.pageMarshaller
 	import UploadRouting.Sha256Segment
 	private type PageFactory = PartialFunction[(String, Envri), Html]
@@ -33,7 +33,7 @@ class StaticRouting(sentryPortalDsn: String)(using envriConfigs: EnvriConfigs) {
 	private val jsAppFolder = "frontendapps"
 
 	private[this] val standardPageFactory: PageFactory = {
-		case ("portal", envri) => views.html.PortalPage(sentryPortalDsn)(envri, envriConfigs(envri))
+		case ("portal", envri) => views.html.PortalPage(sentryPortalDsn, secondaryMetaHosts.get(envri))(envri, envriConfigs(envri))
 		case ("stats", envri) => views.html.StatsPage()(envri, envriConfigs(envri))
 		case ("etcfacade", envri) => views.html.EtcFacadePage()(envri, envriConfigs(envri))
 		case ("dygraph-light", envri) => views.html.DygraphLight()(envri, envriConfigs(envri))

--- a/src/main/twirl/views/JavascriptConfig.scala.html
+++ b/src/main/twirl/views/JavascriptConfig.scala.html
@@ -2,9 +2,12 @@
 @import se.lu.nateko.cp.meta.core.data.EnvriConfig
 @import se.lu.nateko.cp.data.utils.printEnvriConf
 
-@()(implicit envri: Envri, conf: EnvriConfig)
+@(secondaryMetaHost: Option[String] = None)(implicit envri: Envri, conf: EnvriConfig)
 
 <script type="text/javascript">
 	window.envri = "@envri";
 	window.envriConfig = @Html(printEnvriConf(conf));
+	@secondaryMetaHost.map { host =>
+		window.envriConfig.secondaryMetaHost = "@host";
+	}
 </script>

--- a/src/main/twirl/views/PortalPage.scala.html
+++ b/src/main/twirl/views/PortalPage.scala.html
@@ -1,12 +1,12 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.meta.core.data.EnvriConfig
 
-@(sentryDsn: String)(implicit envri: Envri, conf: EnvriConfig)
+@(sentryDsn: String, secondaryMetaHost: Option[String])(implicit envri: Envri, conf: EnvriConfig)
 @CommonPage("Data portal"){
 	<link rel="stylesheet" href="../portal/css/portal.css">
 }{
 	<div id="main"></div>
-	@JavascriptConfig()
+	@JavascriptConfig(secondaryMetaHost)
 	<script type="text/javascript">window.sentryDsn = "@sentryDsn";</script>
 	<script type="module" src="/portal/portal.js"></script>
 }


### PR DESCRIPTION
Temporary test version of `data` with two result panes. Each pane uses a different `meta` endpoint, so we can manually compare how things work with the new `meta-virtuoso`.