### PR TITLE
[portal] Ensure advanced filter results appear when loaded from URL

### DIFF
--- a/src/main/js/portal/main/actions/main.ts
+++ b/src/main/js/portal/main/actions/main.ts
@@ -41,11 +41,11 @@ export function loadApp(user: WhoAmI): PortalThunkAction<void> {
 
 export function bootstrapRoute(user: WhoAmI, route: Route, previewPids?: Sha256Str[]): PortalThunkAction<void> {
 	return (dispatch, getState) => {
-		const {id, tabs} = getState();
+		const {id} = getState();
 
 		switch (route) {
 			case 'search':
-				dispatch(bootstrapSearch(user, tabs));
+				dispatch(bootstrapSearch(user));
 				break;
 
 			case 'preview':

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -1,6 +1,6 @@
 import {PortalThunkAction} from "../store";
 import SpecTable, {Filter, Value} from "../models/SpecTable";
-import {AdvancedFilter, State, TabsState, WhoAmI} from "../models/State";
+import {AdvancedFilter, State, WhoAmI} from "../models/State";
 import * as Payloads from "../reducers/actionpayloads";
 import {isInPidFilteringMode} from "../reducers/utils";
 import config from "../config";
@@ -36,11 +36,17 @@ import {PersistedMapPropsExtended} from "../models/InitMap";
 import scopedKeywords from "../backend/scopedKeywords";
 
 
-export default function bootstrapSearch(user: WhoAmI,tabs: TabsState): PortalThunkAction<void> {
+export default function bootstrapSearch(user: WhoAmI): PortalThunkAction<void> {
 	return (dispatch, getState) => {
 		const filters = getFilters(getState());
 		dispatch(getBackendTables(filters)).then(_ => {
-			dispatch(getFilteredDataObjects);
+			// The Advanced tab (FilterAdvanced.tsx) independently triggers its own
+			// getFilteredDataObjects on mount. Firing it here too races the two
+			// fetchExtendedDataObjInfo responses and can leave state.extendedDobjInfo
+			// desynced from the correct object list/count (rows silently missing).
+			if (getState().tabs.searchTab !== 1) {
+				dispatch(getFilteredDataObjects);
+			}
 		});
 
 		dispatch(new Payloads.BootstrapRouteSearch());

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -40,10 +40,7 @@ export default function bootstrapSearch(user: WhoAmI): PortalThunkAction<void> {
 	return (dispatch, getState) => {
 		const filters = getFilters(getState());
 		dispatch(getBackendTables(filters)).then(_ => {
-			// The Advanced tab (FilterAdvanced.tsx) independently triggers its own
-			// getFilteredDataObjects on mount. Firing it here too races the two
-			// fetchExtendedDataObjInfo responses and can leave state.extendedDobjInfo
-			// desynced from the correct object list/count (rows silently missing).
+			// Advanced tab boostraps its own results, so skip if on that tab
 			if (getState().tabs.searchTab !== 1) {
 				dispatch(getFilteredDataObjects);
 			}


### PR DESCRIPTION
When loading a URL with an advanced filter, (e.g., https://data.icos-cp.eu/portal/#%7B%22filterFileName%22%3A%22VPRM_ECMWF_GEE_2024_CP.nc%22%2C%22tabs%22%3A%7B%22searchTab%22%3A1%7D%7D ), results do not show consistently: sometimes, the results box is empty.

This is because the `bootstrapSearch` runs when the app is loaded, and the Advanced filter search runs as well, introducing a race condition. If the Advanced filter query finishes first, it is then wiped out by the `bootstrapSearch`, and no results are shown because the `extendedDobjInfo` does not match what is found. This is why the paging info is correct (1 of 1, e.g.) but no rows are shown.

The simplest fix for this is to simply disable the `bootstrapSearch` when the Advanced filter tab is selected.

Additionally, we remove an unused parameter from the `bootstrapSearch` function.