### PR TITLE
[stats] Add placeholder data during loading and reset state between views

### DIFF
--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -2,6 +2,30 @@ import React, { Component } from 'react';
 import './styles.css';
 import { getRowSwitch } from './TableRow';
 
+const PLACEHOLDER_ROW_COUNT = 10;
+
+const PLACEHOLDER_WIDTH_PATTERNS = [
+	['col-8', 'col-6', 'col-3'],
+	['col-6', 'col-7', 'col-2'],
+	['col-9', 'col-4', 'col-3'],
+	['col-7', 'col-5', 'col-4'],
+	['col-8', 'col-6', 'col-2'],
+];
+
+const PlaceholderRows = ({ colCount }) =>
+	Array.from({ length: PLACEHOLDER_ROW_COUNT }, (_, i) => {
+		const pattern = PLACEHOLDER_WIDTH_PATTERNS[i % PLACEHOLDER_WIDTH_PATTERNS.length];
+		return (
+			<tr key={'ph-' + i}>
+				{Array.from({ length: colCount }, (_, j) => (
+					<td key={j}>
+						<span className={`placeholder ${pattern[Math.min(j, pattern.length - 1)]}`} />
+					</td>
+				))}
+			</tr>
+		);
+	});
+
 export default class DobjTable extends Component {
 	constructor(props) {
 		super(props);
@@ -26,11 +50,14 @@ export default class DobjTable extends Component {
 					panelTitle={panelTitle}
 				/>
 
-				<div className="card-body table-responsive" style={{ clear: 'both' }}>
+				<div className="card-body table-responsive placeholder-glow" style={{ clear: 'both' }}>
 					<table className="table">
 						<tbody>
 							<TableHeaders tableHeaders={tableHeaders} />
-							{RowSwitch && dataList.map((stat, idx) => <RowSwitch key={'row-' + idx} dobj={stat} onFileNameClick={this.onFileNameClick.bind(this)} />)}
+							{dataList === undefined
+								? <PlaceholderRows colCount={tableHeaders.length} />
+								: RowSwitch && dataList.map((stat, idx) => <RowSwitch key={'row-' + idx} dobj={stat} onFileNameClick={this.onFileNameClick.bind(this)} />)
+							}
 						</tbody>
 					</table>
 				</div>

--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -79,7 +79,7 @@ const Paging = ({ isLoading, hasHashIdFilter, disablePaging, paging, requestPage
 	if (isLoading) {
 		return (
 			<div className="card-header placeholder-glow">
-				<h5 style={{display:'flex', alignItems:'center', gap:'5px'}}>
+				<h5 className="d-flex align-items-center" style={{gap:'5px'}}>
 					{panelTitle}
 					<span className="placeholder" style={{width:'1ch'}} />
 					to

--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -38,11 +38,13 @@ export default class DobjTable extends Component {
 
 	render() {
 		const { dataList, paging, requestPage, panelTitle, tableHeaders, disablePaging, hasHashIdFilter, updateTableWithFilter } = this.props;
+		const isLoading = dataList === undefined;
 		const RowSwitch = dataList && dataList.length ? getRowSwitch(dataList[0], updateTableWithFilter) : undefined;
 
 		return (
 			<div className="card">
 				<Paging
+					isLoading={isLoading}
 					hasHashIdFilter={hasHashIdFilter}
 					disablePaging={disablePaging}
 					paging={paging}
@@ -66,11 +68,19 @@ export default class DobjTable extends Component {
 	}
 }
 
-const Paging = ({ hasHashIdFilter, disablePaging, paging, requestPage, panelTitle }) => {
+const Paging = ({ isLoading, hasHashIdFilter, disablePaging, paging, requestPage, panelTitle }) => {
 	if (hasHashIdFilter) {
 		return (
 			<div className="card-header">
 				<h5 className="card-title">Stats for single data object</h5>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="card-header">
+				<h5 style={{display:'inline'}}>{panelTitle}</h5>
 			</div>
 		);
 	}

--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -3,28 +3,23 @@ import './styles.css';
 import { getRowSwitch } from './TableRow';
 
 const PLACEHOLDER_ROW_COUNT = 10;
+const PLACEHOLDER_COL_RANGES = [[6, 9], [4, 7], [2, 4]];
 
-const PLACEHOLDER_WIDTH_PATTERNS = [
-	['col-8', 'col-6', 'col-3'],
-	['col-6', 'col-7', 'col-2'],
-	['col-9', 'col-4', 'col-3'],
-	['col-7', 'col-5', 'col-4'],
-	['col-8', 'col-6', 'col-2'],
-];
-
-const PlaceholderRows = ({ colCount }) =>
-	Array.from({ length: PLACEHOLDER_ROW_COUNT }, (_, i) => {
-		const pattern = PLACEHOLDER_WIDTH_PATTERNS[i % PLACEHOLDER_WIDTH_PATTERNS.length];
-		return (
+const PlaceholderRows = ({ colCount }) => {
+	const rows = React.useMemo(() =>
+		Array.from({ length: PLACEHOLDER_ROW_COUNT }, (_, i) => (
 			<tr key={'ph-' + i}>
-				{Array.from({ length: colCount }, (_, j) => (
-					<td key={j}>
-						<span className={`placeholder ${pattern[Math.min(j, pattern.length - 1)]}`} />
-					</td>
-				))}
+				{Array.from({ length: colCount }, (_, j) => {
+					const [min, max] = PLACEHOLDER_COL_RANGES[Math.min(j, PLACEHOLDER_COL_RANGES.length - 1)];
+					const width = Math.floor(Math.random() * (max - min + 1)) + min;
+					return <td key={j}><span className={`placeholder col-${width}`} /></td>;
+				})}
 			</tr>
-		);
-	});
+		)),
+		[colCount]
+	);
+	return rows;
+};
 
 export default class DobjTable extends Component {
 	constructor(props) {

--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -2,21 +2,24 @@ import React, { Component } from 'react';
 import './styles.css';
 import { getRowSwitch } from './TableRow';
 
-const PLACEHOLDER_ROW_COUNT = 10;
-const PLACEHOLDER_COL_RANGES = [[6, 9], [4, 7], [2, 4]];
-
-const PlaceholderRows = ({ colCount }) => {
+const PlaceholderRows = ({ colCount, rowCount }) => {
 	const rows = React.useMemo(() =>
-		Array.from({ length: PLACEHOLDER_ROW_COUNT }, (_, i) => (
+		Array.from({ length: rowCount }, (_, i) => (
 			<tr key={'ph-' + i}>
 				{Array.from({ length: colCount }, (_, j) => {
-					const [min, max] = PLACEHOLDER_COL_RANGES[Math.min(j, PLACEHOLDER_COL_RANGES.length - 1)];
-					const width = Math.floor(Math.random() * (max - min + 1)) + min;
-					return <td key={j}><span className={`placeholder col-${width}`} /></td>;
+					if (j === 0) {
+						const pxWidth = Math.floor(Math.random() * 180) + 200; // 200–380px
+						return <td key={j}><span className="placeholder" style={{width: `${pxWidth}px`}} /></td>;
+					}
+					if (j === colCount - 1) {
+						const chWidth = rowCount === 1 ? 5 : 5 - Math.round(i * 4 / (rowCount - 1)); // 5ch→1ch: count col, decreasing
+						return <td key={j}><span className="placeholder" style={{width: `${chWidth}ch`}} /></td>;
+					}
+					return <td key={j}><span className="placeholder" style={{width: '200px'}} /></td>;
 				})}
 			</tr>
 		)),
-		[colCount]
+		[colCount, rowCount]
 	);
 	return rows;
 };
@@ -34,6 +37,7 @@ export default class DobjTable extends Component {
 	render() {
 		const { dataList, paging, requestPage, panelTitle, tableHeaders, disablePaging, hasHashIdFilter, updateTableWithFilter } = this.props;
 		const isLoading = dataList === undefined;
+		const rowCount = disablePaging ? 5 : paging.pagesize;
 		const RowSwitch = dataList && dataList.length ? getRowSwitch(dataList[0], updateTableWithFilter) : undefined;
 
 		return (
@@ -52,7 +56,7 @@ export default class DobjTable extends Component {
 						<tbody>
 							<TableHeaders tableHeaders={tableHeaders} />
 							{isLoading
-								? <PlaceholderRows colCount={tableHeaders.length} />
+								? <PlaceholderRows colCount={tableHeaders.length} rowCount={rowCount} />
 								: RowSwitch && dataList.map((stat, idx) => <RowSwitch key={'row-' + idx} dobj={stat} onFileNameClick={this.onFileNameClick.bind(this)} />)
 							}
 						</tbody>
@@ -74,8 +78,15 @@ const Paging = ({ isLoading, hasHashIdFilter, disablePaging, paging, requestPage
 
 	if (isLoading) {
 		return (
-			<div className="card-header">
-				<h5 style={{display:'inline'}}>{panelTitle}</h5>
+			<div className="card-header placeholder-glow">
+				<h5 style={{display:'flex', alignItems:'center', gap:'5px'}}>
+					{panelTitle}
+					<span className="placeholder" style={{width:'1ch'}} />
+					to
+					<span className="placeholder" style={{width:'3ch'}} />
+					of
+					<span className="placeholder" style={{width:'6ch'}} />
+				</h5>
 			</div>
 		);
 	}

--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -51,7 +51,7 @@ export default class DobjTable extends Component {
 					panelTitle={panelTitle}
 				/>
 
-				<div className="card-body table-responsive placeholder-glow" style={{ clear: 'both' }}>
+				<div className={`card-body table-responsive${isLoading ? ' placeholder-glow' : ''}`} style={{ clear: 'both' }}>
 					<table className="table">
 						<tbody>
 							<TableHeaders tableHeaders={tableHeaders} />

--- a/src/main/js/stats/main/components/DobjTable.jsx
+++ b/src/main/js/stats/main/components/DobjTable.jsx
@@ -51,7 +51,7 @@ export default class DobjTable extends Component {
 					<table className="table">
 						<tbody>
 							<TableHeaders tableHeaders={tableHeaders} />
-							{dataList === undefined
+							{isLoading
 								? <PlaceholderRows colCount={tableHeaders.length} />
 								: RowSwitch && dataList.map((stat, idx) => <RowSwitch key={'row-' + idx} dobj={stat} onFileNameClick={this.onFileNameClick.bind(this)} />)
 							}

--- a/src/main/js/stats/main/components/Filter.jsx
+++ b/src/main/js/stats/main/components/Filter.jsx
@@ -35,7 +35,7 @@ export default class Filter extends Component {
 
 	render() {
 		const { open } = this.state;
-		const { placeholder, filter, value, children } = this.props;
+		const { placeholder, filter, value, children, disabled } = this.props;
 
 		return (
 			<div className="row mt-2" key={filter.name}>
@@ -43,17 +43,19 @@ export default class Filter extends Component {
 				<div className="col-lg-8">
 					{children
 						? children
-						: <Multiselect
-							open={open}
-							placeholder={placeholder}
-							dataKey="id"
-							textField="label"
-							data={value == "" ? filter.values.filter(f => f.count > 0) : filter.values}
-							value={value}
-							filter="contains"
-							onChange={this.handleSelectionChange.bind(this, filter)}
-							onToggle={this.handleToggle.bind(this, value)}
-						/>
+						: disabled
+							? <Multiselect disabled placeholder={placeholder} data={[]} value={[]} dataKey="id" textField="label" />
+							: <Multiselect
+								open={open}
+								placeholder={placeholder}
+								dataKey="id"
+								textField="label"
+								data={value == "" ? filter.values.filter(f => f.count > 0) : filter.values}
+								value={value}
+								filter="contains"
+								onChange={this.handleSelectionChange.bind(this, filter)}
+								onToggle={this.handleToggle.bind(this, value)}
+							/>
 					}
 				</div>
 			</div>

--- a/src/main/js/stats/main/components/Filters.jsx
+++ b/src/main/js/stats/main/components/Filters.jsx
@@ -54,33 +54,38 @@ const LOADING_FILTER_NAMES = [
 	'contributors', 'submitters', 'dlfrom', 'dataOriginCountries'
 ];
 
-const inputPlaceholder = (width = 'w-100') =>
-	<span className={`placeholder d-block ${width}`} style={{height: '38px', borderRadius: '4px'}} />;
-
 const PanelBody = ({ hasHashIdFilter, filters, downloadStats, updateTableWithFilter, temporalFilterUpdate, grayDownloadFilterUpdate }) => {
 	if (!filters || !(filters.length > 0)) {
 		return (
-			<div className="placeholder-glow">
+			<>
 				{LOADING_FILTER_NAMES.map(name => (
-					<div className="row mt-2" key={name}>
-						<label className="col-lg-4 col-form-label">{placeholders[name]}</label>
-						<div className="col-lg-8">{inputPlaceholder()}</div>
-					</div>
+					<Filter key={name} placeholder={placeholders[name]} filter={{name}} disabled={true} value={[]} />
 				))}
-				<div className="row mt-2">
-					<label className="col-lg-4 col-form-label">{placeholders.dlDates}</label>
-					<div className="col-lg-8 d-flex flex-column gap-2">
-						{inputPlaceholder('w-75')}
-						{inputPlaceholder('w-75')}
+				<Filter placeholder={placeholders.dlDates} filter={{name: 'dlDates'}} value={[]}>
+					<div className="row">
+						<div className="col-md-12">
+							<div className="row mb-3">
+								<label className="col-lg-4 col-form-label">From</label>
+								<div className="col-lg-8">
+									<input className="form-control" type="date" disabled />
+								</div>
+							</div>
+							<div className="row mb-3">
+								<label className="col-lg-4 col-form-label">To</label>
+								<div className="col-lg-8">
+									<input className="form-control" type="date" disabled />
+								</div>
+							</div>
+						</div>
 					</div>
-				</div>
-				<div className="row mt-2">
-					<label className="col-lg-4 col-form-label">Search options</label>
-					<div className="col-lg-8 d-flex align-items-center">
-						<span className="placeholder d-block" style={{height: '20px', width: '180px', borderRadius: '4px'}} />
-					</div>
-				</div>
-			</div>
+				</Filter>
+				<Filter placeholder="Search options" filter={{name: 'searchOptions'}} value={[]}>
+					<label className="col-form-label">
+						<input className="form-check-input" type="checkbox" disabled readOnly />
+						<span className="ms-2">Include gray listed IPs</span>
+					</label>
+				</Filter>
+			</>
 		);
 	}
 

--- a/src/main/js/stats/main/components/Filters.jsx
+++ b/src/main/js/stats/main/components/Filters.jsx
@@ -49,35 +49,64 @@ export default function Filters({ filters, downloadStats, resetFilters, updateTa
 	);
 }
 
+const LOADING_FILTER_NAMES = [
+	'specification', 'project', 'dataLevel', 'stations',
+	'contributors', 'submitters', 'dlfrom', 'dataOriginCountries'
+];
+
+const inputPlaceholder = (width = 'w-100') =>
+	<span className={`placeholder d-block ${width}`} style={{height: '38px', borderRadius: '4px'}} />;
+
 const PanelBody = ({ hasHashIdFilter, filters, downloadStats, updateTableWithFilter, temporalFilterUpdate, grayDownloadFilterUpdate }) => {
-	if (filters && filters.length) {
-		const temporalFilters = {
-			name: 'dlDates',
-			values: downloadStats.temporalFilters
-		}
-
+	if (!filters || !(filters.length > 0)) {
 		return (
-			<>
-				{filters.filter(f => f.values && f.values.length && (!hasHashIdFilter || f.displayFilterForSingleObject)).map((filter, idx) =>
-					<Row key={idx} filter={filter} downloadStats={downloadStats} updateTableWithFilter={updateTableWithFilter} />
-				)}
-				<Filter placeholder="Download dates" filter={temporalFilters} value={[]}>
-					<PickDates filterTemporal={temporalFilters.values} setFilterTemporal={temporalFilterUpdate} />
-				</Filter>
-				<Filter placeholder="Search options" filter="" value={[]}>
-					<CheckButton
-						name={"includeGrayDl"}
-						grayDownloadFilterUpdate={grayDownloadFilterUpdate}
-						isChecked={downloadStats.grayDownloadFilter}
-						text={'Include gray listed IPs'}
-					/>
-				</Filter>
-			</>
+			<div className="placeholder-glow">
+				{LOADING_FILTER_NAMES.map(name => (
+					<div className="row mt-2" key={name}>
+						<label className="col-lg-4 col-form-label">{placeholders[name]}</label>
+						<div className="col-lg-8">{inputPlaceholder()}</div>
+					</div>
+				))}
+				<div className="row mt-2">
+					<label className="col-lg-4 col-form-label">{placeholders.dlDates}</label>
+					<div className="col-lg-8 d-flex flex-column gap-2">
+						{inputPlaceholder('w-75')}
+						{inputPlaceholder('w-75')}
+					</div>
+				</div>
+				<div className="row mt-2">
+					<label className="col-lg-4 col-form-label">Search options</label>
+					<div className="col-lg-8 d-flex align-items-center">
+						<span className="placeholder d-block" style={{height: '20px', width: '180px', borderRadius: '4px'}} />
+					</div>
+				</div>
+			</div>
 		);
-
-	} else {
-		return null;
 	}
+
+	const temporalFilters = {
+		name: 'dlDates',
+		values: downloadStats.temporalFilters
+	};
+
+	return (
+		<>
+			{filters.filter(f => f.values && f.values.length && (!hasHashIdFilter || f.displayFilterForSingleObject)).map((filter, idx) =>
+				<Row key={idx} filter={filter} downloadStats={downloadStats} updateTableWithFilter={updateTableWithFilter} />
+			)}
+			<Filter placeholder="Download dates" filter={temporalFilters} value={[]}>
+				<PickDates filterTemporal={temporalFilters.values} setFilterTemporal={temporalFilterUpdate} />
+			</Filter>
+			<Filter placeholder="Search options" filter="" value={[]}>
+				<CheckButton
+					name={"includeGrayDl"}
+					grayDownloadFilterUpdate={grayDownloadFilterUpdate}
+					isChecked={downloadStats.grayDownloadFilter}
+					text={'Include gray listed IPs'}
+				/>
+			</Filter>
+		</>
+	);
 };
 
 const Row = ({ filter, downloadStats, updateTableWithFilter }) => {

--- a/src/main/js/stats/main/models/RadioConfig.js
+++ b/src/main/js/stats/main/models/RadioConfig.js
@@ -4,13 +4,13 @@ const configs = [
 		config: [
 			{
 				envri: ['ICOS', 'SITES'],
-				txt: 'Popular Timeserie variables',
+				txt: 'Popular Timeseries variables',
 				parentTo: "popularTSVars",
 				actionTxt: 'getPopularTimeserieVars'
 			},
 			{
 				envri: ['ICOS', 'SITES'],
-				txt: 'Timeserie',
+				txt: 'Timeseries',
 				actionTxt: 'getPreviewTimeserie'
 			},
 			{

--- a/src/main/js/stats/main/reducer.js
+++ b/src/main/js/stats/main/reducer.js
@@ -51,6 +51,7 @@ export default function(state = initState, action){
 				variousStats: undefined,
 				previewData: undefined,
 				downloadStats: initState.downloadStats,
+				paging: initState.paging,
 			});
 
 		case actionTypes.COUNTRIES_FETCHED:
@@ -217,7 +218,11 @@ export default function(state = initState, action){
 		case actionTypes.RADIO_UPDATED:
 			const partialState = state.view.mode === "previews"
 				? updateRadiosAndPreviewData(state, action)
-				: { mainRadio: state.mainRadio.withSelected(action.actionTxt) };
+				: {
+					mainRadio: state.mainRadio.withSelected(action.actionTxt),
+					variousStats: undefined,
+					paging: initState.paging,
+				};
 
 			return update(partialState);
 
@@ -304,8 +309,9 @@ const aggrResultFormatter = {
 const updateRadiosAndPreviewData = (state, action) => {
 	const radioName = action.isMain ? "mainRadio" : "subRadio";
 	const newRadio = state[radioName].withSelected(action.actionTxt);
-	const previewData = action.radioConfig.name === "mainPreview"
-		? state.previewData
+	const isMainSwitch = action.radioConfig.name === "mainPreview";
+	const previewData = isMainSwitch
+		? undefined
 		: filterPreviewData(newRadio, state.previewDataFull);
 	const mainRadio = radioName === "mainRadio" ? newRadio : state.mainRadio;
 	const subRadio = radioName === "subRadio"
@@ -314,14 +320,16 @@ const updateRadiosAndPreviewData = (state, action) => {
 			? state.subRadio.setActive()
 			: state.subRadio.setInactive();
 
-	const paging = getPreviewPaging(
-		state.previewDataFull,
-		previewData,
-		state.previewSize,
-		state.paging.page,
-		state.mainRadio,
-		state.subRadio
-	);
+	const paging = isMainSwitch
+		? initState.paging
+		: getPreviewPaging(
+			state.previewDataFull,
+			previewData,
+			state.previewSize,
+			state.paging.page,
+			state.mainRadio,
+			state.subRadio
+		);
 
 	return {
 		mainRadio,

--- a/src/main/js/stats/main/reducer.js
+++ b/src/main/js/stats/main/reducer.js
@@ -11,7 +11,7 @@ import FilterTemporal from "./models/FilterTemporal";
 
 export const initState = {
 	view: new ViewMode(localConfig.envri),
-	downloadStats: new StatsTable({}),
+	downloadStats: new StatsTable(undefined),
 	statsMap: new StatsMap(),
 	statsGraph: new StatsGraph(),
 	specProjectLookup: undefined,
@@ -47,7 +47,10 @@ export default function(state = initState, action){
 			return update({
 				view: state.view.setMode(action.mode),
 				statsGraph: {},
-				dateUnit: initState.dateUnit
+				dateUnit: initState.dateUnit,
+				variousStats: undefined,
+				previewData: undefined,
+				downloadStats: initState.downloadStats,
 			});
 
 		case actionTypes.COUNTRIES_FETCHED:


### PR DESCRIPTION
When loading, the view previously looked rather empty, and like it was potentially not loading.

Now, placeholder data (Bootstrap `placeholder`) appears, indicating the content will arrive. This includes data for the views and also for the filters.

Additionally, the state variables are reset between view changes, ensuring stale data is not accidentally presented when waiting for loading.

A typo is corrected as well (Timeserie => Timeseries).