### PR TITLE
[portal] Ensure filteredKeywordsQuery does not run with empty spec list

### DIFF
--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -172,7 +172,8 @@ export const fetchKnownDataObjects = (dobjs: string[]) => {
 };
 
 export function matchesNoResults(options: QueryParameters) {
-	return Filter.allowsNothing(options.specs) || Filter.allowsNothing(options.submitters) || Filter.allowsNothing(options.stations);
+	return (Filter.allowsNothing(options.specs) || Filter.allowsNothing(options.submitters) ||
+		Filter.allowsNothing(options.stations) || Filter.allowsNothing(options.sites));
 }
 
 export function fetchFilteredDataObjects(options: QueryParameters){

--- a/src/main/js/portal/main/backend.ts
+++ b/src/main/js/portal/main/backend.ts
@@ -171,8 +171,12 @@ export const fetchKnownDataObjects = (dobjs: string[]) => {
 		: Promise.resolve({colNames: [], rows: []});
 };
 
+export function matchesNoResults(options: QueryParameters) {
+	return Filter.allowsNothing(options.specs) || Filter.allowsNothing(options.submitters) || Filter.allowsNothing(options.stations);
+}
+
 export function fetchFilteredDataObjects(options: QueryParameters){
-	return Filter.allowsNothing(options.specs) || Filter.allowsNothing(options.submitters) || Filter.allowsNothing(options.stations)
+	return matchesNoResults(options)
 		? Promise.resolve({
 			colNames: [],
 			rows: []

--- a/src/main/js/portal/main/backend/scopedKeywords.ts
+++ b/src/main/js/portal/main/backend/scopedKeywords.ts
@@ -7,7 +7,7 @@ import { UrlStr } from "./declarations";
 import {distinct} from '../utils';
 import { envriFilteringFromClauses, objectFilterClauses } from "../sparqlQueries";
 import { QueryParameters } from "../actions/types";
-import { Filter } from "../models/SpecTable";
+import { matchesNoResults } from "../backend";
 
 export type SpecLookupByKeyword = {[keyword: string]: UrlStr[] | undefined}
 
@@ -39,7 +39,7 @@ where{
 }
 
 function getUniqueKeywords(query: QueryParameters): Promise<string[]>{
-	if (Filter.allowsNothing(query.specs) || Filter.allowsNothing(query.submitters) || Filter.allowsNothing(query.stations)){
+	if (matchesNoResults(query)){
 		return Promise.resolve([]);
 	}
 	return sparqlFetchAndParse(

--- a/src/main/js/portal/main/backend/scopedKeywords.ts
+++ b/src/main/js/portal/main/backend/scopedKeywords.ts
@@ -7,6 +7,7 @@ import { UrlStr } from "./declarations";
 import {distinct} from '../utils';
 import { envriFilteringFromClauses, objectFilterClauses } from "../sparqlQueries";
 import { QueryParameters } from "../actions/types";
+import { Filter } from "../models/SpecTable";
 
 export type SpecLookupByKeyword = {[keyword: string]: UrlStr[] | undefined}
 
@@ -38,6 +39,9 @@ where{
 }
 
 function getUniqueKeywords(query: QueryParameters): Promise<string[]>{
+	if (Filter.allowsNothing(query.specs) || Filter.allowsNothing(query.submitters) || Filter.allowsNothing(query.stations)){
+		return Promise.resolve([]);
+	}
 	return sparqlFetchAndParse(
 		filteredKeywordsQuery(query),
 		commonConfig.sparqlEndpoint,


### PR DESCRIPTION
The `filteredKeywordsQuery` was running with an empty spec list when no results were found.

Instead, use the same logic from `backend.ts`'s `fetchFilteredDataObjects` function to skip running the query if this is the case.