### PR TITLE
[portal] Add active filters, move stations map to filters, add results view switch

### DIFF
--- a/src/main/js/portal/main/actions/common.ts
+++ b/src/main/js/portal/main/actions/common.ts
@@ -38,6 +38,10 @@ export const failWithError: (dispatch: PortalDispatch) => (error: Error) => void
 	dispatch(logError(error));
 };
 
+export const showWarning: (dispatch: PortalDispatch) => (message: string) => void = dispatch => message => {
+	dispatch(new Payloads.MiscWarning(message));
+};
+
 function logError(error: Error): PortalThunkAction<void> {
 	return (_, getState) => {
 		const state = getState();

--- a/src/main/js/portal/main/actions/search.ts
+++ b/src/main/js/portal/main/actions/search.ts
@@ -33,7 +33,9 @@ import Paging from "../models/Paging";
 import { listFilteredDataObjects } from '../sparqlQueries';
 import { sparqlFetchBlob } from "../backend";
 import {PersistedMapPropsExtended} from "../models/InitMap";
+import {deriveMapProps, geoFilterChanged} from "../models/MapProps";
 import scopedKeywords from "../backend/scopedKeywords";
+import deepEqual from 'deep-equal';
 
 
 export default function bootstrapSearch(user: WhoAmI): PortalThunkAction<void> {
@@ -306,10 +308,18 @@ export function switchTab(tabName: string, selectedTabId: number): PortalThunkAc
 }
 
 export function setMapProps(persistedMapProps: PersistedMapPropsExtended): PortalThunkAction<void> {
-	return (dispatch) => {
+	return (dispatch, getState) => {
 		savePersistedMapProps(persistedMapProps)
-		dispatch(new Payloads.MiscUpdateMapProps(persistedMapProps));
-		dispatch(getOriginsThenDobjList);
+
+		const prevMapProps = getState().mapProps;
+		const mapProps = deriveMapProps(persistedMapProps, prevMapProps);
+
+		if (deepEqual(mapProps, prevMapProps)) return;
+
+		dispatch(new Payloads.MiscUpdateMapProps(mapProps));
+
+		if (geoFilterChanged(prevMapProps, mapProps))
+			dispatch(getOriginsThenDobjList);
 	};
 }
 

--- a/src/main/js/portal/main/components/buttons/Paging.tsx
+++ b/src/main/js/portal/main/components/buttons/Paging.tsx
@@ -5,53 +5,73 @@ import config from "../../config";
 import {ExportQuery, SearchOptions} from "../../models/State";
 import { FileDownload } from './FileDownload';
 
-interface Paging {
-	type: 'header' | 'footer'
-	paging: P
-	requestStep: (direction: -1 | 1) => void | undefined
-	searchOptions: SearchOptions | undefined
-	getAllFilteredDataObjects: () => void
-	exportQuery: ExportQuery
-}
-
-export const Paging = (props: Paging) => {
-	const { type, paging, requestStep, searchOptions, getAllFilteredDataObjects, exportQuery } = props;
-
+function pagingCounts(paging: P) {
 	const {offset, objCount, pageCount} = paging;
 	const minObjs = Math.min(offset + pageCount, objCount);
 	const to = minObjs < pageCount
 		? pageCount
 		: minObjs;
 	const count = pageCount < config.stepsize ? to : objCount;
-	const isForwardEnabled = to < count;
+
+	return {offset, to, count, isForwardEnabled: to < count};
+}
+
+interface PagingCount {
+	paging: P
+	searchOptions: SearchOptions | undefined
+	getAllFilteredDataObjects: () => void
+	exportQuery: ExportQuery
+}
+
+export const PagingCount = (props: PagingCount) => {
+	const { paging, searchOptions, getAllFilteredDataObjects, exportQuery } = props;
+
+	const {offset, to, count} = pagingCounts(paging);
 	const showDeprecated = searchOptions ? searchOptions.showDeprecated : false;
 
-	if (type === "header") {
-		return (
-			<div className="card-header bg-transparent">
-				<span className="align-middle">
-					<CountHeader objCount={count} to={to} offset={offset} showDeprecated={showDeprecated} />
+	return (
+		<span className="paging-count py-1">
+			<CountHeader objCount={count} to={to} offset={offset} showDeprecated={showDeprecated} />
 
-					<FileDownload exportQuery={exportQuery} getAllFilteredDataObjects={getAllFilteredDataObjects} searchResultsCount={count} />
-				</span>
-				<div className="float-end lh-sm">
-					<StepButton direction="step-backward" enabled={offset > 0} onStep={() => requestStep(-1)}/>
-					<StepButton direction="step-forward" enabled={isForwardEnabled} onStep={() => requestStep(1)}/>
-				</div>
+			<FileDownload exportQuery={exportQuery} getAllFilteredDataObjects={getAllFilteredDataObjects} searchResultsCount={count} />
+		</span>
+	);
+};
+
+interface PagingSteps {
+	paging: P
+	onStep: (direction: -1 | 1) => void
+}
+
+export const PagingSteps = ({paging, onStep}: PagingSteps) => {
+	const {offset, isForwardEnabled} = pagingCounts(paging);
+
+	return (
+		<>
+			<StepButton direction="step-backward" enabled={offset > 0} onStep={() => onStep(-1)}/>
+			<StepButton direction="step-forward" enabled={isForwardEnabled} onStep={() => onStep(1)}/>
+		</>
+	);
+};
+
+interface PagingFooter {
+	paging: P
+	requestStep: (direction: -1 | 1) => void
+}
+
+export const PagingFooter = ({paging, requestStep}: PagingFooter) => {
+	const onStep = (direction: -1 | 1) => {
+		window.scrollTo(0, 0);
+		requestStep(direction);
+	};
+
+	return (
+		<div className="card-footer">
+			<div style={{textAlign: 'right', lineHeight: '1rem'}}>
+				<PagingSteps paging={paging} onStep={onStep} />
 			</div>
-		);
-	} else if (type === "footer") {
-		return (
-			<div className="card-footer">
-				<div style={{textAlign: 'right', lineHeight: '1rem'}}>
-					<StepButton direction="step-backward" enabled={offset > 0} onStep={() => {window.scrollTo(0, 0);requestStep(-1)}} />
-					<StepButton direction="step-forward" enabled={isForwardEnabled} onStep={() => {window.scrollTo(0, 0);requestStep(1)}} />
-				</div>
-			</div>
-		);
-	} else {
-		return null;
-	}
+		</div>
+	);
 };
 
 interface CountHeader {

--- a/src/main/js/portal/main/components/filters/PanelsWithFilters.tsx
+++ b/src/main/js/portal/main/components/filters/PanelsWithFilters.tsx
@@ -162,12 +162,14 @@ const FilterCtrl: React.FunctionComponent<FilterCtrl> = props => {
 	}
 };
 
+export function getCategoryValueText(filterName: FilterName, value: string | number, countryCodesLookup: Record<string, string>, labelLookup: LabelLookup) {
+	return filterName === 'countryCode'
+		? countryCodesLookup[value]
+		: labelLookup[value]?.label;
+}
+
 function getDataValue(filterName: FilterName, specTable: CompositeSpecTable, countryCodesLookup: Record<string,string>, labelLookup: LabelLookup){
-	const getText = (value: string | number) => {
-		return filterName === 'countryCode'
-			? countryCodesLookup[value]
-			: labelLookup[value]?.label;
-	};
+	const getText = (value: string | number) => getCategoryValueText(filterName, value, countryCodesLookup, labelLookup);
 
 	const name = filterName as CategoryType;
 	const filterUris = specTable.getFilter(name)?.filter(isDefined) ?? [];

--- a/src/main/js/portal/main/components/filters/PanelsWithFilters.tsx
+++ b/src/main/js/portal/main/components/filters/PanelsWithFilters.tsx
@@ -10,6 +10,7 @@ import {FilterNumber, FilterNumbers} from "../../models/FilterNumbers";
 import FilterTemporal from "../../models/FilterTemporal";
 import PickDates from "./PickDates";
 import {KeywordFilter} from "./KeywordFilter";
+import {StationsMapCtrl} from "./StationsMapCtrl";
 import { LabelLookup } from '../../models/State';
 import HelpStorage, {HelpItem} from "../../models/HelpStorage";
 import {isDefined} from "../../utils";
@@ -31,13 +32,15 @@ interface PanelsWithMultiselects extends CommonProps {
 	filterKeywords: string[]
 	setKeywordFilter: (filterKeywords: string[]) => void
 	startCollapsed?: boolean
+	openStationsMap?: () => void
 }
 
 const availableFilters = filters[config.envri];
 
 export const PanelsWithFilters: React.FunctionComponent<PanelsWithMultiselects> = props => {
 	const {specTable, labelLookup, helpStorage, updateFilter, setNumberFilter, filterNumbers, startCollapsed = false,
-		filterTemporal, setFilterTemporal, scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup} = props;
+		filterTemporal, setFilterTemporal, scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup,
+		openStationsMap} = props;
 
 	return (
 		<>
@@ -59,6 +62,7 @@ export const PanelsWithFilters: React.FunctionComponent<PanelsWithMultiselects> 
 					filterKeywords={filterKeywords}
 					setKeywordFilter={setKeywordFilter}
 					startCollapsed={startCollapsed}
+					openStationsMap={i === 0 ? openStationsMap : undefined}
 				/>
 			)}
 		</>
@@ -74,12 +78,18 @@ interface Panel extends CommonProps {
 	filterKeywords: string[]
 	setKeywordFilter: (filterKeywords: string[]) => void
 	startCollapsed?: boolean
+	openStationsMap?: () => void
 }
 
 const Panel: React.FunctionComponent<Panel> = props => {
 	const { header, filterList, specTable, labelLookup, helpStorage, updateFilter, setNumberFilter, filterNumbers, countryCodesLookup,
-		startCollapsed = false, filterTemporal, setFilterTemporal, scopedKeywords, filterKeywords, setKeywordFilter } = props;
+		startCollapsed = false, filterTemporal, setFilterTemporal, scopedKeywords, filterKeywords, setKeywordFilter,
+		openStationsMap } = props;
 	if (filterList.length === 0) return null;
+
+	const stationsMap = openStationsMap
+		? <StationsMapCtrl openStationsMap={openStationsMap} />
+		: null;
 
 	return (
 		<FilterPanel header={header} startCollapsed={startCollapsed}>
@@ -101,6 +111,7 @@ const Panel: React.FunctionComponent<Panel> = props => {
 					setKeywordFilter={setKeywordFilter}
 				/>
 			)}
+			{stationsMap}
 		</FilterPanel>
 	);
 };

--- a/src/main/js/portal/main/components/filters/PanelsWithFilters.tsx
+++ b/src/main/js/portal/main/components/filters/PanelsWithFilters.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {ReactNode} from 'react';
 import config, {filters, CategoryType, NumberFilterCategories, FilterName} from "../../config";
 import CompositeSpecTable, {ColNames} from "../../models/CompositeSpecTable";
 import {Value} from "../../models/SpecTable";
@@ -10,7 +10,6 @@ import {FilterNumber, FilterNumbers} from "../../models/FilterNumbers";
 import FilterTemporal from "../../models/FilterTemporal";
 import PickDates from "./PickDates";
 import {KeywordFilter} from "./KeywordFilter";
-import {StationsMapCtrl} from "./StationsMapCtrl";
 import { LabelLookup } from '../../models/State';
 import HelpStorage, {HelpItem} from "../../models/HelpStorage";
 import {isDefined} from "../../utils";
@@ -32,7 +31,7 @@ interface PanelsWithMultiselects extends CommonProps {
 	filterKeywords: string[]
 	setKeywordFilter: (filterKeywords: string[]) => void
 	startCollapsed?: boolean
-	openStationsMap?: () => void
+	stationsMapCtrl?: ReactNode
 }
 
 const availableFilters = filters[config.envri];
@@ -40,7 +39,7 @@ const availableFilters = filters[config.envri];
 export const PanelsWithFilters: React.FunctionComponent<PanelsWithMultiselects> = props => {
 	const {specTable, labelLookup, helpStorage, updateFilter, setNumberFilter, filterNumbers, startCollapsed = false,
 		filterTemporal, setFilterTemporal, scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup,
-		openStationsMap} = props;
+		stationsMapCtrl} = props;
 
 	return (
 		<>
@@ -62,7 +61,7 @@ export const PanelsWithFilters: React.FunctionComponent<PanelsWithMultiselects> 
 					filterKeywords={filterKeywords}
 					setKeywordFilter={setKeywordFilter}
 					startCollapsed={startCollapsed}
-					openStationsMap={i === 0 ? openStationsMap : undefined}
+					stationsMapCtrl={i === 0 ? stationsMapCtrl : undefined}
 				/>
 			)}
 		</>
@@ -78,21 +77,19 @@ interface Panel extends CommonProps {
 	filterKeywords: string[]
 	setKeywordFilter: (filterKeywords: string[]) => void
 	startCollapsed?: boolean
-	openStationsMap?: () => void
+	stationsMapCtrl?: ReactNode
 }
 
 const Panel: React.FunctionComponent<Panel> = props => {
 	const { header, filterList, specTable, labelLookup, helpStorage, updateFilter, setNumberFilter, filterNumbers, countryCodesLookup,
 		startCollapsed = false, filterTemporal, setFilterTemporal, scopedKeywords, filterKeywords, setKeywordFilter,
-		openStationsMap } = props;
+		stationsMapCtrl } = props;
 	if (filterList.length === 0) return null;
-
-	const stationsMap = openStationsMap
-		? <StationsMapCtrl openStationsMap={openStationsMap} />
-		: null;
 
 	return (
 		<FilterPanel header={header} startCollapsed={startCollapsed}>
+			{stationsMapCtrl}
+
 			{filterList.map((filterName, i) =>
 				<FilterCtrl
 					key={'i' + i}
@@ -111,7 +108,6 @@ const Panel: React.FunctionComponent<Panel> = props => {
 					setKeywordFilter={setKeywordFilter}
 				/>
 			)}
-			{stationsMap}
 		</FilterPanel>
 	);
 };

--- a/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
+++ b/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
@@ -9,9 +9,8 @@ interface OurProps {
 	srid?: SupportedSRIDs
 }
 
-// The preview fits the whole extent of its projection and centers the map in
-// whichever direction is left over, so a frame shaped like anything other than
-// that extent just pads the map out with slack
+const maxPreviewHeight = 300;
+
 function previewMapAspectRatio(srid: SupportedSRIDs | undefined) {
 	const epsgCode = `EPSG:${srid ?? config.olMapSettings.defaultSRID}` as EpsgCode;
 	const [minX, minY, maxX, maxY] = getViewParams(epsgCode).extent;
@@ -21,6 +20,7 @@ function previewMapAspectRatio(srid: SupportedSRIDs | undefined) {
 
 export function StationsMapCtrl(props: OurProps) {
 	const {openStationsMap, mapPreview, srid} = props;
+	const aspectRatio = previewMapAspectRatio(srid);
 
 	function handleKeyDown(event: KeyboardEvent) {
 		if (event.key !== 'Enter' && event.key !== ' ') return;
@@ -30,21 +30,23 @@ export function StationsMapCtrl(props: OurProps) {
 	}
 
 	return (
-		<div
-			className="stations-map-frame bg-light"
-			style={{aspectRatio: String(previewMapAspectRatio(srid))}}
-			role="button"
-			tabIndex={0}
-			title="Open the stations map"
-			onClick={openStationsMap}
-			onKeyDown={handleKeyDown}
-		>
-			{mapPreview}
+		<div className="stations-map-frame-container">
+			<div
+				className="stations-map-frame bg-light"
+				style={{aspectRatio: String(aspectRatio), maxWidth: `${maxPreviewHeight * aspectRatio}px`}}
+				role="button"
+				tabIndex={0}
+				title="Open the stations map"
+				onClick={openStationsMap}
+				onKeyDown={handleKeyDown}
+			>
+				{mapPreview}
 
-			<div className="stations-map-frame-overlay">
-				<span className="stations-map-expand">
-					<i className="fas fa-expand-arrows-alt" aria-hidden="true" />
-				</span>
+				<div className="stations-map-frame-overlay">
+					<span className="stations-map-expand">
+						<i className="fas fa-expand-arrows-alt" aria-hidden="true" />
+					</span>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
+++ b/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
@@ -1,30 +1,51 @@
-import React from 'react';
-import HelpButton from "../../containers/help/HelpButton";
+import React, {KeyboardEvent, ReactNode} from 'react';
+import { EpsgCode, getViewParams, SupportedSRIDs } from 'icos-cp-ol';
+import config from '../../config';
 
 
 interface OurProps {
 	openStationsMap: () => void
+	mapPreview: ReactNode
+	srid?: SupportedSRIDs
+}
+
+// The preview fits the whole extent of its projection and centers the map in
+// whichever direction is left over, so a frame shaped like anything other than
+// that extent just pads the map out with slack
+function previewMapAspectRatio(srid: SupportedSRIDs | undefined) {
+	const epsgCode = `EPSG:${srid ?? config.olMapSettings.defaultSRID}` as EpsgCode;
+	const [minX, minY, maxX, maxY] = getViewParams(epsgCode).extent;
+
+	return (maxX - minX) / (maxY - minY);
 }
 
 export function StationsMapCtrl(props: OurProps) {
-	const {openStationsMap} = props;
+	const {openStationsMap, mapPreview, srid} = props;
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key !== 'Enter' && event.key !== ' ') return;
+
+		event.preventDefault();
+		openStationsMap();
+	}
 
 	return (
-		<>
-			<div className="row" style={{marginTop: 10}}>
-				<div className="col">
-					<label>Stations map</label>
+		<div
+			className="stations-map-frame bg-light"
+			style={{aspectRatio: String(previewMapAspectRatio(srid))}}
+			role="button"
+			tabIndex={0}
+			title="Open the stations map"
+			onClick={openStationsMap}
+			onKeyDown={handleKeyDown}
+		>
+			{mapPreview}
 
-					<HelpButton name="stationsMap" />
-				</div>
+			<div className="stations-map-frame-overlay">
+				<span className="stations-map-expand">
+					<i className="fas fa-expand-arrows-alt" aria-hidden="true" />
+				</span>
 			</div>
-			<div className="row">
-				<div className="col-md-12">
-					<button className="btn btn-light border px-4" type="button" onClick={openStationsMap}>
-						Open map
-					</button>
-				</div>
-			</div>
-		</>
+		</div>
 	);
 }

--- a/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
+++ b/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import HelpButton from "../../containers/help/HelpButton";
+
+
+interface OurProps {
+	openStationsMap: () => void
+}
+
+export const StationsMapCtrl: React.FunctionComponent<OurProps> = props => {
+	const {openStationsMap} = props;
+
+	return (
+		<>
+			<div className="row" style={{marginTop: 10}}>
+				<div className="col">
+					<label>Stations map</label>
+
+					<HelpButton name="stationsMap" />
+				</div>
+			</div>
+			<div className="row">
+				<div className="col-md-12">
+					<button className="btn btn-light border px-4" type="button" onClick={openStationsMap}>
+						Open map
+					</button>
+				</div>
+			</div>
+		</>
+	);
+};

--- a/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
+++ b/src/main/js/portal/main/components/filters/StationsMapCtrl.tsx
@@ -6,7 +6,7 @@ interface OurProps {
 	openStationsMap: () => void
 }
 
-export const StationsMapCtrl: React.FunctionComponent<OurProps> = props => {
+export function StationsMapCtrl(props: OurProps) {
 	const {openStationsMap} = props;
 
 	return (
@@ -27,4 +27,4 @@ export const StationsMapCtrl: React.FunctionComponent<OurProps> = props => {
 			</div>
 		</>
 	);
-};
+}

--- a/src/main/js/portal/main/components/searchResult/ResultViewSwitch.tsx
+++ b/src/main/js/portal/main/components/searchResult/ResultViewSwitch.tsx
@@ -6,7 +6,7 @@ interface OurProps {
 	setCompact: (isCompact: boolean) => void
 }
 
-export const ResultViewSwitch: React.FunctionComponent<OurProps> = props => {
+export function ResultViewSwitch(props: OurProps) {
 	const {isCompact, setCompact} = props;
 
 	return (
@@ -40,4 +40,4 @@ export const ResultViewSwitch: React.FunctionComponent<OurProps> = props => {
 			</label>
 		</div>
 	);
-};
+}

--- a/src/main/js/portal/main/components/searchResult/ResultViewSwitch.tsx
+++ b/src/main/js/portal/main/components/searchResult/ResultViewSwitch.tsx
@@ -20,7 +20,7 @@ export function ResultViewSwitch(props: OurProps) {
 				checked={!isCompact}
 				onChange={() => setCompact(false)}
 			/>
-			<label className="btn btn-outline-secondary d-flex align-items-center" htmlFor="result-view-default" title="View default results">
+			<label className="btn btn-outline-secondary d-flex align-items-center py-1" htmlFor="result-view-default" title="View default results">
 				<i className="fas fa-list me-2" />
 				Default
 			</label>
@@ -34,7 +34,7 @@ export function ResultViewSwitch(props: OurProps) {
 				checked={isCompact}
 				onChange={() => setCompact(true)}
 			/>
-			<label className="btn btn-outline-secondary d-flex align-items-center" htmlFor="result-view-compact" title="View compact results">
+			<label className="btn btn-outline-secondary d-flex align-items-center py-1" htmlFor="result-view-compact" title="View compact results">
 				<i className="fas fa-table me-2" />
 				Compact
 			</label>

--- a/src/main/js/portal/main/components/searchResult/ResultViewSwitch.tsx
+++ b/src/main/js/portal/main/components/searchResult/ResultViewSwitch.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+
+interface OurProps {
+	isCompact: boolean
+	setCompact: (isCompact: boolean) => void
+}
+
+export const ResultViewSwitch: React.FunctionComponent<OurProps> = props => {
+	const {isCompact, setCompact} = props;
+
+	return (
+		<div className="btn-group" role="group" aria-label="Toggle between default and compact search results">
+			<input
+				type="radio"
+				className="btn-check"
+				name="result-view"
+				id="result-view-default"
+				autoComplete="off"
+				checked={!isCompact}
+				onChange={() => setCompact(false)}
+			/>
+			<label className="btn btn-outline-secondary d-flex align-items-center" htmlFor="result-view-default" title="View default results">
+				<i className="fas fa-list me-2" />
+				Default
+			</label>
+
+			<input
+				type="radio"
+				className="btn-check"
+				name="result-view"
+				id="result-view-compact"
+				autoComplete="off"
+				checked={isCompact}
+				onChange={() => setCompact(true)}
+			/>
+			<label className="btn btn-outline-secondary d-flex align-items-center" htmlFor="result-view-compact" title="View compact results">
+				<i className="fas fa-table me-2" />
+				Compact
+			</label>
+		</div>
+	);
+};

--- a/src/main/js/portal/main/components/ui/Tabs.tsx
+++ b/src/main/js/portal/main/components/ui/Tabs.tsx
@@ -52,8 +52,8 @@ export default class Tabs extends Component<Props>{
 
 		return (
 			<div className="card">
-				<div className="card-header">
-					<ul className="nav nav-tabs card-header-tabs">{
+				<div className="card-header aligned-card-header-with-tabs d-flex align-items-end">
+					<ul className="nav nav-tabs card-header-tabs flex-grow-1">{
 						this.tabState.map(tab =>
 							<li key={'tabHeader' + tab.id} className={'nav-item'}>
 								<a style={{cursor: 'pointer'}} className={tab.isActive ? 'nav-link active' : 'nav-link'} onClick={this.onTabClick.bind(this, tab.id)}>{

--- a/src/main/js/portal/main/config.ts
+++ b/src/main/js/portal/main/config.ts
@@ -113,12 +113,25 @@ const excludedStation = {
 	ICOSCities: cirlcePointStyle('white', 'DarkRed', 4, 2)
 }
 
+const includedStationSmall = {
+	ICOS: cirlcePointStyle('tomato', 'white', 3, 1),
+	SITES: cirlcePointStyle('Magenta', 'white', 3, 1),
+	ICOSCities: cirlcePointStyle('tomato', 'white', 3, 1)
+}
+
+const excludedStationSmall = {
+	ICOS: cirlcePointStyle('white', 'DarkRed', 2, 1),
+	SITES: cirlcePointStyle('white', 'DarkMagenta', 2, 1),
+	ICOSCities: cirlcePointStyle('white', 'DarkRed', 2, 1)
+}
+
 export type OlMapSettings = {
 	sridsInMap: Record<SupportedSRIDs, string>
 	defaultSRID: SupportedSRIDs
 	defaultBaseMap: BaseMapId
 	baseMapFilter: BaseMapFilter
 	iconStyles: Record<string, Style>
+	smallIconStyles: Record<string, Style>
 }
 const olMapSettings: OlMapSettings = {
 	sridsInMap: sridsInMap[envri],
@@ -128,6 +141,10 @@ const olMapSettings: OlMapSettings = {
 	iconStyles: {
 		includedStation: includedStation[envri],
 		excludedStation: excludedStation[envri]
+	},
+	smallIconStyles: {
+		includedStation: includedStationSmall[envri],
+		excludedStation: excludedStationSmall[envri]
 	}
 };
 

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -22,6 +22,7 @@ type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type IncomingProps = {
 	removeMapRect: () => void
+	clearAllFilters: () => void
 }
 
 type OurProps = StateProps & DispatchProps & IncomingProps;
@@ -51,7 +52,7 @@ function ActiveFilters(props: OurProps) {
 	const {
 		specTable, filterTemporal, filterNumbers, filterKeywords, filterAdvancedText, filterAdvancedType,
 		filterPids, tabs, spatialRects, labelLookup, countryCodesLookup,
-		updateFilter, setFilterTemporal, setNumberFilter, setKeywordFilter, updateAdvanced, removeMapRect
+		updateFilter, setFilterTemporal, setNumberFilter, setKeywordFilter, updateAdvanced, removeMapRect, clearAllFilters
 	} = props;
 
 	const groups: TagGroup[] = [];
@@ -171,6 +172,10 @@ function ActiveFilters(props: OurProps) {
 			{groups.map(group => (
 				<FilterTagGroup key={group.key} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
 			))}
+			<span className="active-filter-tag active-filter-tag-warning" onClick={clearAllFilters}>
+				Clear all
+				<i className="fas fa-trash" />
+			</span>
 		</div>
 	);
 }

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import {AdvancedFilter, State} from "../../models/State";
+import {PortalDispatch} from "../../store";
+import {ColNames} from "../../models/CompositeSpecTable";
+import {Value} from "../../models/SpecTable";
+import config, {CategoryType, numericFilterLabels, placeholders} from "../../config";
+import FilterTemporal from "../../models/FilterTemporal";
+import {FilterNumber} from "../../models/FilterNumbers";
+import {
+	specFilterUpdate,
+	setFilterTemporal,
+	setNumberFilter,
+	setKeywordFilter,
+	updateAdvanced
+} from "../../actions/search";
+import {isInPidFilteringMode} from "../../reducers/utils";
+import {getCategoryValueText} from "../../components/filters/PanelsWithFilters";
+import {isDefined} from "../../utils";
+
+type StateProps = ReturnType<typeof stateToProps>;
+type DispatchProps = ReturnType<typeof dispatchToProps>;
+type IncomingProps = {
+	removeMapRect: () => void
+}
+
+type OurProps = StateProps & DispatchProps & IncomingProps;
+
+const advancedFilterTypeLabels: {[key in AdvancedFilter]: string} = {
+	dobj: 'Data object PID',
+	collection: 'Collection PID',
+	filename: 'File name'
+};
+
+type TagValue = {
+	key: string
+	text: string
+	onRemove: () => void
+}
+
+type TagGroup = {
+	key: string
+	label: string
+	values: TagValue[]
+}
+
+function ActiveFilters(props: OurProps) {
+	const {
+		specTable, filterTemporal, filterNumbers, filterKeywords, filterAdvancedText, filterAdvancedType,
+		filterPids, tabs, spatialRects, labelLookup, countryCodesLookup,
+		updateFilter, setFilterTemporal, setNumberFilter, setKeywordFilter, updateAdvanced, removeMapRect
+	} = props;
+
+	const groups: TagGroup[] = [];
+
+	if (isInPidFilteringMode(tabs, filterPids)) {
+		groups.push({
+			key: 'advanced',
+			label: advancedFilterTypeLabels[filterAdvancedType],
+			values: [{
+				key: 'advanced',
+				text: filterAdvancedText,
+				onRemove: () => updateAdvanced('', filterAdvancedType)
+			}]
+		});
+	} else {
+		const activeCategoryColumns = specTable.names.filter(colName => specTable.getFilter(colName) !== null);
+
+		activeCategoryColumns.forEach(colName => {
+			const filterValues = (specTable.getFilter(colName) ?? []).filter(isDefined);
+			const categoryName = colName as unknown as CategoryType;
+
+			groups.push({
+				key: `category:${colName}`,
+				label: placeholders[config.envri][categoryName],
+				values: filterValues.map(value => ({
+					key: `${colName}:${value}`,
+					text: getCategoryValueText(categoryName, value, countryCodesLookup, labelLookup) ?? String(value),
+					onRemove: () => updateFilter(colName, filterValues.filter(v => v !== value))
+				}))
+			});
+		});
+
+		if (filterKeywords.length > 0) {
+			groups.push({
+				key: 'keywords',
+				label: 'Keyword',
+				values: filterKeywords.map(keyword => ({
+					key: `keyword:${keyword}`,
+					text: keyword,
+					onRemove: () => setKeywordFilter(filterKeywords.filter(k => k !== keyword))
+				}))
+			});
+		}
+
+		filterNumbers.validFilters.forEach(filterNumber => {
+			groups.push({
+				key: `number:${filterNumber.category}`,
+				label: numericFilterLabels[filterNumber.category],
+				values: [{
+					key: `number:${filterNumber.category}`,
+					text: filterNumber.txt,
+					onRemove: () => setNumberFilter(filterNumber.validate(''))
+				}]
+			});
+		});
+
+		const {dataTime, submission} = filterTemporal;
+
+		const dataTimeValues: TagValue[] = [];
+		if (dataTime.from) {
+			dataTimeValues.push({
+				key: 'dataTime:from',
+				text: `From ${dataTime.fromDateStr}`,
+				onRemove: () => setFilterTemporal(filterTemporal.withDataTimeFrom(undefined))
+			});
+		}
+		if (dataTime.to) {
+			dataTimeValues.push({
+				key: 'dataTime:to',
+				text: `To ${dataTime.toDateStr}`,
+				onRemove: () => setFilterTemporal(filterTemporal.withDataTimeTo(undefined))
+			});
+		}
+		if (dataTimeValues.length > 0) {
+			groups.push({key: 'dataTime', label: 'Sampling date', values: dataTimeValues});
+		}
+
+		const submissionValues: TagValue[] = [];
+		if (submission.from) {
+			submissionValues.push({
+				key: 'submission:from',
+				text: `From ${submission.fromDateStr}`,
+				onRemove: () => setFilterTemporal(filterTemporal.withSubmissionFrom(undefined))
+			});
+		}
+		if (submission.to) {
+			submissionValues.push({
+				key: 'submission:to',
+				text: `To ${submission.toDateStr}`,
+				onRemove: () => setFilterTemporal(filterTemporal.withSubmissionTo(undefined))
+			});
+		}
+		if (submissionValues.length > 0) {
+			groups.push({key: 'submission', label: 'Submission date', values: submissionValues});
+		}
+
+		if (spatialRects && spatialRects.length > 0) {
+			groups.push({
+				key: 'map',
+				label: 'Map filter',
+				values: [{key: 'map', text: 'Active', onRemove: removeMapRect}]
+			});
+		}
+	}
+
+	if (groups.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="active-filters d-flex flex-wrap border-bottom">
+			<span className="active-filters-label">
+				<i className="fas fa-filter" /> Active filters
+			</span>
+			{groups.map(group => <FilterTagGroup key={group.key} label={group.label} values={group.values} />)}
+		</div>
+	);
+}
+
+type FilterTagGroupProps = {
+	label: string
+	values: TagValue[]
+}
+
+function FilterTagGroup({label, values}: FilterTagGroupProps) {
+	return (
+		<div className="active-filter-group">
+			<span className="active-filter-category">{label}</span>
+			{values.map(value => <FilterTag key={value.key} label={value.text} onRemove={value.onRemove} />)}
+		</div>
+	);
+}
+
+type FilterTagProps = {
+	label: string
+	onRemove: () => void
+}
+
+function FilterTag({label, onRemove}: FilterTagProps) {
+	return (
+		<span className="active-filter-tag">
+			{label}
+			<i
+				className="fas fa-times"
+				title="Remove this filter"
+				onClick={onRemove}
+			/>
+		</span>
+	);
+}
+
+function stateToProps(state: State) {
+	return {
+		specTable: state.specTable,
+		filterTemporal: state.filterTemporal,
+		filterNumbers: state.filterNumbers,
+		filterKeywords: state.filterKeywords,
+		filterAdvancedText: state.filterAdvancedText,
+		filterAdvancedType: state.filterAdvancedType,
+		filterPids: state.filterPids,
+		tabs: state.tabs,
+		spatialRects: state.mapProps.rects,
+		labelLookup: state.labelLookup,
+		countryCodesLookup: state.countryCodesLookup
+	};
+}
+
+function dispatchToProps(dispatch: PortalDispatch) {
+	return {
+		updateFilter: (varName: ColNames, values: Value[]) => dispatch(specFilterUpdate(varName, values)),
+		setFilterTemporal: (filterTemporal: FilterTemporal) => dispatch(setFilterTemporal(filterTemporal)),
+		setNumberFilter: (numberFilter: FilterNumber) => dispatch(setNumberFilter(numberFilter)),
+		setKeywordFilter: (filterKeywords: string[]) => dispatch(setKeywordFilter(filterKeywords)),
+		updateAdvanced: (filterText: string, filterType: AdvancedFilter) => dispatch(updateAdvanced(filterText, filterType))
+	};
+}
+
+export default connect(stateToProps, dispatchToProps)(ActiveFilters);

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -166,9 +166,6 @@ function ActiveFilters(props: OurProps) {
 
 	return (
 		<div className="active-filters d-flex flex-wrap border-bottom">
-			<span className="active-filters-label">
-				<i className="fas fa-filter" /> Active filters
-			</span>
 			{groups.map(group => (
 				<FilterTagGroup key={group.key} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
 			))}

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -32,6 +32,8 @@ const advancedFilterTypeLabels: {[key in AdvancedFilter]: string} = {
 	filename: 'File name'
 };
 
+const collapseThreshold = 4;
+
 type TagValue = {
 	key: string
 	text: string
@@ -42,6 +44,7 @@ type TagGroup = {
 	key: string
 	label: string
 	values: TagValue[]
+	onRemoveAll?: () => void
 }
 
 function ActiveFilters(props: OurProps) {
@@ -77,7 +80,8 @@ function ActiveFilters(props: OurProps) {
 					key: `${colName}:${value}`,
 					text: getCategoryValueText(categoryName, value, countryCodesLookup, labelLookup) ?? String(value),
 					onRemove: () => updateFilter(colName, filterValues.filter(v => v !== value))
-				}))
+				})),
+				onRemoveAll: () => updateFilter(colName, [])
 			});
 		});
 
@@ -89,7 +93,8 @@ function ActiveFilters(props: OurProps) {
 					key: `keyword:${keyword}`,
 					text: keyword,
 					onRemove: () => setKeywordFilter(filterKeywords.filter(k => k !== keyword))
-				}))
+				})),
+				onRemoveAll: () => setKeywordFilter([])
 			});
 		}
 
@@ -163,7 +168,9 @@ function ActiveFilters(props: OurProps) {
 			<span className="active-filters-label">
 				<i className="fas fa-filter" /> Active filters
 			</span>
-			{groups.map(group => <FilterTagGroup key={group.key} label={group.label} values={group.values} />)}
+			{groups.map(group => (
+				<FilterTagGroup key={group.key} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
+			))}
 		</div>
 	);
 }
@@ -171,13 +178,19 @@ function ActiveFilters(props: OurProps) {
 type FilterTagGroupProps = {
 	label: string
 	values: TagValue[]
+	onRemoveAll?: () => void
 }
 
-function FilterTagGroup({label, values}: FilterTagGroupProps) {
+function FilterTagGroup({label, values, onRemoveAll}: FilterTagGroupProps) {
+	const isCollapsed = onRemoveAll !== undefined && values.length >= collapseThreshold;
+
 	return (
 		<div className="active-filter-group">
 			<span className="active-filter-category">{label}</span>
-			{values.map(value => <FilterTag key={value.key} label={value.text} onRemove={value.onRemove} />)}
+			{isCollapsed
+				? <FilterTag label={`${values.length} items`} onRemove={onRemoveAll} />
+				: values.map(value => <FilterTag key={value.key} label={value.text} onRemove={value.onRemove} />)
+			}
 		</div>
 	);
 }

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import {connect} from 'react-redux';
 import {AdvancedFilter, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
@@ -179,14 +179,14 @@ function ActiveFilters(props: OurProps) {
 	}
 
 	return (
-		<div className="active-filters d-flex flex-wrap border-bottom">
+		<div className="align-items-center gap-3 p-3 d-flex flex-wrap border-bottom">
 			{groups.map(group => (
 				<FilterTagGroup key={group.name} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
 			))}
-			<span className="active-filter-tag active-filter-tag-warning" onClick={clearAllFilters}>
+			<a className="active-filter-clear text-decoration-none user-select-none" onClick={clearAllFilters}>
 				Clear all
-				<i className="fas fa-trash" />
-			</span>
+				<i className="fas fa-trash ms-1" />
+			</a>
 		</div>
 	);
 }
@@ -201,8 +201,8 @@ function FilterTagGroup({label, values, onRemoveAll}: FilterTagGroupProps) {
 	const isCollapsed = onRemoveAll !== undefined && values.length >= collapseThreshold;
 
 	return (
-		<div className="active-filter-group">
-			<span className="active-filter-category">{label}</span>
+		<div className="d-inline-flex align-items-center gap-2">
+			<span className="fs-sm fw-semibold text-dark">{label}</span>
 			{isCollapsed
 				? <FilterTag label={`${values.length} items`} onRemove={onRemoveAll} />
 				: values.map(value => <FilterTag key={value.key} label={value.text} onRemove={value.onRemove} />)

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -4,7 +4,7 @@ import {AdvancedFilter, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
 import {ColNames} from "../../models/CompositeSpecTable";
 import {Value} from "../../models/SpecTable";
-import config, {CategoryType, numericFilterLabels, placeholders} from "../../config";
+import config, {CategoryType, filters, FilterName, numericFilterLabels, placeholders} from "../../config";
 import FilterTemporal from "../../models/FilterTemporal";
 import {FilterNumber} from "../../models/FilterNumbers";
 import {
@@ -35,6 +35,18 @@ const advancedFilterTypeLabels: {[key in AdvancedFilter]: string} = {
 
 const collapseThreshold = 4;
 
+type GroupName = FilterName | 'map' | 'advanced';
+
+const filterOrder: ReadonlyArray<GroupName> = [
+	'map',
+	...filters[config.envri].flatMap(panel => panel.filterList)
+];
+
+function filterOrderIndex(groupName: GroupName): number {
+	const index = filterOrder.indexOf(groupName);
+	return index === -1 ? filterOrder.length : index;
+}
+
 type TagValue = {
 	key: string
 	text: string
@@ -42,7 +54,7 @@ type TagValue = {
 }
 
 type TagGroup = {
-	key: string
+	name: GroupName
 	label: string
 	values: TagValue[]
 	onRemoveAll?: () => void
@@ -59,7 +71,7 @@ function ActiveFilters(props: OurProps) {
 
 	if (isInPidFilteringMode(tabs, filterPids)) {
 		groups.push({
-			key: 'advanced',
+			name: 'advanced',
 			label: advancedFilterTypeLabels[filterAdvancedType],
 			values: [{
 				key: 'advanced',
@@ -75,7 +87,7 @@ function ActiveFilters(props: OurProps) {
 			const categoryName = colName as unknown as CategoryType;
 
 			groups.push({
-				key: `category:${colName}`,
+				name: categoryName,
 				label: placeholders[config.envri][categoryName],
 				values: filterValues.map(value => ({
 					key: `${colName}:${value}`,
@@ -88,7 +100,7 @@ function ActiveFilters(props: OurProps) {
 
 		if (filterKeywords.length > 0) {
 			groups.push({
-				key: 'keywords',
+				name: 'keywordFilter',
 				label: 'Keyword',
 				values: filterKeywords.map(keyword => ({
 					key: `keyword:${keyword}`,
@@ -101,7 +113,7 @@ function ActiveFilters(props: OurProps) {
 
 		filterNumbers.validFilters.forEach(filterNumber => {
 			groups.push({
-				key: `number:${filterNumber.category}`,
+				name: filterNumber.category,
 				label: numericFilterLabels[filterNumber.category],
 				values: [{
 					key: `number:${filterNumber.category}`,
@@ -129,7 +141,7 @@ function ActiveFilters(props: OurProps) {
 			});
 		}
 		if (dataTimeValues.length > 0) {
-			groups.push({key: 'dataTime', label: 'Sampling date', values: dataTimeValues});
+			groups.push({name: 'dataTime', label: 'Sampling date', values: dataTimeValues});
 		}
 
 		const submissionValues: TagValue[] = [];
@@ -148,17 +160,19 @@ function ActiveFilters(props: OurProps) {
 			});
 		}
 		if (submissionValues.length > 0) {
-			groups.push({key: 'submission', label: 'Submission date', values: submissionValues});
+			groups.push({name: 'submission', label: 'Submission date', values: submissionValues});
 		}
 
 		if (spatialRects && spatialRects.length > 0) {
 			groups.push({
-				key: 'map',
+				name: 'map',
 				label: 'Map filter',
 				values: [{key: 'map', text: 'Active', onRemove: removeMapRect}]
 			});
 		}
 	}
+
+	groups.sort((group, otherGroup) => filterOrderIndex(group.name) - filterOrderIndex(otherGroup.name));
 
 	if (groups.length === 0) {
 		return null;
@@ -167,7 +181,7 @@ function ActiveFilters(props: OurProps) {
 	return (
 		<div className="active-filters d-flex flex-wrap border-bottom">
 			{groups.map(group => (
-				<FilterTagGroup key={group.key} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
+				<FilterTagGroup key={group.name} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
 			))}
 			<span className="active-filter-tag active-filter-tag-warning" onClick={clearAllFilters}>
 				Clear all

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -218,13 +218,13 @@ type FilterTagProps = {
 
 function FilterTag({label, onRemove}: FilterTagProps) {
 	return (
-		<span className="active-filter-tag">
+		<span
+			className="active-filter-tag"
+			onClick={onRemove}
+			title="Remove this filter"
+		>
 			{label}
-			<i
-				className="fas fa-times"
-				title="Remove this filter"
-				onClick={onRemove}
-			/>
+			<i className="fas fa-times" />
 		</span>
 	);
 }

--- a/src/main/js/portal/main/containers/search/ActiveFilters.tsx
+++ b/src/main/js/portal/main/containers/search/ActiveFilters.tsx
@@ -184,8 +184,8 @@ function ActiveFilters(props: OurProps) {
 				<FilterTagGroup key={group.name} label={group.label} values={group.values} onRemoveAll={group.onRemoveAll} />
 			))}
 			<a className="active-filter-clear text-decoration-none user-select-none" onClick={clearAllFilters}>
+				<i className="fas fa-trash me-1" />
 				Clear all
-				<i className="fas fa-trash ms-1" />
 			</a>
 		</div>
 	);
@@ -202,7 +202,7 @@ function FilterTagGroup({label, values, onRemoveAll}: FilterTagGroupProps) {
 
 	return (
 		<div className="d-inline-flex align-items-center gap-2">
-			<span className="fs-sm fw-semibold text-dark">{label}</span>
+			<span className="fs-sm text-dark">{label}</span>
 			{isCollapsed
 				? <FilterTag label={`${values.length} items`} onRemove={onRemoveAll} />
 				: values.map(value => <FilterTag key={value.key} label={value.text} onRemove={value.onRemove} />)

--- a/src/main/js/portal/main/containers/search/Filters.tsx
+++ b/src/main/js/portal/main/containers/search/Filters.tsx
@@ -19,29 +19,19 @@ type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type incommingProps = {
 	tabHeader: string
-	handleFilterReset: () => void
 }
 type OurProps = StateProps & DispatchProps & incommingProps;
 
 class Filters extends Component<OurProps> {
 	render(){
 		const {
-			specTable, filterTemporal, helpStorage, labelLookup, updateFilter, handleFilterReset,
-			setFilterTemporal, filterAdvancedText, filterAdvancedType, setNumberFilter, filterNumbers,
-			scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup, spatialRects
+			specTable, filterTemporal, helpStorage, labelLookup, updateFilter,
+			setFilterTemporal, setNumberFilter, filterNumbers,
+			scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup
 		} = this.props;
-
-		const resetBtnEnabled = filterTemporal.hasFilter
-			|| specTable.hasActiveFilters
-			|| filterNumbers.hasFilters
-			|| filterKeywords.length > 0
-			|| filterAdvancedText.length > 0
-			|| (!!spatialRects && spatialRects.length > 0)
 
 		return (
 			<div>
-				<ResetBtn enabled={resetBtnEnabled} resetFiltersAction={handleFilterReset} />
-
 				<PanelsWithFilters
 					filterNumbers={filterNumbers}
 					specTable={specTable}
@@ -63,29 +53,6 @@ class Filters extends Component<OurProps> {
 	}
 }
 
-interface ResetBtn {
-	resetFiltersAction: Function,
-	enabled: boolean
-}
-
-const ResetBtn = ({ resetFiltersAction, enabled }: ResetBtn) => {
-	const onClick = () => enabled ? resetFiltersAction() : {};
-	const baseStyle = {margin: '7px', fontSize: 14};
-	const style = enabled
-		? {...baseStyle, cursor: 'pointer'}
-		: {...baseStyle, opacity: 0.5};
-	const title = enabled ? "Reset all filters" : "No active filters";
-
-	return (
-		<div className="d-flex justify-content-end">
-			<span className="fa-stack fa-1x" onClick={onClick} title={title} style={style}>
-		 		<i className="fas fa-filter fa-stack-1x" />
-	 			<i className="fas fa-ban fa-stack-2x" />
-			</span>
-		</div>
-	);
-};
-
 function stateToProps(state: State){
 	return {
 		filterTemporal: state.filterTemporal,
@@ -95,10 +62,7 @@ function stateToProps(state: State){
 		labelLookup: state.labelLookup,
 		countryCodesLookup: state.countryCodesLookup,
 		scopedKeywords: state.scopedKeywords,
-		filterKeywords: state.filterKeywords,
-		filterAdvancedText: state.filterAdvancedText,
-		filterAdvancedType: state.filterAdvancedType,
-		spatialRects: state.mapProps.rects
+		filterKeywords: state.filterKeywords
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/Filters.tsx
+++ b/src/main/js/portal/main/containers/search/Filters.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, ReactNode} from 'react';
 import {connect} from 'react-redux';
 import {Value} from "../../models/SpecTable";
 import {State} from "../../models/State";
@@ -19,7 +19,7 @@ type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type incommingProps = {
 	tabHeader: string
-	openStationsMap: () => void
+	stationsMapCtrl: ReactNode
 }
 type OurProps = StateProps & DispatchProps & incommingProps;
 
@@ -28,7 +28,7 @@ class Filters extends Component<OurProps> {
 		const {
 			specTable, filterTemporal, helpStorage, labelLookup, updateFilter,
 			setFilterTemporal, setNumberFilter, filterNumbers,
-			scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup, openStationsMap
+			scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup, stationsMapCtrl
 		} = this.props;
 
 		return (
@@ -47,9 +47,8 @@ class Filters extends Component<OurProps> {
 					filterKeywords={filterKeywords}
 					setKeywordFilter={setKeywordFilter}
 					startCollapsed={false}
-					openStationsMap={openStationsMap}
+					stationsMapCtrl={stationsMapCtrl}
 				/>
-
 			</div>
 		);
 	}

--- a/src/main/js/portal/main/containers/search/Filters.tsx
+++ b/src/main/js/portal/main/containers/search/Filters.tsx
@@ -19,6 +19,7 @@ type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type incommingProps = {
 	tabHeader: string
+	openStationsMap: () => void
 }
 type OurProps = StateProps & DispatchProps & incommingProps;
 
@@ -27,7 +28,7 @@ class Filters extends Component<OurProps> {
 		const {
 			specTable, filterTemporal, helpStorage, labelLookup, updateFilter,
 			setFilterTemporal, setNumberFilter, filterNumbers,
-			scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup
+			scopedKeywords, filterKeywords, setKeywordFilter, countryCodesLookup, openStationsMap
 		} = this.props;
 
 		return (
@@ -46,6 +47,7 @@ class Filters extends Component<OurProps> {
 					filterKeywords={filterKeywords}
 					setKeywordFilter={setKeywordFilter}
 					startCollapsed={false}
+					openStationsMap={openStationsMap}
 				/>
 
 			</div>

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -131,7 +131,7 @@ class Search extends Component<OurProps, OurState> {
 
 					<div style={expandedFilters}>
 						<Tabs tabName="searchTab" selectedTabId={tabs.searchTab} switchTab={switchTab}>
-							<Filters tabHeader="Filters" handleFilterReset={this.handleFilterReset.bind(this)} />
+							<Filters tabHeader="Filters" />
 							<Advanced tabHeader="Advanced" />
 						</Tabs>
 					</div>
@@ -146,11 +146,13 @@ class Search extends Component<OurProps, OurState> {
 							handleAddToCart={this.handleAddToCart.bind(this)}
 							handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
 							removeMapRect={this.handleRemoveMapRect.bind(this)}
+							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
 						<SearchResultCompact
 							tabHeader="Compact view"
 							handlePreview={this.handlePreview.bind(this)}
 							removeMapRect={this.handleRemoveMapRect.bind(this)}
+							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
 						<SearchResultMap
 							key={srid}
@@ -159,6 +161,7 @@ class Search extends Component<OurProps, OurState> {
 							updatePersistedMapProps={this.updatePersistedMapProps.bind(this)}
 							updateMapSelectedSRID={this.updateMapSelectedSRID.bind(this)}
 							removeMapRect={this.handleRemoveMapRect.bind(this)}
+							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
 					</Tabs>
 				</div>

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -81,6 +81,11 @@ class Search extends Component<OurProps, OurState> {
 		this.props.filtersReset();
 	}
 
+	handleRemoveMapRect() {
+		this.persistedMapProps = {...this.persistedMapProps, drawFeatures: []};
+		this.props.setMapProps(this.persistedMapProps);
+	}
+
 	updatePersistedMapProps(persistedMapProps: PersistedMapPropsExtended) {
 		this.persistedMapProps = { ...this.persistedMapProps, ...persistedMapProps };
 		this.props.setMapProps(this.persistedMapProps);
@@ -140,10 +145,12 @@ class Search extends Component<OurProps, OurState> {
 							handlePreview={this.handlePreview.bind(this)}
 							handleAddToCart={this.handleAddToCart.bind(this)}
 							handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+							removeMapRect={this.handleRemoveMapRect.bind(this)}
 						/>
 						<SearchResultCompact
 							tabHeader="Compact view"
 							handlePreview={this.handlePreview.bind(this)}
+							removeMapRect={this.handleRemoveMapRect.bind(this)}
 						/>
 						<SearchResultMap
 							key={srid}
@@ -151,6 +158,7 @@ class Search extends Component<OurProps, OurState> {
 							persistedMapProps={this.persistedMapProps}
 							updatePersistedMapProps={this.updatePersistedMapProps.bind(this)}
 							updateMapSelectedSRID={this.updateMapSelectedSRID.bind(this)}
+							removeMapRect={this.handleRemoveMapRect.bind(this)}
 						/>
 					</Tabs>
 				</div>

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -16,6 +16,8 @@ import Filters from "./Filters";
 import SearchResultCompact from "./SearchResultCompact";
 import Advanced from "./Advanced";
 import StationsMap from './StationsMap';
+import {StationsMapPreview} from './StationsMapPreview';
+import {StationsMapCtrl} from '../../components/filters/StationsMapCtrl';
 import {ResultViewSwitch} from '../../components/searchResult/ResultViewSwitch';
 import { SupportedSRIDs } from 'icos-cp-ol';
 import config from '../../config';
@@ -141,6 +143,12 @@ class Search extends Component<OurProps, OurState> {
 
 		const isCompact = tabs.resultTab === compactViewTabId;
 
+		const stationsMapCtrl = <StationsMapCtrl
+			openStationsMap={this.openStationsMap.bind(this)}
+			mapPreview={<StationsMapPreview persistedMapProps={this.persistedMapProps} />}
+			srid={srid}
+		/>;
+
 		const resultsView = isCompact
 			? <SearchResultCompact
 				handlePreview={this.handlePreview.bind(this)}
@@ -165,7 +173,7 @@ class Search extends Component<OurProps, OurState> {
 
 					<div style={expandedFilters}>
 						<Tabs tabName="searchTab" selectedTabId={tabs.searchTab} switchTab={switchTab}>
-							<Filters tabHeader="Filters" openStationsMap={this.openStationsMap.bind(this)} />
+							<Filters tabHeader="Filters" stationsMapCtrl={stationsMapCtrl} />
 							<Advanced tabHeader="Advanced" />
 						</Tabs>
 					</div>

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -19,7 +19,7 @@ import StationsMap from './StationsMap';
 import {StationsMapPreview} from './StationsMapPreview';
 import {StationsMapCtrl} from '../../components/filters/StationsMapCtrl';
 import {ResultViewSwitch} from '../../components/searchResult/ResultViewSwitch';
-import { SupportedSRIDs } from 'icos-cp-ol';
+import { BaseMapId, SupportedSRIDs } from 'icos-cp-ol';
 import config from '../../config';
 import { PersistedMapPropsExtended } from '../../models/InitMap';
 import { rectsToDrawFeatures } from '../../models/MapProps';
@@ -36,6 +36,9 @@ type OurProps = StateProps & DispatchProps & { HelpSection: ReactNode };
 type OurState = {
 	expandedFilters: boolean
 	srid?: SupportedSRIDs
+	// Kept in state, unlike the other persisted map props, so that a base map picked in the
+	// modal map reaches the preview while both are mounted
+	baseMap?: BaseMapId
 	isStationsMapOpen: boolean
 };
 
@@ -66,6 +69,7 @@ class Search extends Component<OurProps, OurState> {
 		this.state = {
 			expandedFilters: !isSmallDevice(),
 			srid: this.persistedMapProps.srid,
+			baseMap: this.persistedMapProps.baseMap,
 			isStationsMapOpen: false
 		};
 	}
@@ -132,6 +136,10 @@ class Search extends Component<OurProps, OurState> {
 	updatePersistedMapProps(persistedMapProps: PersistedMapPropsExtended) {
 		this.persistedMapProps = { ...this.persistedMapProps, ...persistedMapProps };
 		this.props.setMapProps(this.persistedMapProps);
+
+		const baseMap = this.persistedMapProps.baseMap;
+		if (baseMap !== this.state.baseMap)
+			this.setState({ baseMap });
 	}
 
 	updateMapSelectedSRID(srid: SupportedSRIDs) {
@@ -168,9 +176,20 @@ class Search extends Component<OurProps, OurState> {
 
 		const isCompact = tabs.resultTab === compactViewTabId;
 
+		// Without a center and a zoom the preview fits the whole extent of its projection, and
+		// without visibleToggles it shows every layer it is given. Taking the base map from
+		// state is what makes the preview follow the one picked in the modal map
+		const previewMapProps = {
+			...this.persistedMapProps,
+			baseMap: this.state.baseMap,
+			visibleToggles: undefined,
+			center: undefined,
+			zoom: undefined
+		};
+
 		const stationsMapCtrl = <StationsMapCtrl
 			openStationsMap={this.openStationsMap.bind(this)}
-			mapPreview={<StationsMapPreview persistedMapProps={this.persistedMapProps} />}
+			mapPreview={<StationsMapPreview previewMapProps={previewMapProps} />}
 			srid={srid}
 		/>;
 

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -4,7 +4,9 @@ import { Modal } from 'react-bootstrap';
 import {debounce, Events} from 'icos-cp-utils';
 import Tabs from '../../components/ui/Tabs';
 import SearchResultRegular from './SearchResultRegular';
-import {updateCheckedObjectsInSearch, switchTab, filtersReset, setMapProps} from '../../actions/search';
+import {updateCheckedObjectsInSearch, switchTab, filtersReset, setMapProps, requestStep, getAllFilteredDataObjects} from '../../actions/search';
+import {Paging} from '../../components/buttons/Paging';
+import ActiveFilters from './ActiveFilters';
 import {getLastSegmentsInUrls, isSmallDevice} from '../../utils';
 import {Sha256Str, UrlStr} from "../../backend/declarations";
 import {PortalDispatch} from "../../store";
@@ -14,11 +16,15 @@ import Filters from "./Filters";
 import SearchResultCompact from "./SearchResultCompact";
 import Advanced from "./Advanced";
 import StationsMap from './StationsMap';
+import {ResultViewSwitch} from '../../components/searchResult/ResultViewSwitch';
 import { SupportedSRIDs } from 'icos-cp-ol';
 import config from '../../config';
 import { PersistedMapPropsExtended } from '../../models/InitMap';
 import { getPersistedMapProps } from '../../backend';
 import { addingToCartProhibition } from '../../models/CartItem';
+
+const defaultViewTabId = 0;
+const compactViewTabId = 1;
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
@@ -57,6 +63,10 @@ class Search extends Component<OurProps, OurState> {
 			srid: this.persistedMapProps.srid,
 			isStationsMapOpen: false
 		};
+	}
+
+	setCompactView(isCompact: boolean) {
+		this.props.switchTab('resultTab', isCompact ? compactViewTabId : defaultViewTabId);
 	}
 
 	openStationsMap() {
@@ -123,10 +133,23 @@ class Search extends Component<OurProps, OurState> {
 	}
 
 	render(){
-		const { HelpSection, tabs, switchTab } = this.props;
+		const { HelpSection, tabs, switchTab, paging, searchOptions, exportQuery,
+			requestStep, getAllFilteredDataObjects } = this.props;
 		const { srid } = this.state;
 		const expandedFilters = this.state.expandedFilters ? {} : {height: 0, overflow: 'hidden'};
 		const filterIconClass = this.state.expandedFilters ? "fas fa-angle-up float-end" : "fas fa-angle-down float-end";
+
+		const isCompact = tabs.resultTab === compactViewTabId;
+
+		const resultsView = isCompact
+			? <SearchResultCompact
+				handlePreview={this.handlePreview.bind(this)}
+			/>
+			: <SearchResultRegular
+				handlePreview={this.handlePreview.bind(this)}
+				handleAddToCart={this.handleAddToCart.bind(this)}
+				handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+			/>;
 
 		return (
 			<div className="row" style={{ position: 'relative' }}>
@@ -150,22 +173,29 @@ class Search extends Component<OurProps, OurState> {
 				</div>
 
 				<div className="col-sm-8 col-md-9">
-					<Tabs tabName="resultTab" selectedTabId={tabs.resultTab} switchTab={switchTab}>
-						<SearchResultRegular
-							tabHeader="Search results"
-							handlePreview={this.handlePreview.bind(this)}
-							handleAddToCart={this.handleAddToCart.bind(this)}
-							handleAllCheckboxesChange={this.handleAllCheckboxesChange.bind(this)}
+					<div className="card">
+						<div className="card-header d-flex justify-content-between align-items-center">
+							Search results
+
+							<ResultViewSwitch isCompact={isCompact} setCompact={this.setCompactView.bind(this)} />
+						</div>
+
+						<ActiveFilters
 							removeMapRect={this.handleRemoveMapRect.bind(this)}
 							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
-						<SearchResultCompact
-							tabHeader="Compact view"
-							handlePreview={this.handlePreview.bind(this)}
-							removeMapRect={this.handleRemoveMapRect.bind(this)}
-							clearAllFilters={this.handleFilterReset.bind(this)}
+
+						<Paging
+							searchOptions={searchOptions}
+							type="header"
+							paging={paging}
+							requestStep={requestStep}
+							getAllFilteredDataObjects={getAllFilteredDataObjects}
+							exportQuery={exportQuery}
 						/>
-					</Tabs>
+
+						{resultsView}
+					</div>
 				</div>
 
 				<Modal
@@ -197,7 +227,10 @@ function stateToProps(state: State){
 	return {
 		checkedObjectsInSearch: state.checkedObjectsInSearch,
 		objectsTable: state.objectsTable,
-		tabs: state.tabs
+		tabs: state.tabs,
+		paging: state.paging,
+		searchOptions: state.searchOptions,
+		exportQuery: state.exportQuery
 	};
 }
 
@@ -208,7 +241,9 @@ function dispatchToProps(dispatch: PortalDispatch){
 		updateCheckedObjects: (ids: UrlStr[] | UrlStr) => dispatch(updateCheckedObjectsInSearch(ids)),
 		switchTab: (tabName: string, selectedTabId: number) => dispatch(switchTab(tabName, selectedTabId)),
 		setMapProps: (mapProps: PersistedMapPropsExtended) => dispatch(setMapProps(mapProps)),
-		filtersReset: () => dispatch(filtersReset)
+		filtersReset: () => dispatch(filtersReset),
+		requestStep: (direction: -1 | 1) => dispatch(requestStep(direction)),
+		getAllFilteredDataObjects: () => dispatch(getAllFilteredDataObjects())
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -293,8 +293,7 @@ class Search extends Component<OurProps, OurState> {
 					keyboard={true}
 				>
 					<Modal.Header>
-						{/* Growing the title keeps the buttons at the far end of the header */}
-						<Modal.Title className="flex-grow-1">Stations map</Modal.Title>
+						<Modal.Title className="flex-grow-1">Filter by geographic region</Modal.Title>
 
 						{stationsMapButtons}
 					</Modal.Header>

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -10,7 +10,7 @@ import ActiveFilters from './ActiveFilters';
 import {getLastSegmentsInUrls, isSmallDevice} from '../../utils';
 import {Sha256Str, UrlStr} from "../../backend/declarations";
 import {PortalDispatch} from "../../store";
-import {Route, State} from "../../models/State";
+import {DrawRectBbox, Route, State} from "../../models/State";
 import {addToCart, updateRoute} from "../../actions/common";
 import Filters from "./Filters";
 import SearchResultCompact from "./SearchResultCompact";
@@ -22,6 +22,8 @@ import {ResultViewSwitch} from '../../components/searchResult/ResultViewSwitch';
 import { SupportedSRIDs } from 'icos-cp-ol';
 import config from '../../config';
 import { PersistedMapPropsExtended } from '../../models/InitMap';
+import { rectsToDrawFeatures } from '../../models/MapProps';
+import deepEqual from 'deep-equal';
 import { getPersistedMapProps } from '../../backend';
 import { addingToCartProhibition } from '../../models/CartItem';
 
@@ -41,6 +43,7 @@ class Search extends Component<OurProps, OurState> {
 	private events: typeof Events;
 	private handleResize: Function;
 	private persistedMapProps: PersistedMapPropsExtended;
+	private mapRectsSnapshot?: DrawRectBbox[];
 
 	constructor(props: OurProps) {
 		super(props);
@@ -72,11 +75,28 @@ class Search extends Component<OurProps, OurState> {
 	}
 
 	openStationsMap() {
+		this.mapRectsSnapshot = this.props.spatialRects;
 		this.setState({isStationsMapOpen: true});
 	}
 
-	closeStationsMap() {
+	applyStationsMap() {
+		this.mapRectsSnapshot = undefined;
 		this.setState({isStationsMapOpen: false});
+	}
+
+	cancelStationsMap() {
+		const snapshot = this.mapRectsSnapshot;
+		this.mapRectsSnapshot = undefined;
+		this.setState({isStationsMapOpen: false});
+
+		if (snapshot === undefined) return;
+
+		this.updatePersistedMapProps({drawFeatures: rectsToDrawFeatures(snapshot)});
+	}
+
+	private mapFilterChangedInMap(): boolean {
+		return this.mapRectsSnapshot !== undefined
+			&& !deepEqual(this.props.spatialRects, this.mapRectsSnapshot);
 	}
 
 	handlePreview(urls: UrlStr[]){
@@ -116,12 +136,17 @@ class Search extends Component<OurProps, OurState> {
 
 	updateMapSelectedSRID(srid: SupportedSRIDs) {
 		const { isStationFilterCtrlActive, baseMap, visibleToggles } = this.persistedMapProps;
-		this.persistedMapProps = { 
+		this.updatePersistedMapProps({
 			isStationFilterCtrlActive,
 			baseMap,
 			visibleToggles,
-			srid
-		};
+			srid,
+			center: undefined,
+			zoom: undefined,
+			drawFeatures: []
+		});
+
+		this.mapRectsSnapshot = this.state.isStationsMapOpen ? [] : undefined;
 		// Using srid as key for StationsMap forces React to recreate the component when it changes
 		this.setState({ srid });
 	}
@@ -148,6 +173,17 @@ class Search extends Component<OurProps, OurState> {
 			mapPreview={<StationsMapPreview persistedMapProps={this.persistedMapProps} />}
 			srid={srid}
 		/>;
+
+		const stationsMapButtons = this.mapFilterChangedInMap()
+			? <div className="stations-map-actions d-flex gap-2 me-4">
+				<button type="button" className="btn btn-outline-secondary px-3" onClick={this.cancelStationsMap.bind(this)}>
+					Cancel
+				</button>
+				<button type="button" className="btn btn-primary px-3" onClick={this.applyStationsMap.bind(this)}>
+					Apply
+				</button>
+			</div>
+			: null;
 
 		const resultsView = isCompact
 			? <SearchResultCompact
@@ -208,14 +244,16 @@ class Search extends Component<OurProps, OurState> {
 
 				<Modal
 					show={this.state.isStationsMapOpen}
-					onHide={this.closeStationsMap.bind(this)}
+					onHide={this.applyStationsMap.bind(this)}
 					size="xl"
 					centered
 					backdrop={true}
 					keyboard={true}
 				>
 					<Modal.Header closeButton>
-						<Modal.Title>Stations map</Modal.Title>
+						<Modal.Title className="flex-grow-1">Stations map</Modal.Title>
+
+						{stationsMapButtons}
 					</Modal.Header>
 					<Modal.Body className="p-0" style={{overflow: 'hidden'}}>
 						<StationsMap
@@ -238,7 +276,8 @@ function stateToProps(state: State){
 		tabs: state.tabs,
 		paging: state.paging,
 		searchOptions: state.searchOptions,
-		exportQuery: state.exportQuery
+		exportQuery: state.exportQuery,
+		spatialRects: state.mapProps.rects ?? []
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -5,7 +5,7 @@ import {debounce, Events} from 'icos-cp-utils';
 import Tabs from '../../components/ui/Tabs';
 import SearchResultRegular from './SearchResultRegular';
 import {updateCheckedObjectsInSearch, switchTab, filtersReset, setMapProps, requestStep, getAllFilteredDataObjects} from '../../actions/search';
-import {Paging} from '../../components/buttons/Paging';
+import {PagingCount, PagingSteps} from '../../components/buttons/Paging';
 import ActiveFilters from './ActiveFilters';
 import {getLastSegmentsInUrls, isSmallDevice} from '../../utils';
 import {Sha256Str, UrlStr} from "../../backend/declarations";
@@ -218,24 +218,26 @@ class Search extends Component<OurProps, OurState> {
 
 				<div className="col-sm-8 col-md-9">
 					<div className="card">
-						<div className="card-header d-flex justify-content-between align-items-center">
-							Search results
+						<div className="card-header aligned-card-header d-flex justify-content-between align-items-center gap-3">
+							<PagingCount
+								paging={paging}
+								searchOptions={searchOptions}
+								getAllFilteredDataObjects={getAllFilteredDataObjects}
+								exportQuery={exportQuery}
+							/>
 
-							<ResultViewSwitch isCompact={isCompact} setCompact={this.setCompactView.bind(this)} />
+							<div className="d-flex flex-wrap justify-content-end align-items-center column-gap-3 row-gap-1">
+								<ResultViewSwitch isCompact={isCompact} setCompact={this.setCompactView.bind(this)} />
+
+								<div className="lh-sm text-nowrap">
+									<PagingSteps paging={paging} onStep={requestStep} />
+								</div>
+							</div>
 						</div>
 
 						<ActiveFilters
 							removeMapRect={this.handleRemoveMapRect.bind(this)}
 							clearAllFilters={this.handleFilterReset.bind(this)}
-						/>
-
-						<Paging
-							searchOptions={searchOptions}
-							type="header"
-							paging={paging}
-							requestStep={requestStep}
-							getAllFilteredDataObjects={getAllFilteredDataObjects}
-							exportQuery={exportQuery}
 						/>
 
 						{resultsView}

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -10,7 +10,7 @@ import ActiveFilters from './ActiveFilters';
 import {getLastSegmentsInUrls, isSmallDevice} from '../../utils';
 import {Sha256Str, UrlStr} from "../../backend/declarations";
 import {PortalDispatch} from "../../store";
-import {DrawRectBbox, Route, State} from "../../models/State";
+import {Route, State} from "../../models/State";
 import {addToCart, updateRoute} from "../../actions/common";
 import Filters from "./Filters";
 import SearchResultCompact from "./SearchResultCompact";
@@ -22,8 +22,6 @@ import {ResultViewSwitch} from '../../components/searchResult/ResultViewSwitch';
 import { BaseMapId, SupportedSRIDs } from 'icos-cp-ol';
 import config from '../../config';
 import { PersistedMapPropsExtended } from '../../models/InitMap';
-import { rectsToDrawFeatures } from '../../models/MapProps';
-import deepEqual from 'deep-equal';
 import { getPersistedMapProps } from '../../backend';
 import { addingToCartProhibition } from '../../models/CartItem';
 
@@ -38,14 +36,12 @@ type OurState = {
 	srid?: SupportedSRIDs
 	baseMap?: BaseMapId
 	isStationsMapOpen: boolean
-	isMapFilterReset: boolean
 };
 
 class Search extends Component<OurProps, OurState> {
 	private events: typeof Events;
 	private handleResize: Function;
 	private persistedMapProps: PersistedMapPropsExtended;
-	private mapRectsSnapshot?: DrawRectBbox[];
 
 	constructor(props: OurProps) {
 		super(props);
@@ -69,8 +65,7 @@ class Search extends Component<OurProps, OurState> {
 			expandedFilters: !isSmallDevice(),
 			srid: this.persistedMapProps.srid,
 			baseMap: this.persistedMapProps.baseMap,
-			isStationsMapOpen: false,
-			isMapFilterReset: false
+			isStationsMapOpen: false
 		};
 	}
 
@@ -79,35 +74,11 @@ class Search extends Component<OurProps, OurState> {
 	}
 
 	openStationsMap() {
-		this.mapRectsSnapshot = this.props.spatialRects;
-		this.setState({isStationsMapOpen: true, isMapFilterReset: false});
+		this.setState({isStationsMapOpen: true});
 	}
 
-	applyStationsMap() {
-		this.mapRectsSnapshot = undefined;
-		this.setState({isStationsMapOpen: false, isMapFilterReset: false});
-	}
-
-	cancelStationsMap() {
-		const snapshot = this.mapRectsSnapshot;
-		this.mapRectsSnapshot = undefined;
-		this.setState({isStationsMapOpen: false, isMapFilterReset: false});
-
-		if (snapshot === undefined) return;
-
-		this.updatePersistedMapProps({drawFeatures: rectsToDrawFeatures(snapshot)});
-	}
-
-	resetStationsMap() {
-		this.setState({isMapFilterReset: true});
-		this.clearMapRects();
-	}
-
-	private mapFilterChangedInMap(): boolean {
-		if (this.mapRectsSnapshot === undefined) return false;
-
-		return this.state.isMapFilterReset
-			|| !deepEqual(this.props.spatialRects, this.mapRectsSnapshot);
+	closeStationsMap() {
+		this.setState({isStationsMapOpen: false});
 	}
 
 	handlePreview(urls: UrlStr[]){
@@ -160,7 +131,6 @@ class Search extends Component<OurProps, OurState> {
 			drawFeatures: []
 		});
 
-		this.mapRectsSnapshot = this.state.isStationsMapOpen ? [] : undefined;
 		// Using srid as key for StationsMap forces React to recreate the component when it changes
 		this.setState({ srid });
 	}
@@ -199,22 +169,14 @@ class Search extends Component<OurProps, OurState> {
 		const stationsMapButtons = <div className="d-flex gap-2">
 			<button
 				type="button"
-				className="btn btn-primary"
-				disabled={!this.mapFilterChangedInMap()}
-				onClick={this.applyStationsMap.bind(this)}
-			>
-				Apply
-			</button>
-			<button
-				type="button"
 				className="btn btn-secondary"
 				disabled={this.props.spatialRects.length === 0}
-				onClick={this.resetStationsMap.bind(this)}
+				onClick={this.clearMapRects.bind(this)}
 			>
 				Reset
 			</button>
-			<button type="button" className="btn btn-outline-secondary" onClick={this.cancelStationsMap.bind(this)}>
-				Cancel
+			<button type="button" className="btn btn-primary" onClick={this.closeStationsMap.bind(this)}>
+				Done
 			</button>
 		</div>;
 
@@ -279,7 +241,7 @@ class Search extends Component<OurProps, OurState> {
 
 				<Modal
 					show={this.state.isStationsMapOpen}
-					onHide={this.applyStationsMap.bind(this)}
+					onHide={this.closeStationsMap.bind(this)}
 					container={mainElement}
 					size="xl"
 					centered

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -30,10 +30,6 @@ import { addingToCartProhibition } from '../../models/CartItem';
 const defaultViewTabId = 0;
 const compactViewTabId = 1;
 
-function mainElement() {
-	return document.querySelector<HTMLElement>('main');
-}
-
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type OurProps = StateProps & DispatchProps & { HelpSection: ReactNode };
@@ -110,8 +106,6 @@ class Search extends Component<OurProps, OurState> {
 	private mapFilterChangedInMap(): boolean {
 		if (this.mapRectsSnapshot === undefined) return false;
 
-		// A reset is a change to be applied even when it happens to leave the rectangles as
-		// the map was opened with, such as after drawing one and then resetting
 		return this.state.isMapFilterReset
 			|| !deepEqual(this.props.spatialRects, this.mapRectsSnapshot);
 	}
@@ -309,6 +303,11 @@ class Search extends Component<OurProps, OurState> {
 			</div>
 		);
 	}
+}
+
+// mount modal to "main" if present for styling inheritance
+function mainElement() {
+	return document.querySelector<HTMLElement>('main') ?? document.body;
 }
 
 function stateToProps(state: State){

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -30,16 +30,19 @@ import { addingToCartProhibition } from '../../models/CartItem';
 const defaultViewTabId = 0;
 const compactViewTabId = 1;
 
+function mainElement() {
+	return document.querySelector<HTMLElement>('main');
+}
+
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type OurProps = StateProps & DispatchProps & { HelpSection: ReactNode };
 type OurState = {
 	expandedFilters: boolean
 	srid?: SupportedSRIDs
-	// Kept in state, unlike the other persisted map props, so that a base map picked in the
-	// modal map reaches the preview while both are mounted
 	baseMap?: BaseMapId
 	isStationsMapOpen: boolean
+	isMapFilterReset: boolean
 };
 
 class Search extends Component<OurProps, OurState> {
@@ -70,7 +73,8 @@ class Search extends Component<OurProps, OurState> {
 			expandedFilters: !isSmallDevice(),
 			srid: this.persistedMapProps.srid,
 			baseMap: this.persistedMapProps.baseMap,
-			isStationsMapOpen: false
+			isStationsMapOpen: false,
+			isMapFilterReset: false
 		};
 	}
 
@@ -80,27 +84,36 @@ class Search extends Component<OurProps, OurState> {
 
 	openStationsMap() {
 		this.mapRectsSnapshot = this.props.spatialRects;
-		this.setState({isStationsMapOpen: true});
+		this.setState({isStationsMapOpen: true, isMapFilterReset: false});
 	}
 
 	applyStationsMap() {
 		this.mapRectsSnapshot = undefined;
-		this.setState({isStationsMapOpen: false});
+		this.setState({isStationsMapOpen: false, isMapFilterReset: false});
 	}
 
 	cancelStationsMap() {
 		const snapshot = this.mapRectsSnapshot;
 		this.mapRectsSnapshot = undefined;
-		this.setState({isStationsMapOpen: false});
+		this.setState({isStationsMapOpen: false, isMapFilterReset: false});
 
 		if (snapshot === undefined) return;
 
 		this.updatePersistedMapProps({drawFeatures: rectsToDrawFeatures(snapshot)});
 	}
 
+	resetStationsMap() {
+		this.setState({isMapFilterReset: true});
+		this.clearMapRects();
+	}
+
 	private mapFilterChangedInMap(): boolean {
-		return this.mapRectsSnapshot !== undefined
-			&& !deepEqual(this.props.spatialRects, this.mapRectsSnapshot);
+		if (this.mapRectsSnapshot === undefined) return false;
+
+		// A reset is a change to be applied even when it happens to leave the rectangles as
+		// the map was opened with, such as after drawing one and then resetting
+		return this.state.isMapFilterReset
+			|| !deepEqual(this.props.spatialRects, this.mapRectsSnapshot);
 	}
 
 	handlePreview(urls: UrlStr[]){
@@ -128,9 +141,8 @@ class Search extends Component<OurProps, OurState> {
 		this.props.filtersReset();
 	}
 
-	handleRemoveMapRect() {
-		this.persistedMapProps = {...this.persistedMapProps, drawFeatures: []};
-		this.props.setMapProps(this.persistedMapProps);
+	clearMapRects() {
+		this.updatePersistedMapProps({drawFeatures: []});
 	}
 
 	updatePersistedMapProps(persistedMapProps: PersistedMapPropsExtended) {
@@ -176,9 +188,6 @@ class Search extends Component<OurProps, OurState> {
 
 		const isCompact = tabs.resultTab === compactViewTabId;
 
-		// Without a center and a zoom the preview fits the whole extent of its projection, and
-		// without visibleToggles it shows every layer it is given. Taking the base map from
-		// state is what makes the preview follow the one picked in the modal map
 		const previewMapProps = {
 			...this.persistedMapProps,
 			baseMap: this.state.baseMap,
@@ -193,16 +202,27 @@ class Search extends Component<OurProps, OurState> {
 			srid={srid}
 		/>;
 
-		const stationsMapButtons = this.mapFilterChangedInMap()
-			? <div className="stations-map-actions d-flex gap-2 me-4">
-				<button type="button" className="btn btn-outline-secondary px-3" onClick={this.cancelStationsMap.bind(this)}>
-					Cancel
-				</button>
-				<button type="button" className="btn btn-primary px-3" onClick={this.applyStationsMap.bind(this)}>
-					Apply
-				</button>
-			</div>
-			: null;
+		const stationsMapButtons = <div className="d-flex gap-2">
+			<button
+				type="button"
+				className="btn btn-primary"
+				disabled={!this.mapFilterChangedInMap()}
+				onClick={this.applyStationsMap.bind(this)}
+			>
+				Apply
+			</button>
+			<button
+				type="button"
+				className="btn btn-secondary"
+				disabled={this.props.spatialRects.length === 0}
+				onClick={this.resetStationsMap.bind(this)}
+			>
+				Reset
+			</button>
+			<button type="button" className="btn btn-outline-secondary" onClick={this.cancelStationsMap.bind(this)}>
+				Cancel
+			</button>
+		</div>;
 
 		const resultsView = isCompact
 			? <SearchResultCompact
@@ -255,7 +275,7 @@ class Search extends Component<OurProps, OurState> {
 						</div>
 
 						<ActiveFilters
-							removeMapRect={this.handleRemoveMapRect.bind(this)}
+							removeMapRect={this.clearMapRects.bind(this)}
 							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
 
@@ -266,12 +286,14 @@ class Search extends Component<OurProps, OurState> {
 				<Modal
 					show={this.state.isStationsMapOpen}
 					onHide={this.applyStationsMap.bind(this)}
+					container={mainElement}
 					size="xl"
 					centered
 					backdrop={true}
 					keyboard={true}
 				>
-					<Modal.Header closeButton>
+					<Modal.Header>
+						{/* Growing the title keeps the buttons at the far end of the header */}
 						<Modal.Title className="flex-grow-1">Stations map</Modal.Title>
 
 						{stationsMapButtons}

--- a/src/main/js/portal/main/containers/search/Search.tsx
+++ b/src/main/js/portal/main/containers/search/Search.tsx
@@ -1,5 +1,6 @@
 import React, {Component, ReactNode} from 'react';
 import { connect } from 'react-redux';
+import { Modal } from 'react-bootstrap';
 import {debounce, Events} from 'icos-cp-utils';
 import Tabs from '../../components/ui/Tabs';
 import SearchResultRegular from './SearchResultRegular';
@@ -12,7 +13,7 @@ import {addToCart, updateRoute} from "../../actions/common";
 import Filters from "./Filters";
 import SearchResultCompact from "./SearchResultCompact";
 import Advanced from "./Advanced";
-import SearchResultMap from './SearchResultMap';
+import StationsMap from './StationsMap';
 import { SupportedSRIDs } from 'icos-cp-ol';
 import config from '../../config';
 import { PersistedMapPropsExtended } from '../../models/InitMap';
@@ -25,6 +26,7 @@ type OurProps = StateProps & DispatchProps & { HelpSection: ReactNode };
 type OurState = {
 	expandedFilters: boolean
 	srid?: SupportedSRIDs
+	isStationsMapOpen: boolean
 };
 
 class Search extends Component<OurProps, OurState> {
@@ -52,8 +54,17 @@ class Search extends Component<OurProps, OurState> {
 
 		this.state = {
 			expandedFilters: !isSmallDevice(),
-			srid: this.persistedMapProps.srid
+			srid: this.persistedMapProps.srid,
+			isStationsMapOpen: false
 		};
+	}
+
+	openStationsMap() {
+		this.setState({isStationsMapOpen: true});
+	}
+
+	closeStationsMap() {
+		this.setState({isStationsMapOpen: false});
 	}
 
 	handlePreview(urls: UrlStr[]){
@@ -99,7 +110,7 @@ class Search extends Component<OurProps, OurState> {
 			visibleToggles,
 			srid
 		};
-		// Using srid as key for SearchResultMap forces React to recreate the component when it changes
+		// Using srid as key for StationsMap forces React to recreate the component when it changes
 		this.setState({ srid });
 	}
 
@@ -131,7 +142,7 @@ class Search extends Component<OurProps, OurState> {
 
 					<div style={expandedFilters}>
 						<Tabs tabName="searchTab" selectedTabId={tabs.searchTab} switchTab={switchTab}>
-							<Filters tabHeader="Filters" />
+							<Filters tabHeader="Filters" openStationsMap={this.openStationsMap.bind(this)} />
 							<Advanced tabHeader="Advanced" />
 						</Tabs>
 					</div>
@@ -154,17 +165,29 @@ class Search extends Component<OurProps, OurState> {
 							removeMapRect={this.handleRemoveMapRect.bind(this)}
 							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
-						<SearchResultMap
+					</Tabs>
+				</div>
+
+				<Modal
+					show={this.state.isStationsMapOpen}
+					onHide={this.closeStationsMap.bind(this)}
+					size="xl"
+					centered
+					backdrop={true}
+					keyboard={true}
+				>
+					<Modal.Header closeButton>
+						<Modal.Title>Stations map</Modal.Title>
+					</Modal.Header>
+					<Modal.Body className="p-0" style={{overflow: 'hidden'}}>
+						<StationsMap
 							key={srid}
-							tabHeader="Stations map"
 							persistedMapProps={this.persistedMapProps}
 							updatePersistedMapProps={this.updatePersistedMapProps.bind(this)}
 							updateMapSelectedSRID={this.updateMapSelectedSRID.bind(this)}
-							removeMapRect={this.handleRemoveMapRect.bind(this)}
-							clearAllFilters={this.handleFilterReset.bind(this)}
 						/>
-					</Tabs>
-				</div>
+					</Modal.Body>
+				</Modal>
 			</div>
 		);
 	}

--- a/src/main/js/portal/main/containers/search/SearchResultCompact.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultCompact.tsx
@@ -8,12 +8,14 @@ import {addToCart, removeFromCart} from "../../actions/common";
 import config, {timezone} from "../../config";
 import {Paging} from "../../components/buttons/Paging";
 import SearchResultCompactRow from "../../components/searchResult/SearchResultCompactRow";
+import ActiveFilters from './ActiveFilters';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type IncomingActions = {
 	handlePreview: (id: UrlStr[]) => void
+	removeMapRect: () => void
 }
 type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
 
@@ -28,11 +30,13 @@ class SearchResultCompact extends Component<OurProps> {
 	render(){
 		const {preview, cart, objectsTable, addToCart, lookup, paging, sorting, searchOptions,
 			toggleSort, requestStep, removeFromCart, handlePreview,
-			getAllFilteredDataObjects, exportQuery, extendedDobjInfo, user} = this.props;
+			getAllFilteredDataObjects, exportQuery, extendedDobjInfo, user, removeMapRect} = this.props;
 		const sortProps: SortProps = {sorting, toggleSort};
 
 		return (
 			<div className="card">
+				<ActiveFilters removeMapRect={removeMapRect} />
+
 				<Paging
 					searchOptions={searchOptions}
 					type="header"

--- a/src/main/js/portal/main/containers/search/SearchResultCompact.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultCompact.tsx
@@ -16,6 +16,7 @@ type DispatchProps = ReturnType<typeof dispatchToProps>;
 type IncomingActions = {
 	handlePreview: (id: UrlStr[]) => void
 	removeMapRect: () => void
+	clearAllFilters: () => void
 }
 type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
 
@@ -30,12 +31,12 @@ class SearchResultCompact extends Component<OurProps> {
 	render(){
 		const {preview, cart, objectsTable, addToCart, lookup, paging, sorting, searchOptions,
 			toggleSort, requestStep, removeFromCart, handlePreview,
-			getAllFilteredDataObjects, exportQuery, extendedDobjInfo, user, removeMapRect} = this.props;
+			getAllFilteredDataObjects, exportQuery, extendedDobjInfo, user, removeMapRect, clearAllFilters} = this.props;
 		const sortProps: SortProps = {sorting, toggleSort};
 
 		return (
 			<div className="card">
-				<ActiveFilters removeMapRect={removeMapRect} />
+				<ActiveFilters removeMapRect={removeMapRect} clearAllFilters={clearAllFilters} />
 
 				<Paging
 					searchOptions={searchOptions}

--- a/src/main/js/portal/main/containers/search/SearchResultCompact.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultCompact.tsx
@@ -2,23 +2,19 @@ import React, {Component, CSSProperties} from 'react';
 import { connect } from 'react-redux';
 import {State} from "../../models/State";
 import {PortalDispatch} from "../../store";
-import {getAllFilteredDataObjects, requestStep, toggleSort} from "../../actions/search";
+import {toggleSort} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
 import {addToCart, removeFromCart} from "../../actions/common";
 import config, {timezone} from "../../config";
-import {Paging} from "../../components/buttons/Paging";
 import SearchResultCompactRow from "../../components/searchResult/SearchResultCompactRow";
-import ActiveFilters from './ActiveFilters';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type IncomingActions = {
 	handlePreview: (id: UrlStr[]) => void
-	removeMapRect: () => void
-	clearAllFilters: () => void
 }
-type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
+type OurProps = StateProps & DispatchProps & IncomingActions;
 
 type SortProps = {
 	sorting: State['sorting']
@@ -29,68 +25,54 @@ const headerStyle: CSSProperties = {whiteSpace: 'nowrap', paddingRight: 0, paddi
 
 class SearchResultCompact extends Component<OurProps> {
 	render(){
-		const {preview, cart, objectsTable, addToCart, lookup, paging, sorting, searchOptions,
-			toggleSort, requestStep, removeFromCart, handlePreview,
-			getAllFilteredDataObjects, exportQuery, extendedDobjInfo, user, removeMapRect, clearAllFilters} = this.props;
+		const {preview, cart, objectsTable, addToCart, lookup, sorting,
+			toggleSort, removeFromCart, handlePreview, extendedDobjInfo, user} = this.props;
 		const sortProps: SortProps = {sorting, toggleSort};
 
 		return (
-			<div className="card">
-				<ActiveFilters removeMapRect={removeMapRect} clearAllFilters={clearAllFilters} />
+			<div className="card-body">
+				<div className="table-responsive">
+					<table className="table">
+						<thead>
+						<tr>
+							<th style={headerStyle}>
+								Data object<SortButton varName="fileName" {...sortProps}/>
+							</th>
+							<th style={headerStyle}>
+								Size<SortButton varName="size" {...sortProps}/>
+							</th>
+							<th style={headerStyle}>
+								Submission time ({timezone[config.envri].label})<SortButton varName="submTime" {...sortProps}/>
+							</th>
+							<th style={headerStyle}>
+								From time ({timezone[config.envri].label})<SortButton varName="timeStart" {...sortProps}/>
+							</th>
+							<th style={headerStyle}>
+								To time ({timezone[config.envri].label})<SortButton varName="timeEnd" {...sortProps}/>
+							</th>
+						</tr>
+						</thead>
+						<tbody>{
+							objectsTable.map((objInfo, i) => {
+								const isAddedToCart = cart.hasItem(objInfo.dobj);
 
-				<Paging
-					searchOptions={searchOptions}
-					type="header"
-					paging={paging}
-					requestStep={requestStep}
-					getAllFilteredDataObjects={getAllFilteredDataObjects}
-					exportQuery={exportQuery}
-				/>
-
-				<div className="card-body">
-					<div className="table-responsive">
-						<table className="table">
-							<thead>
-							<tr>
-								<th style={headerStyle}>
-									Data object<SortButton varName="fileName" {...sortProps}/>
-								</th>
-								<th style={headerStyle}>
-									Size<SortButton varName="size" {...sortProps}/>
-								</th>
-								<th style={headerStyle}>
-									Submission time ({timezone[config.envri].label})<SortButton varName="submTime" {...sortProps}/>
-								</th>
-								<th style={headerStyle}>
-									From time ({timezone[config.envri].label})<SortButton varName="timeStart" {...sortProps}/>
-								</th>
-								<th style={headerStyle}>
-									To time ({timezone[config.envri].label})<SortButton varName="timeEnd" {...sortProps}/>
-								</th>
-							</tr>
-							</thead>
-							<tbody>{
-								objectsTable.map((objInfo, i) => {
-									const isAddedToCart = cart.hasItem(objInfo.dobj);
-
-									return (
-										<SearchResultCompactRow
-											lookup={lookup}
-											preview={preview}
-											extendedDobjInfo={extendedDobjInfo}
-											handlePreview={handlePreview}
-											objInfo={objInfo}
-											isAddedToCart={isAddedToCart}
-											addToCart={addToCart}
-											removeFromCart={removeFromCart}
-											key={'dobj_' + i}
-											user={user}
-										/>
-									);
-								})
-							}</tbody>
-						</table>
-					</div>
+								return (
+									<SearchResultCompactRow
+										lookup={lookup}
+										preview={preview}
+										extendedDobjInfo={extendedDobjInfo}
+										handlePreview={handlePreview}
+										objInfo={objInfo}
+										isAddedToCart={isAddedToCart}
+										addToCart={addToCart}
+										removeFromCart={removeFromCart}
+										key={'dobj_' + i}
+										user={user}
+									/>
+								);
+							})
+						}</tbody>
+					</table>
 				</div>
 			</div>
 		);
@@ -124,10 +106,7 @@ function stateToProps(state: State){
 		objectsTable: state.objectsTable,
 		preview: state.preview,
 		cart: state.cart,
-		paging: state.paging,
 		sorting: state.sorting,
-		searchOptions: state.searchOptions,
-		exportQuery: state.exportQuery,
 		extendedDobjInfo: state.extendedDobjInfo,
 		user: state.user
 	};
@@ -137,9 +116,7 @@ function dispatchToProps(dispatch: PortalDispatch){
 	return {
 		addToCart: (ids: UrlStr[]) => dispatch(addToCart(ids)),
 		toggleSort: (varName: string) => dispatch(toggleSort(varName)),
-		requestStep: (direction: -1 | 1) => dispatch(requestStep(direction)),
 		removeFromCart: (ids: UrlStr[]) => dispatch(removeFromCart(ids)),
-		getAllFilteredDataObjects: () => dispatch(getAllFilteredDataObjects()),
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/SearchResultMap.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultMap.tsx
@@ -6,6 +6,7 @@ import { PortalDispatch } from '../../store';
 import { failWithError } from '../../actions/common';
 import { Value } from '../../models/SpecTable';
 import { Copyright } from 'icos-cp-copyright';
+import ActiveFilters from './ActiveFilters';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
@@ -15,6 +16,7 @@ type incommingProps = {
 	persistedMapProps: PersistedMapPropsExtended
 	updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void
 	updateMapSelectedSRID: UpdateMapSelectedSRID
+	removeMapRect: () => void
 }
 type OurProps = StateProps & DispatchProps & incommingProps
 
@@ -37,22 +39,26 @@ class SearchResultMap extends Component<OurProps> {
 
 	render() {
 		return (
-			<div id="map" style={{ width: '100%', height: '90vh', position:'relative' }} tabIndex={1}>
-				<div id="stationFilterCtrl" className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>
-				<div id="popover" className="ol-popup"></div>
-				<div id="projSwitchCtrl" className="ol-layer-control ol-layer-control-lr" style={{ zIndex: 99, marginRight: 10, padding: 0 }}></div>
-				<div id="layerCtrl" className="ol-layer-control ol-layer-control-ur"></div>
-				<div id="attribution" className="ol-attribution ol-unselectable ol-control ol-uncollapsible" style={{right: 15}}>
-					<ul>
-						<li>
-							<Copyright />
-						</li>
-					</ul>
-					<ul>
-						<li id="baseMapAttribution" />
-					</ul>
+			<>
+				<ActiveFilters removeMapRect={this.props.removeMapRect} />
+
+				<div id="map" style={{ width: '100%', height: '90vh', position:'relative' }} tabIndex={1}>
+					<div id="stationFilterCtrl" className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>
+					<div id="popover" className="ol-popup"></div>
+					<div id="projSwitchCtrl" className="ol-layer-control ol-layer-control-lr" style={{ zIndex: 99, marginRight: 10, padding: 0 }}></div>
+					<div id="layerCtrl" className="ol-layer-control ol-layer-control-ur"></div>
+					<div id="attribution" className="ol-attribution ol-unselectable ol-control ol-uncollapsible" style={{right: 15}}>
+						<ul>
+							<li>
+								<Copyright />
+							</li>
+						</ul>
+						<ul>
+							<li id="baseMapAttribution" />
+						</ul>
+					</div>
 				</div>
-			</div>
+			</>
 		);
 	}
 

--- a/src/main/js/portal/main/containers/search/SearchResultMap.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultMap.tsx
@@ -17,6 +17,7 @@ type incommingProps = {
 	updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void
 	updateMapSelectedSRID: UpdateMapSelectedSRID
 	removeMapRect: () => void
+	clearAllFilters: () => void
 }
 type OurProps = StateProps & DispatchProps & incommingProps
 
@@ -40,7 +41,7 @@ class SearchResultMap extends Component<OurProps> {
 	render() {
 		return (
 			<>
-				<ActiveFilters removeMapRect={this.props.removeMapRect} />
+				<ActiveFilters removeMapRect={this.props.removeMapRect} clearAllFilters={this.props.clearAllFilters} />
 
 				<div id="map" style={{ width: '100%', height: '90vh', position:'relative' }} tabIndex={1}>
 					<div id="stationFilterCtrl" className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -24,6 +24,7 @@ type IncomingActions = {
 	handleAddToCart: (objInfo: UrlStr[]) => void
 	handleAllCheckboxesChange: () => void
 	removeMapRect: () => void
+	clearAllFilters: () => void
 }
 type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
 
@@ -39,7 +40,7 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, removeMapRect } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, removeMapRect, clearAllFilters } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -50,7 +51,7 @@ function SearchResultRegular(props: OurProps) {
 
 	return (
 		<div className="card">
-			<ActiveFilters removeMapRect={removeMapRect} />
+			<ActiveFilters removeMapRect={removeMapRect} clearAllFilters={clearAllFilters} />
 
 			<Paging
 				searchOptions={searchOptions}

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -14,6 +14,7 @@ import SearchResultRegularRow from "../../components/searchResult/SearchResultRe
 import { addingToCartProhibition } from '../../models/CartItem';
 import DownloadButton from '../../components/buttons/DownloadButton';
 import { useDownloadInfo } from '../../hooks/useDownloadInfo';
+import ActiveFilters from './ActiveFilters';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
@@ -22,6 +23,7 @@ type IncomingActions = {
 	handlePreview: (id: UrlStr[]) => void
 	handleAddToCart: (objInfo: UrlStr[]) => void
 	handleAllCheckboxesChange: () => void
+	removeMapRect: () => void
 }
 type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
 
@@ -37,7 +39,7 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, removeMapRect } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -48,6 +50,8 @@ function SearchResultRegular(props: OurProps) {
 
 	return (
 		<div className="card">
+			<ActiveFilters removeMapRect={removeMapRect} />
+
 			<Paging
 				searchOptions={searchOptions}
 				type="header"

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -14,7 +14,6 @@ import SearchResultRegularRow from "../../components/searchResult/SearchResultRe
 import { addingToCartProhibition } from '../../models/CartItem';
 import DownloadButton from '../../components/buttons/DownloadButton';
 import { useDownloadInfo } from '../../hooks/useDownloadInfo';
-import ActiveFilters from './ActiveFilters';
 
 
 type StateProps = ReturnType<typeof stateToProps>;
@@ -23,10 +22,8 @@ type IncomingActions = {
 	handlePreview: (id: UrlStr[]) => void
 	handleAddToCart: (objInfo: UrlStr[]) => void
 	handleAllCheckboxesChange: () => void
-	removeMapRect: () => void
-	clearAllFilters: () => void
 }
-type OurProps = StateProps & DispatchProps & IncomingActions & {tabHeader: string};
+type OurProps = StateProps & DispatchProps & IncomingActions;
 
 const dropdownLookup = {
 	fileName: 'File name',
@@ -37,10 +34,10 @@ const dropdownLookup = {
 };
 
 function SearchResultRegular(props: OurProps) {
-	const {preview, objectsTable, previewLookup, paging, sorting, searchOptions,
+	const {preview, objectsTable, previewLookup, paging, sorting,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user, removeMapRect, clearAllFilters } = props;
+		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -50,18 +47,7 @@ function SearchResultRegular(props: OurProps) {
 		extendedDobjInfo, labelLookup});
 
 	return (
-		<div className="card">
-			<ActiveFilters removeMapRect={removeMapRect} clearAllFilters={clearAllFilters} />
-
-			<Paging
-				searchOptions={searchOptions}
-				type="header"
-				paging={paging}
-				requestStep={requestStep}
-				getAllFilteredDataObjects={getAllFilteredDataObjects}
-				exportQuery={exportQuery}
-			/>
-
+		<>
 			<div className="card-body pb-0">
 
 				<div className="panel-srollable-controls d-flex justify-content-between flex-wrap">
@@ -154,7 +140,7 @@ function SearchResultRegular(props: OurProps) {
 				getAllFilteredDataObjects={getAllFilteredDataObjects}
 				exportQuery={exportQuery}
 			/>
-		</div>
+		</>
 	);
 }
 
@@ -168,7 +154,6 @@ function stateToProps(state: State){
 		cart: state.cart,
 		paging: state.paging,
 		sorting: state.sorting,
-		searchOptions: state.searchOptions,
 		extendedDobjInfo: state.extendedDobjInfo,
 		exportQuery: state.exportQuery,
 		user: state.user

--- a/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
+++ b/src/main/js/portal/main/containers/search/SearchResultRegular.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { KnownDataObject, State} from "../../models/State";
 import {PortalDispatch} from "../../store";
-import {getAllFilteredDataObjects, requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
+import {requestStep, toggleSort, updateCheckedObjectsInSearch} from "../../actions/search";
 import {UrlStr} from "../../backend/declarations";
-import {Paging} from "../../components/buttons/Paging";
+import {PagingFooter} from "../../components/buttons/Paging";
 import CheckAllBoxes from "../../components/controls/CheckAllBoxes";
 import Dropdown from "../../components/controls/Dropdown";
 import CartBtn from "../../components/buttons/CartBtn";
@@ -37,7 +37,7 @@ function SearchResultRegular(props: OurProps) {
 	const {preview, objectsTable, previewLookup, paging, sorting,
 		toggleSort, requestStep, labelLookup, checkedObjectsInSearch, extendedDobjInfo,
 		updateCheckedObjects, handlePreview, handleAddToCart,
-		handleAllCheckboxesChange, getAllFilteredDataObjects, exportQuery, user } = props;
+		handleAllCheckboxesChange, user } = props;
 
 	const objectText = checkedObjectsInSearch.length <= 1 ? "object" : "objects";
 	const checkedUriSet = new Set<string>(checkedObjectsInSearch);
@@ -132,14 +132,7 @@ function SearchResultRegular(props: OurProps) {
 					}
 				</div>
 			</div>
-			<Paging
-				searchOptions={undefined}
-				type="footer"
-				paging={paging}
-				requestStep={requestStep}
-				getAllFilteredDataObjects={getAllFilteredDataObjects}
-				exportQuery={exportQuery}
-			/>
+			<PagingFooter paging={paging} requestStep={requestStep} />
 		</>
 	);
 }
@@ -155,7 +148,6 @@ function stateToProps(state: State){
 		paging: state.paging,
 		sorting: state.sorting,
 		extendedDobjInfo: state.extendedDobjInfo,
-		exportQuery: state.exportQuery,
 		user: state.user
 	};
 }
@@ -165,7 +157,6 @@ function dispatchToProps(dispatch: PortalDispatch){
 		updateCheckedObjects: (ids: UrlStr[] | UrlStr) => dispatch(updateCheckedObjectsInSearch(ids)),
 		toggleSort: (varName: string) => dispatch(toggleSort(varName)),
 		requestStep: (direction: -1 | 1) => dispatch(requestStep(direction)),
-		getAllFilteredDataObjects: () => dispatch(getAllFilteredDataObjects()),
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/StationsMap.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMap.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { State } from "../../models/State";
 import InitMap, { PersistedMapPropsExtended, UpdateMapSelectedSRID } from '../../models/InitMap';
 import { PortalDispatch } from '../../store';
-import { failWithError } from '../../actions/common';
+import { failWithError, showWarning } from '../../actions/common';
 import { Value } from '../../models/SpecTable';
 import { Copyright } from 'icos-cp-copyright';
 import config from '../../config';
@@ -90,6 +90,7 @@ class StationsMap extends Component<OurProps> {
 				mapProps: this.props.mapProps,
 				updateMapSelectedSRID: this.props.updateMapSelectedSRID,
 				updatePersistedMapProps: this.props.updatePersistedMapProps,
+				showWarning: this.props.showWarning,
 				labelLookup: this.props.labelLookup,
 				selectedStations: this.props.selectedStations
 			})
@@ -121,6 +122,7 @@ function stateToProps(state: State) {
 function dispatchToProps(dispatch: PortalDispatch) {
 	return {
 		failWithError: (error: Error) => failWithError(dispatch)(error),
+		showWarning: (message: string) => showWarning(dispatch)(message),
 	};
 }
 

--- a/src/main/js/portal/main/containers/search/StationsMap.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMap.tsx
@@ -6,22 +6,21 @@ import { PortalDispatch } from '../../store';
 import { failWithError } from '../../actions/common';
 import { Value } from '../../models/SpecTable';
 import { Copyright } from 'icos-cp-copyright';
-import ActiveFilters from './ActiveFilters';
 
+
+const mapAspectRatio = '16 / 15';
+const mapMaxHeight = 'calc(100vh - 140px)'; // accounts for margin and header
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
 type incommingProps = {
-	tabHeader: string
 	persistedMapProps: PersistedMapPropsExtended
 	updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void
 	updateMapSelectedSRID: UpdateMapSelectedSRID
-	removeMapRect: () => void
-	clearAllFilters: () => void
 }
 type OurProps = StateProps & DispatchProps & incommingProps
 
-class SearchResultMap extends Component<OurProps> {
+class StationsMap extends Component<OurProps> {
 	private initMap?: InitMap = undefined;
 
 	constructor(props: OurProps) {
@@ -40,26 +39,22 @@ class SearchResultMap extends Component<OurProps> {
 
 	render() {
 		return (
-			<>
-				<ActiveFilters removeMapRect={this.props.removeMapRect} clearAllFilters={this.props.clearAllFilters} />
-
-				<div id="map" style={{ width: '100%', height: '90vh', position:'relative' }} tabIndex={1}>
-					<div id="stationFilterCtrl" className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>
-					<div id="popover" className="ol-popup"></div>
-					<div id="projSwitchCtrl" className="ol-layer-control ol-layer-control-lr" style={{ zIndex: 99, marginRight: 10, padding: 0 }}></div>
-					<div id="layerCtrl" className="ol-layer-control ol-layer-control-ur"></div>
-					<div id="attribution" className="ol-attribution ol-unselectable ol-control ol-uncollapsible" style={{right: 15}}>
-						<ul>
-							<li>
-								<Copyright />
-							</li>
-						</ul>
-						<ul>
-							<li id="baseMapAttribution" />
-						</ul>
-					</div>
+			<div id="map" style={{ width: '100%', aspectRatio: mapAspectRatio, maxHeight: mapMaxHeight, position:'relative' }} tabIndex={1}>
+				<div id="stationFilterCtrl" className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>
+				<div id="popover" className="ol-popup"></div>
+				<div id="projSwitchCtrl" className="ol-layer-control ol-layer-control-lr" style={{ zIndex: 99, marginRight: 10, padding: 0 }}></div>
+				<div id="layerCtrl" className="ol-layer-control ol-layer-control-ur"></div>
+				<div id="attribution" className="ol-attribution ol-unselectable ol-control ol-uncollapsible" style={{right: 15}}>
+					<ul>
+						<li>
+							<Copyright />
+						</li>
+					</ul>
+					<ul>
+						<li id="baseMapAttribution" />
+					</ul>
 				</div>
-			</>
+			</div>
 		);
 	}
 
@@ -112,4 +107,4 @@ function dispatchToProps(dispatch: PortalDispatch) {
 	};
 }
 
-export default connect(stateToProps, dispatchToProps)(SearchResultMap);
+export default connect(stateToProps, dispatchToProps)(StationsMap);

--- a/src/main/js/portal/main/containers/search/StationsMap.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMap.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, CSSProperties } from 'react';
 import { connect } from 'react-redux';
 import { State } from "../../models/State";
 import InitMap, { PersistedMapPropsExtended, UpdateMapSelectedSRID } from '../../models/InitMap';
@@ -6,10 +6,12 @@ import { PortalDispatch } from '../../store';
 import { failWithError } from '../../actions/common';
 import { Value } from '../../models/SpecTable';
 import { Copyright } from 'icos-cp-copyright';
+import config from '../../config';
 
 
 const mapAspectRatio = '1 / 1';
 const mapMaxHeight = 'calc(100vh - 140px)'; // accounts for margin and header
+const previewIdPrefix = 'preview-';
 
 type StateProps = ReturnType<typeof stateToProps>;
 type DispatchProps = ReturnType<typeof dispatchToProps>;
@@ -17,6 +19,7 @@ type incommingProps = {
 	persistedMapProps: PersistedMapPropsExtended
 	updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void
 	updateMapSelectedSRID: UpdateMapSelectedSRID
+	isPreview?: boolean
 }
 type OurProps = StateProps & DispatchProps & incommingProps
 
@@ -37,21 +40,31 @@ class StationsMap extends Component<OurProps> {
 		});
 	}
 
+	private get idPrefix() {
+		return this.props.isPreview ? previewIdPrefix : '';
+	}
+
 	render() {
+		const { isPreview } = this.props;
+		const idPrefix = this.idPrefix;
+		const style: CSSProperties = isPreview
+			? { position: 'absolute', inset: 0 }
+			: { width: '100%', aspectRatio: mapAspectRatio, maxHeight: mapMaxHeight, position: 'relative' };
+
 		return (
-			<div id="map" style={{ width: '100%', aspectRatio: mapAspectRatio, maxHeight: mapMaxHeight, position:'relative' }} tabIndex={1}>
-				<div id="stationFilterCtrl" className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>
-				<div id="popover" className="ol-popup"></div>
-				<div id="projSwitchCtrl" className="ol-layer-control ol-layer-control-lr" style={{ zIndex: 99, marginRight: 10, padding: 0 }}></div>
-				<div id="layerCtrl" className="ol-layer-control ol-layer-control-ur"></div>
-				<div id="attribution" className="ol-attribution ol-unselectable ol-control ol-uncollapsible" style={{right: 15}}>
+			<div id={idPrefix + 'map'} className={isPreview ? 'stations-map-preview' : undefined} style={style} tabIndex={isPreview ? -1 : 1}>
+				<div id={idPrefix + 'stationFilterCtrl'} className="ol-control ol-layer-control-ur" style={{ top: 70, fontSize: 20 }}></div>
+				<div id={idPrefix + 'popover'} className="ol-popup"></div>
+				<div id={idPrefix + 'projSwitchCtrl'} className="ol-layer-control ol-layer-control-lr" style={{ zIndex: 99, marginRight: 10, padding: 0 }}></div>
+				<div id={idPrefix + 'layerCtrl'} className="ol-layer-control ol-layer-control-ur"></div>
+				<div id={idPrefix + 'attribution'} className="ol-attribution ol-unselectable ol-control ol-uncollapsible" style={{right: 15}}>
 					<ul>
 						<li>
 							<Copyright />
 						</li>
 					</ul>
 					<ul>
-						<li id="baseMapAttribution" />
+						<li id={idPrefix + 'baseMapAttribution'} />
 					</ul>
 				</div>
 			</div>
@@ -66,7 +79,11 @@ class StationsMap extends Component<OurProps> {
 				'../../models/InitMap'
 			);
 			this.initMap = new InitMap({
-				mapRootElement: document.getElementById('map')!,
+				mapRootElement: document.getElementById(this.idPrefix + 'map')!,
+				idPrefix: this.idPrefix,
+				iconStyles: this.props.isPreview ? config.olMapSettings.smallIconStyles : undefined,
+				keepFitted: this.props.isPreview,
+				showDeleteRectBtns: !this.props.isPreview,
 				allStations: this.props.allStations,
 				stationPos4326Lookup: this.props.stationPos4326Lookup,
 				persistedMapProps: this.props.persistedMapProps,

--- a/src/main/js/portal/main/containers/search/StationsMap.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMap.tsx
@@ -8,7 +8,7 @@ import { Value } from '../../models/SpecTable';
 import { Copyright } from 'icos-cp-copyright';
 
 
-const mapAspectRatio = '16 / 15';
+const mapAspectRatio = '1 / 1';
 const mapMaxHeight = 'calc(100vh - 140px)'; // accounts for margin and header
 
 type StateProps = ReturnType<typeof stateToProps>;

--- a/src/main/js/portal/main/containers/search/StationsMap.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMap.tsx
@@ -33,6 +33,8 @@ class StationsMap extends Component<OurProps> {
 	componentDidUpdate(){
 		if (this.initMap === undefined) return;
 
+		this.initMap.baseMapUpdated(this.props.persistedMapProps.baseMap);
+
 		this.initMap.incomingPropsUpdated({
 			allStations: this.props.allStations,
 			mapProps: this.props.mapProps,
@@ -84,6 +86,7 @@ class StationsMap extends Component<OurProps> {
 				iconStyles: this.props.isPreview ? config.olMapSettings.smallIconStyles : undefined,
 				keepFitted: this.props.isPreview,
 				showDeleteRectBtns: !this.props.isPreview,
+				hideExcludedStations: this.props.isPreview,
 				allStations: this.props.allStations,
 				stationPos4326Lookup: this.props.stationPos4326Lookup,
 				persistedMapProps: this.props.persistedMapProps,

--- a/src/main/js/portal/main/containers/search/StationsMapPreview.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMapPreview.tsx
@@ -4,14 +4,12 @@ import StationsMap from './StationsMap';
 
 
 interface OurProps {
-	persistedMapProps: PersistedMapPropsExtended
+	previewMapProps: PersistedMapPropsExtended
 }
 
 function ignoreMapProps() {}
 
-export function StationsMapPreview(props: OurProps) {
-	const previewMapProps = {...props.persistedMapProps, center: undefined, zoom: undefined};
-
+export function StationsMapPreview({previewMapProps}: OurProps) {
 	// Using srid as key forces React to recreate the map when the projection changes
 	return (
 		<StationsMap

--- a/src/main/js/portal/main/containers/search/StationsMapPreview.tsx
+++ b/src/main/js/portal/main/containers/search/StationsMapPreview.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { PersistedMapPropsExtended } from '../../models/InitMap';
+import StationsMap from './StationsMap';
+
+
+interface OurProps {
+	persistedMapProps: PersistedMapPropsExtended
+}
+
+function ignoreMapProps() {}
+
+export function StationsMapPreview(props: OurProps) {
+	const previewMapProps = {...props.persistedMapProps, center: undefined, zoom: undefined};
+
+	// Using srid as key forces React to recreate the map when the projection changes
+	return (
+		<StationsMap
+			key={previewMapProps.srid}
+			isPreview={true}
+			persistedMapProps={previewMapProps}
+			updatePersistedMapProps={ignoreMapProps}
+			updateMapSelectedSRID={ignoreMapProps}
+		/>
+	);
+}

--- a/src/main/js/portal/main/models/HelpStorage.ts
+++ b/src/main/js/portal/main/models/HelpStorage.ts
@@ -11,8 +11,7 @@ const titles = {
 	previewCsvDownload: "CSV download",
 	previewURL: "Preview chart URL",
 	keywordFilter: "Keyword",
-	textFilters: "Advanced: Text filters",
-	stationsMap: "Stations map"
+	textFilters: "Advanced: Text filters"
 };
 
 type HelpId = HelpItemName | UrlStr
@@ -156,9 +155,6 @@ const initItems: HelpItem[] = [
 
 	new HelpItem('station', 'If applicable, the research station that produced the original data for this data object. ' +
 		'Typically, all data except elaborated products have a station of origin.'),
-
-	new HelpItem('stationsMap', 'The stations map allows filtering based on geographic sampling location, and highlights stations ' +
-		'found with the currently selected filters. Data can be filtered using the "draw rectangle" icon on the right.'),
 
 	new HelpItem(
 		'stationclass',

--- a/src/main/js/portal/main/models/HelpStorage.ts
+++ b/src/main/js/portal/main/models/HelpStorage.ts
@@ -11,7 +11,8 @@ const titles = {
 	previewCsvDownload: "CSV download",
 	previewURL: "Preview chart URL",
 	keywordFilter: "Keyword",
-	textFilters: "Advanced: Text filters"
+	textFilters: "Advanced: Text filters",
+	stationsMap: "Stations map"
 };
 
 type HelpId = HelpItemName | UrlStr
@@ -155,6 +156,9 @@ const initItems: HelpItem[] = [
 
 	new HelpItem('station', 'If applicable, the research station that produced the original data for this data object. ' +
 		'Typically, all data except elaborated products have a station of origin.'),
+
+	new HelpItem('stationsMap', 'The stations map allows filtering based on geographic sampling location, and highlights stations ' +
+		'found with the currently selected filters. Data can be filtered using the "draw rectangle" icon on the right.'),
 
 	new HelpItem(
 		'stationclass',

--- a/src/main/js/portal/main/models/InitMap.ts
+++ b/src/main/js/portal/main/models/InitMap.ts
@@ -56,6 +56,7 @@ interface Props extends UpdateProps {
 	iconStyles?: OlMapSettings['iconStyles']
 	keepFitted?: boolean
 	showDeleteRectBtns?: boolean
+	hideExcludedStations?: boolean
 }
 interface UpdateProps {
 	allStations: UrlStr[]
@@ -65,6 +66,8 @@ interface UpdateProps {
 export type StationPosLookup = Record<UrlStr, { coord: number[], stationLbl: string }>
 
 const countryBordersId = 'countryBorders';
+const excludedStationsId = 'excludedStations';
+const includedStationsId = 'includedStations';
 const olMapSettings = config.olMapSettings;
 const isIncludedStation = 'isIncluded';
 
@@ -84,6 +87,7 @@ export default class InitMap {
 	private readonly getStationPosLookup: () => StationPosLookup
 	private readonly idPrefix: string
 	private readonly iconStyles: OlMapSettings['iconStyles']
+	private readonly hideExcludedStations: boolean
 
 	constructor(props: Props) {
 		const {mapRootElement, persistedMapProps, updatePersistedMapProps} = props;
@@ -91,6 +95,7 @@ export default class InitMap {
 		this.persistedMapProps = persistedMapProps;
 		this.idPrefix = props.idPrefix ?? '';
 		this.iconStyles = props.iconStyles ?? olMapSettings.iconStyles;
+		this.hideExcludedStations = props.hideExcludedStations ?? false;
 		this.fetchCountriesTopo();
 
 		this.allStations = props.allStations
@@ -144,7 +149,7 @@ export default class InitMap {
 		this.layerControl = new LayerControl({
 			element: document.getElementById(this.idPrefix + 'layerCtrl') ?? undefined,
 			selectedBaseMap,
-			updateCtrl: this.updateLayerCtrl
+			updateCtrl: this.updateLayerCtrl.bind(this)
 		});
 		this.layerControl.on('change', e => {
 			const layerCtrl = e.target as LayerControl;
@@ -233,6 +238,9 @@ export default class InitMap {
 	}
 
 	private toggleLayerVisibility(layerId: string): boolean {
+		// The preview is too small to make sense of the stations that a filter left out
+		if (this.hideExcludedStations && layerId === excludedStationsId) return false;
+
 		const visibleToggles = this.persistedMapProps.visibleToggles;
 		return visibleToggles === undefined || visibleToggles.includes(layerId);
 	}
@@ -252,7 +260,7 @@ export default class InitMap {
 		const includedStations = createPointData(this.selectedStations, this.stationPosLookup, {[isIncludedStation]: true});
 
 		const excludedStationsToggle: LayerWrapper = this.getLayerWrapper({
-			id: 'excludedStations',
+			id: excludedStationsId,
 			label: 'Station filtered out',
 			layerType: 'toggle',
 			geoType: 'point',
@@ -262,7 +270,7 @@ export default class InitMap {
 			interactive: true
 		});
 		const includedStationsToggle: LayerWrapper = this.getLayerWrapper({
-			id: 'includedStations',
+			id: includedStationsId,
 			label: 'Station',
 			layerType: 'toggle',
 			geoType: 'point',
@@ -319,7 +327,26 @@ export default class InitMap {
 		}
 	}
 
+	// The preview and the modal map are mounted at the same time, so a base map picked in one
+	// has to be applied to the other. Which layers are visible is deliberately not shared,
+	// and the rest of the persisted props are only read while a map is being created
+	baseMapUpdated(baseMap: PersistedMapPropsExtended['baseMap']): void {
+		if (baseMap === undefined || baseMap === this.layerControl.selectedBaseMap) return;
+
+		this.layerControl.toggleBaseMaps(baseMap);
+		// Base maps added later, the countries one, read their visibility from here
+		this.persistedMapProps = {...this.persistedMapProps, baseMap};
+		this.layerControl.updateCtrl();
+	}
+
 	updateLayerCtrl(self: LayerControl): () => void {
+		// LayerControl.createId knows nothing about the map instance, so the preview and the
+		// modal map would otherwise build inputs sharing ids and a radio group name. A label
+		// then targets whichever input the document holds first, i.e. the wrong map
+		const createId = (ctrlType: 'radio' | 'toggle', layerId: string) =>
+			this.idPrefix + self.createId(ctrlType, layerId);
+		const baseMapGroupName = this.idPrefix + 'basemap';
+
 		return () => {
 			if (self.map === undefined)
 				return;
@@ -337,11 +364,11 @@ export default class InitMap {
 
 				baseMaps.forEach(bm => {
 					const row = document.createElement('div');
-					const id = self.createId('radio', bm.get('id'));
+					const id = createId('radio', bm.get('id'));
 
 					const radio = document.createElement('input');
 					radio.setAttribute('id', id);
-					radio.setAttribute('name', 'basemap');
+					radio.setAttribute('name', baseMapGroupName);
 					radio.setAttribute('type', 'radio');
 					radio.setAttribute('style', 'margin:0px 5px 0px 0px;');
 					if (bm.getVisible()) {
@@ -366,7 +393,7 @@ export default class InitMap {
 					const legendItem = getLayerIcon(toggleLayer);
 					const row = document.createElement('div');
 					row.setAttribute('style', 'display:table;');
-					const id = self.createId('toggle', toggleLayer.get('id'));
+					const id = createId('toggle', toggleLayer.get('id'));
 
 					const toggle = document.createElement('input');
 					toggle.setAttribute('id', id);

--- a/src/main/js/portal/main/models/InitMap.ts
+++ b/src/main/js/portal/main/models/InitMap.ts
@@ -238,7 +238,6 @@ export default class InitMap {
 	}
 
 	private toggleLayerVisibility(layerId: string): boolean {
-		// The preview is too small to make sense of the stations that a filter left out
 		if (this.hideExcludedStations && layerId === excludedStationsId) return false;
 
 		const visibleToggles = this.persistedMapProps.visibleToggles;
@@ -327,22 +326,15 @@ export default class InitMap {
 		}
 	}
 
-	// The preview and the modal map are mounted at the same time, so a base map picked in one
-	// has to be applied to the other. Which layers are visible is deliberately not shared,
-	// and the rest of the persisted props are only read while a map is being created
 	baseMapUpdated(baseMap: PersistedMapPropsExtended['baseMap']): void {
 		if (baseMap === undefined || baseMap === this.layerControl.selectedBaseMap) return;
 
 		this.layerControl.toggleBaseMaps(baseMap);
-		// Base maps added later, the countries one, read their visibility from here
 		this.persistedMapProps = {...this.persistedMapProps, baseMap};
 		this.layerControl.updateCtrl();
 	}
 
 	updateLayerCtrl(self: LayerControl): () => void {
-		// LayerControl.createId knows nothing about the map instance, so the preview and the
-		// modal map would otherwise build inputs sharing ids and a radio group name. A label
-		// then targets whichever input the document holds first, i.e. the wrong map
 		const createId = (ctrlType: 'radio' | 'toggle', layerId: string) =>
 			this.idPrefix + self.createId(ctrlType, layerId);
 		const baseMapGroupName = this.idPrefix + 'basemap';

--- a/src/main/js/portal/main/models/InitMap.ts
+++ b/src/main/js/portal/main/models/InitMap.ts
@@ -5,7 +5,7 @@ import {LabelLookup, MapProps, State, StationPos4326Lookup} from './State';
 import { UrlStr } from '../backend/declarations';
 import {difference, throwError} from '../utils';
 import {Filter, Value} from './SpecTable';
-import config from '../config';
+import config, { OlMapSettings } from '../config';
 import { Coordinate } from 'ol/coordinate';
 import Point from 'ol/geom/Point';
 import VectorLayer from 'ol/layer/Vector';
@@ -50,6 +50,10 @@ interface Props extends UpdateProps {
 	persistedMapProps: PersistedMapPropsExtended
 	updatePersistedMapProps: (persistedMapProps: PersistedMapPropsExtended) => void
 	updateMapSelectedSRID: UpdateMapSelectedSRID
+	idPrefix?: string
+	iconStyles?: OlMapSettings['iconStyles']
+	keepFitted?: boolean
+	showDeleteRectBtns?: boolean
 }
 interface UpdateProps {
 	allStations: UrlStr[]
@@ -75,11 +79,15 @@ export default class InitMap {
 	private countriesTopo?: CountriesTopo;
 	private persistedMapProps: PersistedMapPropsExtended<BaseMapId | 'Countries'>;
 	private readonly getStationPosLookup: () => StationPosLookup
+	private readonly idPrefix: string
+	private readonly iconStyles: OlMapSettings['iconStyles']
 
 	constructor(props: Props) {
 		const {mapRootElement, persistedMapProps, updatePersistedMapProps} = props;
 
 		this.persistedMapProps = persistedMapProps;
+		this.idPrefix = props.idPrefix ?? '';
+		this.iconStyles = props.iconStyles ?? olMapSettings.iconStyles;
 		this.fetchCountriesTopo();
 
 		this.allStations = props.allStations
@@ -100,7 +108,7 @@ export default class InitMap {
 
 		const selectedBaseMap = persistedMapProps.baseMap ?? olMapSettings.defaultBaseMap;
 		const tileLayers = getBaseMapLayers(selectedBaseMap, olMapSettings.baseMapFilter);
-		this.popup = new Popup('popover');
+		this.popup = new Popup(this.idPrefix + 'popover');
 
 		const controls: Control[] = getDefaultControls(projection);
 
@@ -120,14 +128,15 @@ export default class InitMap {
 		this.stationPosLookup = this.getStationPosLookup()
 
 		this.stationFilterControl = new StationFilterControl({
-			element: document.getElementById('stationFilterCtrl') ?? undefined,
+			element: document.getElementById(this.idPrefix + 'stationFilterCtrl') ?? undefined,
 			isActive: persistedMapProps.isStationFilterCtrlActive ?? false,
-			updatePersistedMapProps
+			updatePersistedMapProps,
+			showDeleteRectBtns: props.showDeleteRectBtns
 		});
 		controls.push(this.stationFilterControl);
 
 		this.layerControl = new LayerControl({
-			element: document.getElementById('layerCtrl') ?? undefined,
+			element: document.getElementById(this.idPrefix + 'layerCtrl') ?? undefined,
 			selectedBaseMap,
 			updateCtrl: this.updateLayerCtrl
 		});
@@ -156,6 +165,9 @@ export default class InitMap {
 		this.olWrapper = new OLWrapper(olProps);
 		this.addInteractivity();
 
+		if (props.keepFitted)
+			this.olWrapper.map.on('change:size', () => this.fitView());
+
 		this.olWrapper.map.on("moveend", e => {
 			const map = e.target as Map;
 			const view = map.getView();
@@ -167,10 +179,17 @@ export default class InitMap {
 		if (width < minWidth) return;
 
 		getESRICopyRight(esriBaseMapNames).then(attributions => {
-			this.olWrapper.attributionUpdater = new Copyright(attributions, projection, 'baseMapAttribution', minWidth);
+			this.olWrapper.attributionUpdater = new Copyright(attributions, projection, this.idPrefix + 'baseMapAttribution', minWidth);
 		});
 
 		this.updatePoints(props.mapProps)
+	}
+
+	private fitView() {
+		const size = this.olWrapper.map.getSize();
+		if (size === undefined || size[0] === 0 || size[1] === 0) return;
+
+		this.olWrapper.map.getView().fit(this.olWrapper.viewParams.extent, { size });
 	}
 
 	private async fetchCountriesTopo() {
@@ -212,7 +231,7 @@ export default class InitMap {
 
 	private createProjectionControl(persistedMapProps: PersistedMapPropsExtended, updateMapSelectedSRID: UpdateMapSelectedSRID) {
 		return new ProjectionControl({
-			element: document.getElementById('projSwitchCtrl') ?? undefined,
+			element: document.getElementById(this.idPrefix + 'projSwitchCtrl') ?? undefined,
 			supportedSRIDs: olMapSettings.sridsInMap,
 			selectedSRID: persistedMapProps.srid ?? olMapSettings.defaultSRID,
 			switchProjAction: updateMapSelectedSRID
@@ -230,7 +249,7 @@ export default class InitMap {
 			layerType: 'toggle',
 			geoType: 'point',
 			data: excludedStations,
-			style: olMapSettings.iconStyles.excludedStation,
+			style: this.iconStyles.excludedStation,
 			zIndex: 110,
 			interactive: true
 		});
@@ -240,7 +259,7 @@ export default class InitMap {
 			layerType: 'toggle',
 			geoType: 'point',
 			data: includedStations,
-			style: olMapSettings.iconStyles.includedStation,
+			style: this.iconStyles.includedStation,
 			zIndex: 120,
 			interactive: true
 		});

--- a/src/main/js/portal/main/models/InitMap.ts
+++ b/src/main/js/portal/main/models/InitMap.ts
@@ -31,6 +31,7 @@ import {
 } from "icos-cp-ol";
 import VectorSource from 'ol/source/Vector';
 import Geometry from 'ol/geom/Geometry';
+import deepEqual from 'deep-equal';
 
 
 export type UpdateMapSelectedSRID = (srid: SupportedSRIDs) => void
@@ -50,6 +51,7 @@ interface Props extends UpdateProps {
 	persistedMapProps: PersistedMapPropsExtended
 	updatePersistedMapProps: (persistedMapProps: PersistedMapPropsExtended) => void
 	updateMapSelectedSRID: UpdateMapSelectedSRID
+	showWarning: (message: string) => void
 	idPrefix?: string
 	iconStyles?: OlMapSettings['iconStyles']
 	keepFitted?: boolean
@@ -75,6 +77,7 @@ export default class InitMap {
 	private readonly stationFilterControl: StationFilterControl;
 	private allStations: UrlStr[]
 	private selectedStations: UrlStr[]
+	private mapProps: MapProps
 	private stationPosLookup: StationPosLookup
 	private countriesTopo?: CountriesTopo;
 	private persistedMapProps: PersistedMapPropsExtended<BaseMapId | 'Countries'>;
@@ -92,6 +95,7 @@ export default class InitMap {
 
 		this.allStations = props.allStations
 		this.selectedStations = props.selectedStations
+		this.mapProps = props.mapProps
 
 		const srid = persistedMapProps.srid === undefined
 			? olMapSettings.defaultSRID
@@ -131,7 +135,9 @@ export default class InitMap {
 			element: document.getElementById(this.idPrefix + 'stationFilterCtrl') ?? undefined,
 			isActive: persistedMapProps.isStationFilterCtrlActive ?? false,
 			updatePersistedMapProps,
-			showDeleteRectBtns: props.showDeleteRectBtns
+			showDeleteRectBtns: props.showDeleteRectBtns,
+			srid,
+			onDrawRejected: props.showWarning
 		});
 		controls.push(this.stationFilterControl);
 
@@ -175,14 +181,16 @@ export default class InitMap {
 		});
 
 		const minWidth = 600;
-		const width = document.getElementsByTagName('body')[0].getBoundingClientRect().width;
-		if (width < minWidth) return;
+		const bodyWidth = document.getElementsByTagName('body')[0].getBoundingClientRect().width;
 
-		getESRICopyRight(esriBaseMapNames).then(attributions => {
-			this.olWrapper.attributionUpdater = new Copyright(attributions, projection, this.idPrefix + 'baseMapAttribution', minWidth);
-		});
+		// Copyright hides itself below minWidth anyway, so on narrow screens skip the fetch
+		if (bodyWidth >= minWidth) {
+			getESRICopyRight(esriBaseMapNames).then(attributions => {
+				this.olWrapper.attributionUpdater = new Copyright(attributions, projection, this.idPrefix + 'baseMapAttribution', minWidth);
+			});
+		}
 
-		this.updatePoints(props.mapProps)
+		this.updatePoints()
 	}
 
 	private fitView() {
@@ -226,7 +234,7 @@ export default class InitMap {
 
 	private toggleLayerVisibility(layerId: string): boolean {
 		const visibleToggles = this.persistedMapProps.visibleToggles;
-		return visibleToggles === undefined || visibleToggles.includes(layerId)
+		return visibleToggles === undefined || visibleToggles.includes(layerId);
 	}
 
 	private createProjectionControl(persistedMapProps: PersistedMapPropsExtended, updateMapSelectedSRID: UpdateMapSelectedSRID) {
@@ -238,8 +246,8 @@ export default class InitMap {
 		});
 	}
 
-	private updatePoints(mapProps: MapProps) {
-		const excludedUris = difference(this.allStations, this.selectedStations)
+	private updatePoints() {
+		const excludedUris = difference(this.allStations, this.selectedStations);
 		const excludedStations = createPointData(excludedUris, this.stationPosLookup, {[isIncludedStation]: false});
 		const includedStations = createPointData(this.selectedStations, this.stationPosLookup, {[isIncludedStation]: true});
 
@@ -266,7 +274,7 @@ export default class InitMap {
 
 		this.olWrapper.addToggleLayers([includedStationsToggle, excludedStationsToggle]);
 		this.layerControl.updateCtrl();
-		this.stationFilterControl.reDrawFeaturesFromMapProps(mapProps)
+		this.stationFilterControl.reDrawFeaturesFromMapProps(this.mapProps);
 	}
 
 	getLayerWrapper({id, label, layerType, geoType, data, style, zIndex, interactive}: Omit<LayerWrapperArgs, 'visible'>): LayerWrapper {
@@ -288,19 +296,27 @@ export default class InitMap {
 	}
 
 	incomingPropsUpdated(props: UpdateProps): void {
-		const stationListIsSame = Filter.areEqual(this.allStations, props.allStations)
-		const spatFilterIsSame = Filter.areEqual(this.selectedStations, props.selectedStations)
+		const stationListIsSame = Filter.areEqual(this.allStations, props.allStations);
+		const spatFilterIsSame = Filter.areEqual(this.selectedStations, props.selectedStations);
+		const mapPropsIsSame = deepEqual(this.mapProps, props.mapProps);
 
-		if(stationListIsSame && spatFilterIsSame) return
-
-		this.allStations = props.allStations
-		this.selectedStations = props.selectedStations
-
-		if(!stationListIsSame){
-			this.stationPosLookup = this.getStationPosLookup()
+		if (stationListIsSame && spatFilterIsSame && mapPropsIsSame) {
+			return;
 		}
 
-		this.updatePoints(props.mapProps)
+		this.allStations = props.allStations;
+		this.selectedStations = props.selectedStations;
+		this.mapProps = props.mapProps;
+
+		if (!stationListIsSame){
+			this.stationPosLookup = this.getStationPosLookup();
+		}
+
+		if (stationListIsSame && spatFilterIsSame) {
+			this.stationFilterControl.reDrawFeaturesFromMapProps(this.mapProps);
+		} else {
+			this.updatePoints();
+		}
 	}
 
 	updateLayerCtrl(self: LayerControl): () => void {

--- a/src/main/js/portal/main/models/MapProps.ts
+++ b/src/main/js/portal/main/models/MapProps.ts
@@ -2,7 +2,7 @@ import deepEqual from 'deep-equal';
 import { SupportedSRIDs } from 'icos-cp-ol';
 import type { Coordinate } from 'ol/coordinate';
 import config from '../config';
-import { drawRectBoxToCoords, round } from '../utils';
+import { round } from '../utils';
 import type { DrawRectBbox, MapProps } from './State';
 import type { DrawFeature } from './StationFilterControl';
 
@@ -38,14 +38,6 @@ export function coordsToRect(coords: Coordinate[][], srid: SupportedSRIDs): Draw
 
 export function drawFeaturesToRects(drawFeatures: DrawFeature[], srid: SupportedSRIDs): DrawRectBbox[] {
 	return drawFeatures.map(drawFeature => coordsToRect(drawFeature.coords, srid));
-}
-
-export function rectsToDrawFeatures(rects: DrawRectBbox[]): DrawFeature[] {
-	return rects.map(rect => ({
-		id: Symbol(),
-		type: stationFilterRectType,
-		coords: [drawRectBoxToCoords(rect)]
-	}));
 }
 
 export function deriveMapProps(source: MapPropsSource, currentMapProps: MapProps): MapProps {

--- a/src/main/js/portal/main/models/MapProps.ts
+++ b/src/main/js/portal/main/models/MapProps.ts
@@ -1,0 +1,74 @@
+import deepEqual from 'deep-equal';
+import { SupportedSRIDs } from 'icos-cp-ol';
+import type { Coordinate } from 'ol/coordinate';
+import config from '../config';
+import { drawRectBoxToCoords, round } from '../utils';
+import type { DrawRectBbox, MapProps } from './State';
+import type { DrawFeature } from './StationFilterControl';
+
+
+export const stationFilterRectType = 'stationFilterRect';
+
+type MapPropsSource = {
+	srid?: SupportedSRIDs
+	drawFeatures?: DrawFeature[]
+}
+
+function coordRounder(srid: SupportedSRIDs) {
+	return srid === '4326'
+		? (val: number) => round(val, 5)
+		: (val: number) => Math.round(val);
+}
+
+export function coordsToRect(coords: Coordinate[][], srid: SupportedSRIDs): DrawRectBbox {
+	const rounder = coordRounder(srid);
+	const corners = coords[0];
+
+	// Ensure corners in consistent order
+	const [x1, y1] = corners[0];
+	const [x2, y2] = corners[2];
+
+	return [
+		rounder(Math.min(x1, x2)),
+		rounder(Math.min(y1, y2)),
+		rounder(Math.max(x1, x2)),
+		rounder(Math.max(y1, y2))
+	];
+}
+
+export function drawFeaturesToRects(drawFeatures: DrawFeature[], srid: SupportedSRIDs): DrawRectBbox[] {
+	return drawFeatures.map(drawFeature => coordsToRect(drawFeature.coords, srid));
+}
+
+export function rectsToDrawFeatures(rects: DrawRectBbox[]): DrawFeature[] {
+	return rects.map(rect => ({
+		id: Symbol(),
+		type: stationFilterRectType,
+		coords: [drawRectBoxToCoords(rect)]
+	}));
+}
+
+export function deriveMapProps(source: MapPropsSource, currentMapProps: MapProps): MapProps {
+	const srid = source.srid ?? config.olMapSettings.defaultSRID;
+	const rects = source.drawFeatures === undefined
+		? currentMapProps.rects ?? []
+		: drawFeaturesToRects(source.drawFeatures, srid);
+
+	return { srid, rects };
+}
+
+export function geoFilterChanged(prevMapProps: MapProps, mapProps: MapProps): boolean {
+	const prevRects = prevMapProps.rects ?? [];
+	const rects = mapProps.rects ?? [];
+
+	if (prevRects.length === 0 && rects.length === 0) return false;
+
+	return prevMapProps.srid !== mapProps.srid || !deepEqual(prevRects, rects);
+}
+
+export function rectsConflict(rect: DrawRectBbox, otherRect: DrawRectBbox): boolean {
+	const overlapX = Math.min(rect[2], otherRect[2]) - Math.max(rect[0], otherRect[0]);
+	const overlapY = Math.min(rect[3], otherRect[3]) - Math.max(rect[1], otherRect[1]);
+
+	return overlapX >= 0 && overlapY >= 0 && (overlapX > 0 || overlapY > 0);
+}

--- a/src/main/js/portal/main/models/StationFilterControl.ts
+++ b/src/main/js/portal/main/models/StationFilterControl.ts
@@ -16,6 +16,9 @@ import Polygon from 'ol/geom/Polygon';
 import { Coordinate } from 'ol/coordinate';
 import { MapProps} from './State';
 import { drawRectBoxToCoords } from '../utils';
+import { coordsToRect, drawFeaturesToRects, rectsConflict, stationFilterRectType } from './MapProps';
+import { SupportedSRIDs } from 'icos-cp-ol';
+import deepEqual from 'deep-equal';
 
 export interface DrawFeature {
 	id: Symbol
@@ -26,6 +29,8 @@ export interface DrawFeature {
 export interface StationFilterControlOptions extends Options {
 	isActive: boolean
 	updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void
+	srid: SupportedSRIDs
+	onDrawRejected: (message: string) => void
 	showDeleteRectBtns?: boolean
 }
 
@@ -61,6 +66,8 @@ export class StationFilterControl extends Control {
 	private selects: Record<string, Select> = {};
 	private drawFeatures: DrawFeature[] = [];
 	private updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void;
+	private readonly srid: SupportedSRIDs;
+	private readonly onDrawRejected: (message: string) => void;
 
 	constructor(options: StationFilterControlOptions) {
 
@@ -71,6 +78,8 @@ export class StationFilterControl extends Control {
 
 		this.isActive = options.isActive;
 		this.updatePersistedMapProps = options.updatePersistedMapProps;
+		this.srid = options.srid;
+		this.onDrawRejected = options.onDrawRejected;
 
 		this.controlButton = this.drawCtrlBtn();
 		this.setTooltip();
@@ -85,7 +94,6 @@ export class StationFilterControl extends Control {
 		this.drawSource = new VectorSource({ wrapX: false });
 		this.drawLayer = new VectorLayer({ source: this.drawSource, zIndex: 400 });
 		this.draw = new Draw({
-			source: this.drawSource,
 			type: 'Circle',
 			geometryFunction: createBox(),
 		});
@@ -121,7 +129,7 @@ export class StationFilterControl extends Control {
 			} else {
 				map?.removeInteraction(this.draw);
 				features.forEach(feature => {
-					if (feature.get('type') !== 'stationFilterRect') {
+					if (feature.get('type') !== stationFilterRectType) {
 						style.cursor = 'pointer';
 						feature.setStyle(iconStyle);
 					}
@@ -162,32 +170,44 @@ export class StationFilterControl extends Control {
 	}
 
 	reDrawFeaturesFromMapProps(mapProps: MapProps) {
-		if (mapProps.rects === undefined || mapProps.rects.length === this.drawFeatures.length) return;
+		const rects = mapProps.rects ?? [];
+		if (deepEqual(rects, drawFeaturesToRects(this.drawFeatures, this.srid))) return;
 
 		this.removeAllDrawFeatures();
 		this.removeAllDeleteRectBtns();
 		this.drawFeatures = [];
 
-		mapProps.rects.forEach(rect => {
+		rects.forEach(rect => {
 			const geometry = new Polygon([drawRectBoxToCoords(rect)]);
-			const feature = new Feature({ geometry });
-			this.drawSource.addFeature(feature);
-			this.addDrawFeature(new DrawEvent(DrawEventType.DRAWEND, feature));
+			this.addDrawFeature(new DrawEvent(DrawEventType.DRAWEND, new Feature({ geometry })));
 		});
 
 		this.setActiveState(this.isActive);
 	}
 
 	private addDrawFeature(ev: DrawEvent) {
-		ev.feature.setProperties({ id: Symbol(), type: 'stationFilterRect' });
+		ev.feature.setProperties({ id: Symbol(), type: stationFilterRectType });
+		this.drawSource.addFeature(ev.feature);
 		this.addDeleteFilterRectBtn(ev.feature);
 		const drawFeature = featureToDrawFeature(ev.feature);
 		this.drawFeatures.push(drawFeature);
 	}
 
 	private addDrawFeatureAndUpdate(ev: DrawEvent) {
+		if (this.conflictsWithExistingRect(ev.feature)) {
+			this.onDrawRejected('Filter rectangles cannot overlap');
+			return;
+		}
+
 		this.addDrawFeature(ev);
 		this.updateApp();
+	}
+
+	private conflictsWithExistingRect(feature: Feature<Geometry>): boolean {
+		const rect = coordsToRect((<Polygon>feature.getGeometry()).getCoordinates(), this.srid);
+		const existingRects = drawFeaturesToRects(this.drawFeatures, this.srid);
+
+		return existingRects.some(existingRect => rectsConflict(rect, existingRect));
 	}
 
 	private removeAllDeleteRectBtns() {

--- a/src/main/js/portal/main/models/StationFilterControl.ts
+++ b/src/main/js/portal/main/models/StationFilterControl.ts
@@ -26,6 +26,7 @@ export interface DrawFeature {
 export interface StationFilterControlOptions extends Options {
 	isActive: boolean
 	updatePersistedMapProps: (mapProps: PersistedMapPropsExtended) => void
+	showDeleteRectBtns?: boolean
 }
 
 enum DrawEventType {
@@ -77,6 +78,7 @@ export class StationFilterControl extends Control {
 		this.deleteRectBtnSource = new VectorSource();
 		this.deleteRectBtnLayer = new VectorLayer({
 			source: this.deleteRectBtnSource,
+			visible: options.showDeleteRectBtns ?? true,
 			zIndex: 410
 		});
 

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -67,6 +67,47 @@ ul.dashed > li:before {
 	user-select: none;
 }
 
+.active-filters {
+	align-items: center;
+	gap: 14px;
+	padding: 10px 15px;
+}
+
+.active-filters-label {
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: #495057;
+	white-space: nowrap;
+}
+
+.active-filter-group {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.active-filter-category {
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: #6c757d;
+	white-space: nowrap;
+}
+
+.active-filter-tag {
+	display: inline-flex;
+	align-items: center;
+	background-color: #dee2e6;
+	border-radius: 3px;
+	padding: 2px 8px;
+	font-size: 0.85rem;
+	user-select: none;
+
+	.fa-times {
+		cursor: pointer;
+		margin-left: 6px;
+	}
+}
+
 .dropdown-details .dropdown {
 	position: absolute;
 	top: auto;

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -108,6 +108,15 @@ ul.dashed > li:before {
 	}
 }
 
+.active-filter-tag-warning {
+	background-color: var(--bs-warning);
+	cursor: pointer;
+
+	.fa-trash {
+		margin-left: 6px;
+	}
+}
+
 .dropdown-details .dropdown {
 	position: absolute;
 	top: auto;

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -73,13 +73,6 @@ ul.dashed > li:before {
 	padding: 10px 15px;
 }
 
-.active-filters-label {
-	font-size: 0.85rem;
-	font-weight: 600;
-	color: #495057;
-	white-space: nowrap;
-}
-
 .active-filter-group {
 	display: inline-flex;
 	align-items: center;

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -165,3 +165,17 @@ ul.dashed > li:before {
 		display: none;
 	}
 }
+
+.stations-map-actions {
+	animation: fade-in 0.2s ease-in;
+
+	.btn {
+		padding-top: 0.125rem;
+		padding-bottom: 0.125rem;
+	}
+}
+
+@keyframes fade-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -1,4 +1,3 @@
-
 .panel-srollable-controls {
 	position: sticky;
 	top: 0;
@@ -19,6 +18,24 @@
 
 .tab-pane .card:last-child {
 	border-radius: 0 0 0.4rem 0.4rem;
+}
+
+.aligned-card-header, .aligned-card-header-with-tabs {
+	min-height: 48px;
+	padding-top: 0;
+}
+
+.aligned-card-header {
+	padding-bottom: 0;
+}
+
+/* account for tabs reaching bottom of header */
+.aligned-card-header-with-tabs {
+	padding-bottom: var(--bs-card-cap-padding-y);
+}
+
+.paging-count {
+	flex: 1 1 0;
 }
 
 .extended-info-item {

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -67,32 +67,12 @@ ul.dashed > li:before {
 	user-select: none;
 }
 
-.active-filters {
-	align-items: center;
-	gap: 14px;
-	padding: 10px 15px;
-}
-
-.active-filter-group {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-}
-
-.active-filter-category {
-	font-size: 0.8rem;
-	font-weight: 600;
-	color: #6c757d;
-	white-space: nowrap;
-}
-
 .active-filter-tag {
 	display: inline-flex;
 	align-items: center;
-	background-color: #dee2e6;
-	border-radius: 3px;
+	background-color: var(--bs-secondary-bg);
+	border-radius: 4px;
 	padding: 2px 8px;
-	font-size: 0.85rem;
 	user-select: none;
 
 	.fa-times {
@@ -101,13 +81,9 @@ ul.dashed > li:before {
 	}
 }
 
-.active-filter-tag-warning {
-	background-color: var(--bs-warning);
+.active-filter-clear {
 	cursor: pointer;
-
-	.fa-trash {
-		margin-left: 6px;
-	}
+	padding: 2px 4px;
 }
 
 .dropdown-details .dropdown {

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -92,9 +92,14 @@ ul.dashed > li:before {
 	border-radius: 4px;
 	padding: 2px 8px;
 	user-select: none;
+	transition: filter 0.2s;
 
 	.fa-times {
 		margin-left: 6px;
+	}
+
+	&:hover {
+		filter: brightness(80%);
 	}
 }
 

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -158,17 +158,3 @@ ul.dashed > li:before {
 		display: none;
 	}
 }
-
-.stations-map-actions {
-	animation: fade-in 0.2s ease-in;
-
-	.btn {
-		padding-top: 0.125rem;
-		padding-bottom: 0.125rem;
-	}
-}
-
-@keyframes fade-in {
-	from { opacity: 0; }
-	to { opacity: 1; }
-}

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -122,12 +122,18 @@ ul.dashed > li:before {
 	box-shadow: 9px 8px 20px -18px rgba(0, 0, 0, 0.75);
 }
 
+.stations-map-frame-container {
+	display: flex;
+	justify-content: center;
+	margin-left: calc(var(--bs-card-spacer-x) * -1);
+	margin-right: calc(var(--bs-card-spacer-x) * -1);
+}
+
 .stations-map-frame {
 	position: relative;
 	overflow: hidden;
 	cursor: pointer;
-	margin-left: calc(var(--bs-card-spacer-x) * -1);
-	margin-right: calc(var(--bs-card-spacer-x) * -1);
+	width: 100%;
 }
 
 .stations-map-frame-overlay {

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -68,6 +68,7 @@ ul.dashed > li:before {
 }
 
 .active-filter-tag {
+	cursor: pointer;
 	display: inline-flex;
 	align-items: center;
 	background-color: var(--bs-secondary-bg);
@@ -76,7 +77,6 @@ ul.dashed > li:before {
 	user-select: none;
 
 	.fa-times {
-		cursor: pointer;
 		margin-left: 6px;
 	}
 }

--- a/src/main/js/portal/main/portal.scss
+++ b/src/main/js/portal/main/portal.scss
@@ -121,3 +121,41 @@ ul.dashed > li:before {
 	background: white;
 	box-shadow: 9px 8px 20px -18px rgba(0, 0, 0, 0.75);
 }
+
+.stations-map-frame {
+	position: relative;
+	overflow: hidden;
+	cursor: pointer;
+	margin-left: calc(var(--bs-card-spacer-x) * -1);
+	margin-right: calc(var(--bs-card-spacer-x) * -1);
+}
+
+.stations-map-frame-overlay {
+	position: absolute;
+	inset: 0;
+	z-index: 50;
+}
+
+.stations-map-expand {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 4px;
+	color: #333;
+	background-color: rgba(255, 255, 255, 0.85);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.stations-map-preview {
+	.ol-control,
+	.ol-layer-control,
+	.ol-popup,
+	.ol-scale-line {
+		display: none;
+	}
+}

--- a/src/main/js/portal/main/reducers/actionpayloads.ts
+++ b/src/main/js/portal/main/reducers/actionpayloads.ts
@@ -3,6 +3,7 @@ import {
 	AdvancedFilter,
 	KnownDataObject,
 	LabelLookup,
+	MapProps,
 	MetaData,
 	MetaDataWStats,
 	StateSerialized,
@@ -22,7 +23,6 @@ import Cart from "../models/Cart";
 import FilterTemporal from "../models/FilterTemporal";
 import {SearchOption} from "../actions/types";
 import {FilterNumber} from "../models/FilterNumbers";
-import {PersistedMapPropsExtended} from "../models/InitMap";
 
 
 export abstract class ActionPayload{}
@@ -145,7 +145,11 @@ export class MiscUpdateSearchOption extends MiscPayload{
 }
 
 export class MiscUpdateMapProps extends MiscPayload{
-	constructor(readonly persistedMapProps: PersistedMapPropsExtended){super();}
+	constructor(readonly mapProps: MapProps){super();}
+}
+
+export class MiscWarning extends MiscPayload{
+	constructor(readonly message: string){super();}
 }
 
 export class MiscUpdateAddToCart extends MiscPayload {

--- a/src/main/js/portal/main/reducers/miscReducer.ts
+++ b/src/main/js/portal/main/reducers/miscReducer.ts
@@ -1,8 +1,8 @@
 import {
 	MiscError, MiscPayload, MiscUpdateSearchOption, MiscResetFilters, MiscRestoreFromHistory,
-	MiscLoadError, MiscRestoreFilters, MiscUpdateMapProps, MiscUpdateAddToCart
+	MiscLoadError, MiscRestoreFilters, MiscUpdateMapProps, MiscUpdateAddToCart, MiscWarning
 } from "./actionpayloads";
-import stateUtils, {CategFilters, defaultState, DrawRectBbox, MapProps, State} from "../models/State";
+import stateUtils, {CategFilters, defaultState, State} from "../models/State";
 import * as Toaster from 'icos-cp-toaster';
 import {getObjCount} from "./utils";
 import Paging from "../models/Paging";
@@ -11,8 +11,6 @@ import config, {CategoryType, numberFilterKeys} from "../config";
 import CompositeSpecTable from "../models/CompositeSpecTable";
 import {getNewPaging} from "./backendReducer";
 import {FilterNumber, FilterNumbers} from "../models/FilterNumbers";
-import {DrawFeature} from "../models/StationFilterControl";
-import {round} from "../utils";
 
 export default function(state: State, payload: MiscPayload): State{
 
@@ -40,7 +38,13 @@ export default function(state: State, payload: MiscPayload): State{
 	}
 
 	if (payload instanceof MiscUpdateMapProps){
-		return stateUtils.update(state, handleUpdateMapProps(state, payload));
+		return stateUtils.update(state, { mapProps: payload.mapProps });
+	}
+
+	if (payload instanceof MiscWarning){
+		return stateUtils.update(state, {
+			toasterData: new Toaster.ToasterData(Toaster.TOAST_WARNING, payload.message)
+		});
 	}
 
 	if (payload instanceof MiscLoadError){
@@ -53,26 +57,6 @@ export default function(state: State, payload: MiscPayload): State{
 
 	return state;
 
-};
-
-const handleUpdateMapProps = (state: State, payload: MiscUpdateMapProps): Partial<State> => {
-	const persistedMapProps = payload.persistedMapProps;
-	const srid = persistedMapProps.srid ?? config.olMapSettings.defaultSRID;
-	const rounder = srid === '4326'
-		? (val: number) => round(val, 5)
-		: (val: number) => Math.round(val);
-	const coordHandler = (df: DrawFeature): DrawRectBbox => {
-		const rect = df.coords[0];
-		return rect[0].concat(rect[2]).map(rounder) as DrawRectBbox;
-	};
-	const mapProps: MapProps = {
-		srid,
-		rects: persistedMapProps.drawFeatures?.map(coordHandler) ?? state.mapProps.rects ?? []
-	};
-
-	return {
-		mapProps
-	};
 };
 
 const handleMiscUpdateSearchOption = (state: State, payload: MiscUpdateSearchOption): Partial<State> => {

--- a/src/main/js/portal/package-lock.json
+++ b/src/main/js/portal/package-lock.json
@@ -16,7 +16,7 @@
         "icos-cp-copyright": "^0.0.2",
         "icos-cp-draggable": "0.0.2",
         "icos-cp-ol": "4.2.2",
-        "icos-cp-toaster": "0.7.2",
+        "icos-cp-toaster": "^0.8.1",
         "icos-cp-utils": "0.2.0",
         "linkify-it": "^5.0.2",
         "ol": "9.1.0",
@@ -2318,9 +2318,10 @@
       "license": "GPL-3.0"
     },
     "node_modules/icos-cp-toaster": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/icos-cp-toaster/-/icos-cp-toaster-0.7.2.tgz",
-      "integrity": "sha512-1Rt720VgdDTCSMAvnLxf0Jm+6vqSAeZSCupcaNgg1g+NJsxThDUaxZivHEeOKB2VXHgggmIPbKJC4u4unX7QQA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/icos-cp-toaster/-/icos-cp-toaster-0.8.1.tgz",
+      "integrity": "sha512-bTKEVMhKwql+mga3pt+egzHTWAWzT4bI8rX/32TP+nsBETjqw/nDHwDmSAnGTycKUFc4DizKe18EDIxmowYd3w==",
+      "license": "GPL-3.0",
       "dependencies": {
         "react": "^18.2.0"
       }

--- a/src/main/js/portal/package.json
+++ b/src/main/js/portal/package.json
@@ -54,7 +54,7 @@
     "icos-cp-copyright": "^0.0.2",
     "icos-cp-draggable": "0.0.2",
     "icos-cp-ol": "4.2.2",
-    "icos-cp-toaster": "0.7.2",
+    "icos-cp-toaster": "0.8.1",
     "icos-cp-utils": "0.2.0",
     "linkify-it": "^5.0.2",
     "ol": "9.1.0",


### PR DESCRIPTION
Three main areas for changes related to the filters and main view:

1. Adds an "Active filters" list, allowing easy removal of filters and informing users of which filters are enabled.

The "clear filters" button moves to the Active filters list, so it is removed from the Filters view, which was an odd spot for it to begin with.

2. Moves the "Stations map" to the Filters area, instead of existing as a "search results" tab.

The new "Stations map preview" displays a live view of included stations. The base map updates if the modal's base map is updated, and active map filters are displayed on the map.

The main, interactive "Stations map" is moved to a modal that appears when the preview is clicked. This loads a separate instance of the map. Buttons are included for applying filters, resetting the filters, and canceling the operation, reverting to the filter state when the modal was opened. Several existing bugs were identified and are fixed:
- Map markers did not load at small initial width
- SPARQL queries were triggered too often, when unnecessary (e.g. on resize)
- Overlapping filter rectangles were possible to create, crashing the portal app

3. Removes the "search results" tabs, changing to a switch for default vs. compact search results views.

Possible future work:
- Add a polygon tool to the map, to draw an arbitrary polygon; once added, allow shapes to overlap, automatically merging them into a single polygon if they overlap
- Revisit portal controls, such as pagination buttons, export to CSV button, and SPARQL query button, to make them more obvious and easier to use