### PR TITLE
Fix URI protocol rewriting in the Python core library

### DIFF
--- a/src/main/python/icoscp_core/src/icoscp_core/__init__.py
+++ b/src/main/python/icoscp_core/src/icoscp_core/__init__.py
@@ -4,4 +4,4 @@ Python API for access to ICOS Carbon Portal-based data portals and their
 core services, such as authentication, metadata access, and data access.
 """
 
-__version__ = "0.3.12"
+__version__ = "0.3.13"

--- a/src/main/python/icoscp_core/src/icoscp_core/metaclient.py
+++ b/src/main/python/icoscp_core/src/icoscp_core/metaclient.py
@@ -160,7 +160,7 @@ class MetadataClient:
 		:return: a list of `DataObjectLite` instances with basic data
 		object metadata (defined in `queries.dataobjlist` package).
 		"""
-		query = dataobj_lite_list(datatype, station, filters, include_deprecated, order_by, limit, offset)
+		query = dataobj_lite_list(datatype, station, filters, include_deprecated, order_by, limit, offset, self._envri_conf)
 		qres = self.sparql_select(query)
 		return [parse_dobj_lite(b) for b in qres.bindings]
 

--- a/src/main/python/icoscp_core/src/icoscp_core/queries/dataobjlist.py
+++ b/src/main/python/icoscp_core/src/icoscp_core/queries/dataobjlist.py
@@ -6,6 +6,7 @@ from typing import Literal, TypeAlias, TypedDict
 from ..sparql import Binding, as_long, as_uri, as_opt_uri, as_string, as_datetime, as_opt_float
 from ..metacore import UriResource
 from ..geofeaturemeta import Point
+from ..envri import EnvriConfig, ICOS_CONFIG
 
 
 @dataclass(frozen=True)
@@ -122,11 +123,13 @@ def _selector_values_clause(varname: str, uris: list[str]) -> str:
 	else:
 		return f"VALUES ?{varname} {{ {'<' + '> <'.join(uris) + '>'} }}"
 
-def _get_uri_list(selector: CategorySelector) -> list[str]:
+def _get_uri_list(selector: CategorySelector, conf: EnvriConfig) -> list[str]:
 	if selector is None: return []
 	def to_uri(uri_or_res: object) -> str:
 		uri = getattr(uri_or_res, "uri", None) or str(uri_or_res)
-		return uri.replace("https://", "http://")
+		if conf.meta_instance_prefix.startswith("http://"):
+			return uri.replace("https://", "http://", 1)
+		return uri
 	if type(selector) is list:
 		return [to_uri(uri_or_res) for uri_or_res in selector]
 	return [to_uri(selector)]
@@ -138,11 +141,12 @@ def dataobj_lite_list(
 	include_deprecated: bool,
 	order_by: OrderBy | OrderByProp | None,
 	limit: int,
-	offset: int
+	offset: int,
+	conf: EnvriConfig = ICOS_CONFIG
 ) -> str:
 
-	specUris =  _get_uri_list(datatype)
-	stationUris = _get_uri_list(station)
+	specUris =  _get_uri_list(datatype, conf)
+	stationUris = _get_uri_list(station, conf)
 	stationMandatory = "?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith ?station ."
 	stationLink = f"OPTIONAL{{ {stationMandatory} }}" if len(stationUris) == 0 else stationMandatory
 	samplingHeightPresent = any(f is SamplingHeightFilter for f in filters)


### PR DESCRIPTION
Queries using the HTTPS protocol were rewritten to HTTP. This works well for ICOS but not other ENVRIs. The rewriting will only be applied to ICOS now.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215769476620007